### PR TITLE
Convert output to close price only

### DIFF
--- a/bin/helpers/invoke_model.py
+++ b/bin/helpers/invoke_model.py
@@ -86,7 +86,7 @@ else:
 
 for ticker, ticker_predictions in predictions.items():
     closing_prices = [
-        ticker_prediction[3] for ticker_prediction in ticker_predictions
+        ticker_prediction[0] for ticker_prediction in ticker_predictions
     ]
 
     print('ticker: {}'.format(ticker))

--- a/cmd/lambda/createpositions/main.py
+++ b/cmd/lambda/createpositions/main.py
@@ -69,7 +69,7 @@ def handler(event: any, context: any) -> dict[str, any]:
         )
 
         moves_by_ticker = {
-            ticker: predictions_by_ticker[ticker][0][3] -
+            ticker: predictions_by_ticker[ticker][0][0] -
             current_prices_by_ticker[ticker]['price']
             for ticker in predictions_by_ticker
         }

--- a/ml/lstm/predict/entrypoint.py
+++ b/ml/lstm/predict/entrypoint.py
@@ -48,9 +48,17 @@ def invocations() -> flask.Response:
         )
 
         prediction = numpy.squeeze(prediction, axis=0)
-        unscaled_predictions = scalers[ticker].inverse_transform(
-            X=prediction,
-        )
+
+        scaler = scalers[ticker]
+
+        minimum_value = scaler.data_min_[features.CLOSE_PRICE_INDEX]
+        maximum_value = scaler.data_max_[features.CLOSE_PRICE_INDEX]
+
+        unscaled_predictions = (
+            prediction*(
+                maximum_value -
+                minimum_value)
+        ) + minimum_value
 
         predictions[ticker] = unscaled_predictions.tolist()
 

--- a/ml/lstm/train/entrypoint.py
+++ b/ml/lstm/train/entrypoint.py
@@ -45,7 +45,7 @@ parser.add_argument(
 
 arguments = parser.parse_args()
 
-features_count = len(features.FEATURE_NAMES)
+features_count = 1
 
 output_length = features.WINDOW_OUTPUT_LENGTH
 

--- a/pkg/features/features.py
+++ b/pkg/features/features.py
@@ -25,6 +25,8 @@ REQUIRED_COLUMNS = tuple(
 WINDOW_INPUT_LENGTH = 30
 WINDOW_OUTPUT_LENGTH = 5
 
+CLOSE_PRICE_INDEX = 3
+
 
 class Client:
     def __init__(self):
@@ -146,11 +148,9 @@ class Client:
         labels = data[:, labels_slice, :]
 
         labels = tensorflow.stack(
-            values=[labels],
+            [labels[:, :, CLOSE_PRICE_INDEX]],
             axis=-1,
         )
-
-        labels = tensorflow.squeeze(labels, axis=-1)
 
         inputs.set_shape([None, self.window_input_length, None])
         labels.set_shape([None, self.window_output_length, None])

--- a/pkg/features/test_features.py
+++ b/pkg/features/test_features.py
@@ -55,12 +55,12 @@ class TestCreateDataset(unittest.TestCase):
 
         data = numpy.array(
             object=[
-                [1, 2, 3],
-                [4, 5, 6],
-                [7, 8, 9],
-                [10, 11, 12],
-                [13, 14, 15],
-                [16, 17, 18],
+                [1, 2, 3, 4, 5],
+                [4, 5, 6, 7, 8],
+                [7, 8, 9, 10, 11],
+                [10, 11, 12, 13, 14],
+                [13, 14, 15, 16, 17],
+                [16, 17, 18, 19, 20],
             ],
             dtype=numpy.float32,
         )
@@ -123,6 +123,7 @@ class TestSplitWindow(unittest.TestCase):
 
         day_count = 3
         feature_count = 5
+        label_count = 1
 
         expected_input_shape = (
             day_count,
@@ -132,7 +133,7 @@ class TestSplitWindow(unittest.TestCase):
         expected_labels_shape = (
             day_count,
             client.window_output_length,
-            feature_count,
+            label_count,
         )
 
         self.assertEqual(inputs.shape.as_list(), list(expected_input_shape))
@@ -162,16 +163,16 @@ class TestSplitWindow(unittest.TestCase):
         expected_labels_values = numpy.array(
             object=[
                 [
-                    [7, 8, 9, 10, 11],
-                    [9, 10, 11, 12, 13],
+                    [10],
+                    [12],
                 ],
                 [
-                    [17, 18, 19, 20, 21],
-                    [19, 20, 21, 22, 23],
+                    [20],
+                    [22],
                 ],
                 [
-                    [27, 28, 29, 30, 31],
-                    [29, 30, 31, 32, 33],
+                    [30],
+                    [32],
                 ],
             ],
             dtype=numpy.float32,


### PR DESCRIPTION
### Changes

- change model predictions to `close_price` label only
- fixes #93 

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

### Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
Keep the text below to alert the maintainer.
-->

Hey, @forstmeier - here's a pull request to review!  