### PR TITLE
ruff - S101 - no `assert`

### DIFF
--- a/tests/pipelines/test_drop_duplicates.py
+++ b/tests/pipelines/test_drop_duplicates.py
@@ -68,4 +68,4 @@ def test_drop_duplicates(input_data, subset, expected_output) -> None:
         result_sorted = result_output
         expected_sorted = expected_output
 
-    assert result_sorted.equals(expected_sorted)
+    assert result_sorted.equals(expected_sorted)  # noqa: S101

--- a/tests/pipelines/test_drop_nulls.py
+++ b/tests/pipelines/test_drop_nulls.py
@@ -58,4 +58,4 @@ dataframe = pl.DataFrame(
     ],
 )
 def test_drop_nulls(input_data, subset, expected_output) -> None:
-    assert drop_nulls(input_data, subset).equals(expected_output)
+    assert drop_nulls(input_data, subset).equals(expected_output)  # noqa: S101

--- a/tests/pipelines/test_filter_data_by_column_value.py
+++ b/tests/pipelines/test_filter_data_by_column_value.py
@@ -47,4 +47,4 @@ from pipelines.transformations import filter_data_by_column_value
     ],
 )
 def test_filter_data_by_column_value(input_data, column, value, expected_output) -> None:
-    assert filter_data_by_column_value(input_data, column, value).equals(expected_output)
+    assert filter_data_by_column_value(input_data, column, value).equals(expected_output)  # noqa: S101

--- a/tests/pipelines/test_min_max_scaler.py
+++ b/tests/pipelines/test_min_max_scaler.py
@@ -75,4 +75,4 @@ dataframe = pl.DataFrame(
     ],
 )
 def test_min_max_scaler(input_data, feature_range, expected_output) -> None:
-    assert min_max_scaler(input_data, feature_range).equals(expected_output)
+    assert min_max_scaler(input_data, feature_range).equals(expected_output)  # noqa: S101

--- a/tests/pipelines/test_select_columns.py
+++ b/tests/pipelines/test_select_columns.py
@@ -51,6 +51,6 @@ from pipelines.transformations import select_columns
 def test_select_columns(input_data, subset, expected_output) -> None:
     result = select_columns(input_data, subset)
     if isinstance(result, list):
-        assert result == expected_output
+        assert result == expected_output  # noqa: S101
     else:
-        assert result.equals(pl.DataFrame(expected_output))
+        assert result.equals(pl.DataFrame(expected_output))  # noqa: S101

--- a/tests/pipelines/test_sort_by_columns.py
+++ b/tests/pipelines/test_sort_by_columns.py
@@ -52,4 +52,4 @@ from pipelines.transformations import sort_by_columns
     ],
 )
 def test_sort_by_columns(input_data, subset, descending, expected_output) -> None:
-    assert sort_by_columns(input_data, subset, descending).equals(expected_output)
+    assert sort_by_columns(input_data, subset, descending).equals(expected_output)  # noqa: S101


### PR DESCRIPTION
### Changes

Using `assert` is a bad pattern except in `pytest`. Overwriting S101 in tests, leaving everywhere else. 
