### PR TITLE
ruff - fix S106 hardcoded passwords

### DIFF
--- a/pkg/data/test_data.py
+++ b/pkg/data/test_data.py
@@ -1,4 +1,5 @@
 """Unit tests for Alpaca Client."""
+
 import unittest
 import datetime
 
@@ -7,8 +8,14 @@ from alpaca.data import requests as alpaca_data_requests
 from pkg.data import data
 
 
+ALPACA_API_KEY = "alpaca_api_key"  # noqa: S106
+ALPACA_API_SECRET = "alpaca_api_secret"  # noqa: S106
+EDGAR_USER_AGENT = "edgar_user_agent"  # noqa: S106
+
+
 class MockAlpacaHistoricalResponse:
     """Mock Alpaca historical response."""
+
     def __init__(
         self,
         data: dict[str, any],
@@ -37,6 +44,7 @@ class MockAlpacaHistoricalResponse:
 
 class MockAlpacaHistoricalClient:
     """Mock Alpaca historical client."""
+
     def __init__(
         self,
         response: MockAlpacaHistoricalResponse,
@@ -58,6 +66,7 @@ class MockAlpacaHistoricalClient:
 
 class MockHTTPGetResponse:
     """Mock HTTP response."""
+
     def __init__(
         self,
         text: str = None,
@@ -72,6 +81,7 @@ class MockHTTPGetResponse:
 
 class MockHttpClient:
     """Mock HTTP client."""
+
     def __init__(
         self,
         responses: dict[str, any],
@@ -158,12 +168,13 @@ def mock_get_forms_contents_success(
 
 class TestGetRangeEquitiesBars(unittest.TestCase):
     """Unit tests for get range equities bars."""
+
     def test_get_range_equities_bars_alpaca_get_stock_bars_error(self) -> None:
         """Test get range equities bars alpaca get stock bars error."""
         client = data.Client(
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            edgar_user_agent="edgar_user_agent",
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            edgar_user_agent=EDGAR_USER_AGENT,
         )
 
         client.alpaca_historical_client = MockAlpacaHistoricalClient(
@@ -183,9 +194,9 @@ class TestGetRangeEquitiesBars(unittest.TestCase):
     def test_get_range_equities_bars_success(self) -> None:
         """Test get range equities bars success."""
         client = data.Client(
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            edgar_user_agent="edgar_user_agent",
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            edgar_user_agent=EDGAR_USER_AGENT,
         )
 
         client.alpaca_historical_client = MockAlpacaHistoricalClient(
@@ -240,12 +251,13 @@ class TestGetRangeEquitiesBars(unittest.TestCase):
 
 class TestPrivateGetFormsInformation(unittest.TestCase):
     """Unit tests for private get forms information."""
+
     def test_private_get_forms_information_success(self) -> None:
         """Test private get forms information success."""
         client = data.Client(
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            edgar_user_agent="edgar_user_agent",
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            edgar_user_agent=EDGAR_USER_AGENT,
         )
 
         forms_information = client._get_forms_information(
@@ -285,12 +297,13 @@ class TestPrivateGetFormsInformation(unittest.TestCase):
 
 class TestPrivateGetFormsContents(unittest.TestCase):
     """Unit tests for private get forms contents."""
+
     def test_private_get_forms_contents_success(self) -> None:
         """Test private get forms contents success."""
         client = data.Client(
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            edgar_user_agent="edgar_user_agent",
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            edgar_user_agent=EDGAR_USER_AGENT,
         )
 
         client.http_client = MockHttpClient(
@@ -342,12 +355,13 @@ class TestPrivateGetFormsContents(unittest.TestCase):
 
 class TestGetRangeCorporateFilings(unittest.TestCase):
     """Unit tests for get range corporate filings."""
+
     def setUp(self) -> None:
         """Set up test."""
         self.client = data.Client(
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            edgar_user_agent="edgar_user_agent",
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            edgar_user_agent=EDGAR_USER_AGENT,
         )
 
     def tearDown(self) -> None:

--- a/pkg/trade/test_trade.py
+++ b/pkg/trade/test_trade.py
@@ -4,6 +4,12 @@ import unittest
 from pkg.trade import trade
 
 
+DARQUBE_API_KEY = "darqube_api_key"  # noqa: S106
+ALPACA_API_KEY = "alpaca_api_key"  # noqa: S106
+ALPACA_API_SECRET = "alpaca_api_secret"  # noqa: S106
+ALPHA_VANTAGE_API_KEY = "alpha_vantage_api_key"  # noqa: S106
+
+
 class MockAlpacaClock:
     def __init__(
         self,
@@ -261,10 +267,10 @@ def mock_get_risk_free_rate_success() -> float:
 class TestCheckSetPositionAvailability(unittest.TestCase):
     def test_check_position_set_availability_success(self) -> None:
         client = trade.Client(
-            darqube_api_key="darqube_api_key",
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            alpha_vantage_api_key="alpha_vantage_api_key",
+            darqube_api_key=DARQUBE_API_KEY,
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         )
 
         monday_calendar_days = [
@@ -443,10 +449,10 @@ class TestCheckSetPositionAvailability(unittest.TestCase):
 class TestPrivateGetAvailableTickers(unittest.TestCase):
     def setUp(self) -> None:
         self.client = trade.Client(
-            darqube_api_key="darqube_api_key",
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            alpha_vantage_api_key="alpha_vantage_api_key",
+            darqube_api_key=DARQUBE_API_KEY,
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         )
 
     def tearDown(self) -> None:
@@ -527,10 +533,10 @@ class TestPrivateGetAvailableTickers(unittest.TestCase):
 class TestGetAvailableTickers(unittest.TestCase):
     def setUp(self) -> None:
         self.client = trade.Client(
-            darqube_api_key="daruqbe_api_key",
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            alpha_vantage_api_key="alpha_vantage_api_key",
+            darqube_api_key=DARUQBE_API_KEY,
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         )
 
     def tearDown(self) -> None:
@@ -559,10 +565,10 @@ class TestGetAvailableTickers(unittest.TestCase):
 class TestSetPositions(unittest.TestCase):
     def setUp(self) -> None:
         self.client = trade.Client(
-            darqube_api_key="darqube_api_key",
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            alpha_vantage_api_key="alpha_vantage_api_key",
+            darqube_api_key=DARQUBE_API_KEY,
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         )
 
     def tearDown(self) -> None:
@@ -657,10 +663,10 @@ class TestSetPositions(unittest.TestCase):
 class TestClearPositions(unittest.TestCase):
     def setUp(self) -> None:
         self.client = trade.Client(
-            darqube_api_key="daruqbe_api_key",
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            alpha_vantage_api_key="alpha_vantage_api_key",
+            darqube_api_key=DARUQBE_API_KEY,
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         )
 
     def tearDown(self) -> None:
@@ -696,10 +702,10 @@ class TestClearPositions(unittest.TestCase):
 class TestPrivateGetPortfolioDailyReturns(unittest.TestCase):
     def setUp(self) -> None:
         self.client = trade.Client(
-            darqube_api_key="darqube_api_key",
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            alpha_vantage_api_key="alpha_vantage_api_key",
+            darqube_api_key=DARQUBE_API_KEY,
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         )
 
     def tearDown(self) -> None:
@@ -776,10 +782,10 @@ class TestPrivateGetPortfolioDailyReturns(unittest.TestCase):
 class TestPrivateGetBenchmarkDailyReturns(unittest.TestCase):
     def setUp(self) -> None:
         self.client = trade.Client(
-            darqube_api_key="darqube_api_key",
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            alpha_vantage_api_key="alpha_vantage_api_key",
+            darqube_api_key=DARQUBE_API_KEY,
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         )
 
     def tearDown(self) -> None:
@@ -866,10 +872,10 @@ class TestPrivateGetBenchmarkDailyReturns(unittest.TestCase):
 class TestPrivateCumulativeReturns(unittest.TestCase):
     def setUp(self) -> None:
         self.client = trade.Client(
-            darqube_api_key="darqube_api_key",
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            alpha_vantage_api_key="alpha_vantage_api_key",
+            darqube_api_key=DARQUBE_API_KEY,
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         )
 
     def tearDown(self) -> None:
@@ -888,10 +894,10 @@ class TestPrivateCumulativeReturns(unittest.TestCase):
 class TestPrivateGetRiskFreeRate(unittest.TestCase):
     def setUp(self) -> None:
         self.client = trade.Client(
-            darqube_api_key="darqube_api_key",
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            alpha_vantage_api_key="alpha_vantage_api_key",
+            darqube_api_key=DARQUBE_API_KEY,
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         )
 
     def tearDown(self) -> None:
@@ -942,10 +948,10 @@ class TestPrivateGetRiskFreeRate(unittest.TestCase):
 class TestGetPerformanceMetrics(unittest.TestCase):
     def setUp(self) -> None:
         self.client = trade.Client(
-            darqube_api_key="darqube_api_key",
-            alpaca_api_key="alpaca_api_key",
-            alpaca_api_secret="alpaca_api_secret",
-            alpha_vantage_api_key="alpha_vantage_api_key",
+            darqube_api_key=DARQUBE_API_KEY,
+            alpaca_api_key=ALPACA_API_KEY,
+            alpaca_api_secret=ALPACA_API_SECRET,
+            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
         )
 
     def tearDown(self) -> None:

--- a/pkg/twitter/test_twitter.py
+++ b/pkg/twitter/test_twitter.py
@@ -3,6 +3,12 @@ import unittest
 from pkg.twitter import twitter
 
 
+API_KEY = "api_key"
+API_KEY_SECRET = "api_key_secret"  # noqa: S106
+ACCESS_TOKEN = "access_token"  # noqa: S106
+ACCESS_TOKEN_SECRET = "access_token_secret"  # noqa: S106
+
+
 class MockTwitterClient:
     def __init__(self) -> None:
         pass
@@ -48,10 +54,10 @@ class MockTwitterAPI:
 class TestSendTweet(unittest.TestCase):
     def test_send_tweet_success(self) -> None:
         client = twitter.Client(
-            api_key="api_key",
-            api_key_secret="api_key_secret",
-            access_token="access_token",
-            access_token_secret="access_token_secret",
+            api_key=API_KEY,
+            api_key_secret=API_KEY_SECRET,
+            access_token=ACCESS_TOKEN,
+            access_token_secret=ACCESS_TOKEN_SECRET,
             image_files_path="image/files/path",
         )
 
@@ -65,10 +71,10 @@ class TestSendTweet(unittest.TestCase):
 class TestUpdateProfile(unittest.TestCase):
     def test_update_profile_success(self) -> None:
         client = twitter.Client(
-            api_key="api_key",
-            api_key_secret="api_key_secret",
-            access_token="access_token",
-            access_token_secret="access_token_secret",
+            api_key=API_KEY,
+            api_key_secret=API_KEY_SECRET,
+            access_token=ACCESS_TOKEN,
+            access_token_secret=ACCESS_TOKEN_SECRET,
             image_files_path="images",
         )
 


### PR DESCRIPTION
### Changes

S106 throws errors when it detects passwords. In our case, these were just
unit tests with dummy strings, so I ignored the specific cases.
