### PR TITLE
ignore S101 for tests

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -97,3 +97,10 @@ ignore = [
   "ANN101", # don't need to type annotate `self`
   "PT006",  # Wrong type passed to first argument of `@pytest.mark.parametrize` --> unnecessary
 ]
+
+[lint.per-file-ignores]
+"pkg/trade/test_trade.py" = ["S101"]
+"pkg/model/test_model.py" = ["S101"]
+"pkg/storage/test_storage.py" = ["S101"]
+"pkg/features/test_features.py" = ["S101"]
+"pkg/data/test_data.py" = ["S101"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -102,5 +102,4 @@ ignore = [
 "pkg/trade/test_trade.py" = ["S101"]
 "pkg/model/test_model.py" = ["S101"]
 "pkg/storage/test_storage.py" = ["S101"]
-"pkg/features/test_features.py" = ["S101"]
 "pkg/data/test_data.py" = ["S101"]


### PR DESCRIPTION
### Changes

Ignoring S101 for tests. Using `assert` is an anti-pattern except for tests.
