### PR TITLE
Ignoring PLR2004 for tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ cmd/script/trainmodel/secrets.env
 wandb
 lightning_logs/
 tft_model.ckpt
+
+.mise.toml

--- a/ruff.toml
+++ b/ruff.toml
@@ -99,7 +99,8 @@ ignore = [
 ]
 
 [lint.per-file-ignores]
-"pkg/trade/test_trade.py" = ["S101"]
-"pkg/model/test_model.py" = ["S101"]
-"pkg/storage/test_storage.py" = ["S101"]
-"pkg/data/test_data.py" = ["S101"]
+"pkg/trade/test_trade.py" = ["S101", "PLR2004"]
+"pkg/model/test_model.py" = ["S101", "PLR2004"]
+"pkg/storage/test_storage.py" = ["S101", "PLR2004"]
+"pkg/data/test_data.py" = ["S101", "PLR2004"]
+


### PR DESCRIPTION
Ignoring PLR2004 in tests directory.

It is generally good to avoid `magical numbers` in code because it makes the code unclear, e.g.

instead of

```python
area = 3.14 * radius ** 2
```

it is much clearer to write
```python
PI = 3.14
area = PI * radius ** 2
```

In the case of tests however, I think it is fine to have the magic numbers since the context is essentially to assert a thing equals a specific value.
