### PR TITLE
split unit test and coverage report

### DIFF
--- a/.github/workflows/publish-test-coverage.yml
+++ b/.github/workflows/publish-test-coverage.yml
@@ -1,5 +1,9 @@
 name: Checks
-on: [push]
+on:
+  push:
+    branches:
+      - main
+      - master
 env:
   AWS_ACCESS_KEY_ID: ''
   AWS_SECRET_ACCESS_KEY: ''
@@ -15,7 +19,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+      - name: Install poetry
+        uses: Gr1N/setup-poetry@v8
       - name: Install dependencies
-        run: pip3 install -r requirements.txt
+        run: poetry install
       - name: Run unit tests
         run: make test
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          path-to-lcov: coverage.xml


### PR DESCRIPTION
create a separate action for running tests and uploading coverage report when pushes to main.

Otherwise just run the unit tests and don't send to overalls.

We probably don't want overalls to report every single branch.
