### PR TITLE
Deprecate `unittest`/implement `pytest`

### DIFF
--- a/pkg/data/test_data.py
+++ b/pkg/data/test_data.py
@@ -1,7 +1,4 @@
-"""Unit tests for Alpaca Client."""
-
 import datetime
-import unittest
 from typing import Optional
 
 import pytest
@@ -16,8 +13,6 @@ EDGAR_USER_AGENT = "edgar_user_agent"  # noqa: S105
 
 
 class MockAlpacaHistoricalResponse:
-    """Mock Alpaca historical response."""
-
     def __init__(
         self,
         data: dict[str, any],
@@ -44,8 +39,6 @@ class MockAlpacaHistoricalResponse:
 
 
 class MockAlpacaHistoricalClient:
-    """Mock Alpaca historical client."""
-
     def __init__(
         self,
         response: MockAlpacaHistoricalResponse,
@@ -66,8 +59,6 @@ class MockAlpacaHistoricalClient:
 
 
 class MockHTTPGetResponse:
-    """Mock HTTP response."""
-
     def __init__(
         self,
         text: Optional[str] = None,  # noqa: UP007
@@ -81,8 +72,6 @@ class MockHTTPGetResponse:
 
 
 class MockHttpClient:
-    """Mock HTTP client."""
-
     def __init__(
         self,
         responses: dict[str, any],
@@ -119,7 +108,6 @@ def mock_get_forms_information_error(  # noqa: PLR0913
     forms: list[str],
     target_form: str,
 ) -> list[dict[str, any]]:
-    """Mock get forms information error."""
     _ = start_at, end_at, accession_numbers, acceptance_dates, forms, target_form
 
     msg = "get forms information error"
@@ -134,7 +122,6 @@ def mock_get_forms_information_success(  # noqa: PLR0913
     forms: list[str],
     target_form: str,
 ) -> list[dict[str, any]]:
-    """Mock get forms information success."""
     _ = start_at, end_at, accession_numbers, acceptance_dates, forms, target_form
 
     return [
@@ -149,7 +136,6 @@ def mock_get_forms_contents_error(
     cik: str,
     forms_information: list[dict[str, any]],
 ) -> list[dict[str, any]]:
-    """Mock get forms contents error."""
     _ = cik, forms_information
 
     msg = "get forms contents error"
@@ -160,7 +146,6 @@ def mock_get_forms_contents_success(
     cik: str,
     forms_information: list[dict[str, any]],
 ) -> list[dict[str, any]]:
-    """Mock get forms contents success."""
     _ = cik, forms_information
 
     return [
@@ -171,76 +156,231 @@ def mock_get_forms_contents_success(
     ]
 
 
-class TestGetRangeEquitiesBars(unittest.TestCase):
-    """Unit tests for get range equities bars."""
+def test_get_range_equities_bars_alpaca_get_stock_bars_error() -> None:
+    """Test get range equities bars alpaca get stock bars error."""
+    client = data.Client(
+        alpaca_api_key=ALPACA_API_KEY,
+        alpaca_api_secret=ALPACA_API_SECRET,
+        edgar_user_agent=EDGAR_USER_AGENT,
+    )
 
-    def test_get_range_equities_bars_alpaca_get_stock_bars_error(self) -> None:
-        """Test get range equities bars alpaca get stock bars error."""
-        client = data.Client(
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            edgar_user_agent=EDGAR_USER_AGENT,
+    client.alpaca_historical_client = MockAlpacaHistoricalClient(
+        response=None,
+        exception=Exception("get stock bars error"),
+    )
+
+    with pytest.raises(Exception, match="get stock bars"):
+        _ = client.get_range_equities_bars(
+            tickers=["TICKER"],
+            start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
+                tzinfo=config.TIMEZONE,
+            ),
+            end_at=datetime.datetime.strptime("1977-05-28", "%Y-%m-%d").replace(
+                tzinfo=config.TIMEZONE,
+            ),
         )
 
-        client.alpaca_historical_client = MockAlpacaHistoricalClient(
-            response=None,
-            exception=Exception("get stock bars error"),
-        )
 
-        with pytest.raises(Exception, match="get stock bars"):
-            _ = client.get_range_equities_bars(
-                tickers=["TICKER"],
-                start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
+def test_get_range_equities_bars_success() -> None:
+    client = data.Client(
+        alpaca_api_key=ALPACA_API_KEY,
+        alpaca_api_secret=ALPACA_API_SECRET,
+        edgar_user_agent=EDGAR_USER_AGENT,
+    )
+
+    client.alpaca_historical_client = MockAlpacaHistoricalClient(
+        response=MockAlpacaHistoricalResponse(
+            data={
+                "TICKER": [
+                    {
+                        "t": "1977-05-25T00:00:00Z",
+                        "o": "5.0",
+                        "h": "6.0",
+                        "l": "4.0",
+                        "c": "5.0",
+                        "v": "100.0",
+                    },
+                    {
+                        "t": "1977-05-25T00:00:00Z",
+                        "o": "6.0",
+                        "h": "7.0",
+                        "l": "5.0",
+                        "c": "6.0",
+                        "v": "200.0",
+                    },
+                    {
+                        "t": "1977-05-25T00:00:00Z",
+                        "o": "7.0",
+                        "h": "8.0",
+                        "l": "6.0",
+                        "c": "7.0",
+                        "v": "300.0",
+                    },
+                ],
+            },
+        ),
+        exception=None,
+    )
+
+    range_equities_bars = client.get_range_equities_bars(
+        tickers=["TICKER"],
+        start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
+            tzinfo=config.TIMEZONE,
+        ),
+        end_at=datetime.datetime.strptime("1977-05-28", "%Y-%m-%d").replace(
+            tzinfo=config.TIMEZONE,
+        ),
+    )
+
+    assert len(range_equities_bars) == 3
+    assert range_equities_bars.iloc[0]["ticker"] == "TICKER"
+    assert range_equities_bars.iloc[0]["open_price"] == 5.0
+    assert range_equities_bars.iloc[0]["high_price"] == 6.0
+    assert range_equities_bars.iloc[0]["low_price"] == 4.0
+    assert range_equities_bars.iloc[0]["close_price"] == 5.0
+    assert range_equities_bars.iloc[0]["volume"] == 100.0
+    assert range_equities_bars.iloc[0]["source"] == "ALPACA"
+
+
+def test_private_get_forms_information_success() -> None:
+    client = data.Client(
+        alpaca_api_key=ALPACA_API_KEY,
+        alpaca_api_secret=ALPACA_API_SECRET,
+        edgar_user_agent=EDGAR_USER_AGENT,
+    )
+
+    forms_information = client._get_forms_information(
+        start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
+            tzinfo=config.TIMEZONE,
+        ),
+        end_at=datetime.datetime.strptime("1977-05-28", "%Y-%m-%d").replace(
+            tzinfo=config.TIMEZONE,
+        ),
+        accession_numbers=[
+            "0001171843-24-001239",
+            "0001193125-15-118890",
+        ],
+        acceptance_dates=[
+            "1977-05-26T18:36:45.000Z",
+            "1977-05-28T18:36:45.000Z",
+        ],
+        forms=[
+            "10-K",
+            "10-K",
+        ],
+        target_form="10-K",
+    )
+
+    assert forms_information[0]["accession_number"] == "0001171843-24-001239"
+    assert forms_information[0]["acceptance_date"] == datetime.datetime(
+        1977,
+        5,
+        26,
+        18,
+        36,
+        45,
+        tzinfo=config.TIMEZONE,
+    )
+
+
+def test_private_get_forms_contents_success() -> None:
+    client = data.Client(
+        alpaca_api_key=ALPACA_API_KEY,
+        alpaca_api_secret=ALPACA_API_SECRET,
+        edgar_user_agent=EDGAR_USER_AGENT,
+    )
+
+    client.http_client = MockHttpClient(
+        responses={
+            "edgar/data": MockHTTPGetResponse(
+                text="<xml>form contents</xml>",
+            ),
+        },
+        exceptions=None,
+    )
+
+    forms_contents = client._get_forms_contents(
+        cik="0001123494",
+        forms_information=[
+            {
+                "acceptance_date": datetime.datetime(
+                    1977,
+                    5,
+                    26,
+                    18,
+                    36,
+                    45,
                     tzinfo=config.TIMEZONE,
                 ),
-                end_at=datetime.datetime.strptime("1977-05-28", "%Y-%m-%d").replace(
-                    tzinfo=config.TIMEZONE,
-                ),
-            )
+                "accession_number": "0001171843-24-001239",
+            },
+        ],
+    )
 
-    def test_get_range_equities_bars_success(self) -> None:
-        """Test get range equities bars success."""
-        client = data.Client(
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            edgar_user_agent=EDGAR_USER_AGENT,
+    assert forms_contents[0]["acceptance_date"] == datetime.datetime(
+        1977,
+        5,
+        26,
+        18,
+        36,
+        45,
+        tzinfo=config.TIMEZONE,
+    )
+
+    assert forms_contents[0]["content"] == ["form contents"]
+
+
+def test_get_range_corporate_filings_get_tickers_http_error() -> None:
+    client = data.Client(
+        alpaca_api_key=ALPACA_API_KEY,
+        alpaca_api_secret=ALPACA_API_SECRET,
+        edgar_user_agent=EDGAR_USER_AGENT,
+    )
+
+    client.http_client = MockHttpClient(
+        responses={},
+        exceptions={
+            "www.sec.gov": Exception("get tickers http error"),
+        },
+    )
+
+    with pytest.raises(Exception, match="get tickers http"):
+        _ = client.get_range_corporate_filings(
+            tickers=["TICKER"],
+            start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
+                tzinfo=config.TIMEZONE,
+            ),
+            end_at=datetime.datetime.strptime("1977-05-28", "%Y-%m-%d").replace(
+                tzinfo=config.TIMEZONE,
+            ),
         )
 
-        client.alpaca_historical_client = MockAlpacaHistoricalClient(
-            response=MockAlpacaHistoricalResponse(
+
+def test_get_range_corporate_filings_get_submissions_http_error() -> None:
+    client = data.Client(
+        alpaca_api_key=ALPACA_API_KEY,
+        alpaca_api_secret=ALPACA_API_SECRET,
+        edgar_user_agent=EDGAR_USER_AGENT,
+    )
+
+    client.http_client = MockHttpClient(
+        responses={
+            "sec.gov": MockHTTPGetResponse(
                 data={
-                    "TICKER": [
-                        {
-                            "t": "1977-05-25T00:00:00Z",
-                            "o": "5.0",
-                            "h": "6.0",
-                            "l": "4.0",
-                            "c": "5.0",
-                            "v": "100.0",
-                        },
-                        {
-                            "t": "1977-05-25T00:00:00Z",
-                            "o": "6.0",
-                            "h": "7.0",
-                            "l": "5.0",
-                            "c": "6.0",
-                            "v": "200.0",
-                        },
-                        {
-                            "t": "1977-05-25T00:00:00Z",
-                            "o": "7.0",
-                            "h": "8.0",
-                            "l": "6.0",
-                            "c": "7.0",
-                            "v": "300.0",
-                        },
-                    ],
+                    "0": {
+                        "cik_str": 1123494,
+                        "ticker": "TICKER",
+                    },
                 },
             ),
-            exception=None,
-        )
+        },
+        exceptions={
+            "data.sec.gov": Exception("get submissions http error"),
+        },
+    )
 
-        range_equities_bars = client.get_range_equities_bars(
+    with pytest.raises(Exception, match="get submissions http"):
+        _ = client.get_range_corporate_filings(
             tickers=["TICKER"],
             start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
                 tzinfo=config.TIMEZONE,
@@ -250,284 +390,43 @@ class TestGetRangeEquitiesBars(unittest.TestCase):
             ),
         )
 
-        assert len(range_equities_bars) == 3
-        assert range_equities_bars.iloc[0]["ticker"] == "TICKER"
-        assert range_equities_bars.iloc[0]["open_price"] == 5.0
-        assert range_equities_bars.iloc[0]["high_price"] == 6.0
-        assert range_equities_bars.iloc[0]["low_price"] == 4.0
-        assert range_equities_bars.iloc[0]["close_price"] == 5.0
-        assert range_equities_bars.iloc[0]["volume"] == 100.0
-        assert range_equities_bars.iloc[0]["source"] == "ALPACA"
 
+def test_get_range_corporate_filings_get_forms_information_error() -> None:
+    client = data.Client(
+        alpaca_api_key=ALPACA_API_KEY,
+        alpaca_api_secret=ALPACA_API_SECRET,
+        edgar_user_agent=EDGAR_USER_AGENT,
+    )
 
-class TestPrivateGetFormsInformation(unittest.TestCase):
-    """Unit tests for private get forms information."""
-
-    def test_private_get_forms_information_success(self) -> None:
-        """Test private get forms information success."""
-        client = data.Client(
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            edgar_user_agent=EDGAR_USER_AGENT,
-        )
-
-        forms_information = client._get_forms_information(
-            start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
-                tzinfo=config.TIMEZONE,
-            ),
-            end_at=datetime.datetime.strptime("1977-05-28", "%Y-%m-%d").replace(
-                tzinfo=config.TIMEZONE,
-            ),
-            accession_numbers=[
-                "0001171843-24-001239",
-                "0001193125-15-118890",
-            ],
-            acceptance_dates=[
-                "1977-05-26T18:36:45.000Z",
-                "1977-05-28T18:36:45.000Z",
-            ],
-            forms=[
-                "10-K",
-                "10-K",
-            ],
-            target_form="10-K",
-        )
-
-        assert forms_information[0]["accession_number"] == "0001171843-24-001239"
-        assert forms_information[0]["acceptance_date"] == datetime.datetime(
-            1977,
-            5,
-            26,
-            18,
-            36,
-            45,
-            tzinfo=config.TIMEZONE,
-        )
-
-
-class TestPrivateGetFormsContents(unittest.TestCase):
-    """Unit tests for private get forms contents."""
-
-    def test_private_get_forms_contents_success(self) -> None:
-        """Test private get forms contents success."""
-        client = data.Client(
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            edgar_user_agent=EDGAR_USER_AGENT,
-        )
-
-        client.http_client = MockHttpClient(
-            responses={
-                "edgar/data": MockHTTPGetResponse(
-                    text="<xml>form contents</xml>",
-                ),
-            },
-            exceptions=None,
-        )
-
-        forms_contents = client._get_forms_contents(
-            cik="0001123494",
-            forms_information=[
-                {
-                    "acceptance_date": datetime.datetime(
-                        1977,
-                        5,
-                        26,
-                        18,
-                        36,
-                        45,
-                        tzinfo=config.TIMEZONE,
-                    ),
-                    "accession_number": "0001171843-24-001239",
+    client.http_client = MockHttpClient(
+        responses={
+            "www.sec.gov": MockHTTPGetResponse(
+                data={
+                    "0": {
+                        "cik_str": 1123494,
+                        "ticker": "TICKER",
+                    },
                 },
-            ],
-        )
-
-        assert forms_contents[0]["acceptance_date"] == datetime.datetime(
-            1977,
-            5,
-            26,
-            18,
-            36,
-            45,
-            tzinfo=config.TIMEZONE,
-        )
-
-        assert forms_contents[0]["content"] == ["form contents"]
-
-
-class TestGetRangeCorporateFilings(unittest.TestCase):
-    """Unit tests for get range corporate filings."""
-
-    def setUp(self) -> None:
-        """Set up test."""
-        self.client = data.Client(
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            edgar_user_agent=EDGAR_USER_AGENT,
-        )
-
-    def test_get_range_corporate_filings_get_tickers_http_error(self) -> None:
-        """Test get range corporate filings get tickers http error."""
-        self.client.http_client = MockHttpClient(
-            responses={},
-            exceptions={
-                "www.sec.gov": Exception("get tickers http error"),
-            },
-        )
-
-        with pytest.raises(Exception, match="get tickers http"):
-            _ = self.client.get_range_corporate_filings(
-                tickers=["TICKER"],
-                start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
-                    tzinfo=config.TIMEZONE,
-                ),
-                end_at=datetime.datetime.strptime("1977-05-28", "%Y-%m-%d").replace(
-                    tzinfo=config.TIMEZONE,
-                ),
-            )
-
-    def test_get_range_corporate_filings_get_submissions_http_error(self) -> None:
-        """Test get range corporate filings get submissions http error."""
-        self.client.http_client = MockHttpClient(
-            responses={
-                "sec.gov": MockHTTPGetResponse(
-                    data={
-                        "0": {
-                            "cik_str": 1123494,
-                            "ticker": "TICKER",
+            ),
+            "data.sec.gov": MockHTTPGetResponse(
+                data={
+                    "filings": {
+                        "recent": {
+                            "accessionNumber": ["0001171843-24-001239"],
+                            "acceptanceDateTime": ["1977-05-26T18:36:45.000Z"],
+                            "form": ["10-K"],
                         },
                     },
-                ),
-            },
-            exceptions={
-                "data.sec.gov": Exception("get submissions http error"),
-            },
-        )
+                },
+            ),
+        },
+        exceptions=None,
+    )
 
-        with pytest.raises(Exception, match="get submissions http"):
-            _ = self.client.get_range_corporate_filings(
-                tickers=["TICKER"],
-                start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
-                    tzinfo=config.TIMEZONE,
-                ),
-                end_at=datetime.datetime.strptime("1977-05-28", "%Y-%m-%d").replace(
-                    tzinfo=config.TIMEZONE,
-                ),
-            )
+    client._get_forms_information = mock_get_forms_information_error
 
-    def test_get_range_corporate_filings_get_forms_information_error(self) -> None:
-        """Test get range corporate filings get forms information error."""
-        self.client.http_client = MockHttpClient(
-            responses={
-                "www.sec.gov": MockHTTPGetResponse(
-                    data={
-                        "0": {
-                            "cik_str": 1123494,
-                            "ticker": "TICKER",
-                        },
-                    },
-                ),
-                "data.sec.gov": MockHTTPGetResponse(
-                    data={
-                        "filings": {
-                            "recent": {
-                                "accessionNumber": ["0001171843-24-001239"],
-                                "acceptanceDateTime": ["1977-05-26T18:36:45.000Z"],
-                                "form": ["10-K"],
-                            },
-                        },
-                    },
-                ),
-            },
-            exceptions=None,
-        )
-
-        self.client._get_forms_information = mock_get_forms_information_error
-
-        with pytest.raises(Exception, match="get forms information"):
-            _ = self.client.get_range_corporate_filings(
-                tickers=["TICKER"],
-                start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
-                    tzinfo=config.TIMEZONE,
-                ),
-                end_at=datetime.datetime.strptime("1977-05-28", "%Y-%m-%d").replace(
-                    tzinfo=config.TIMEZONE,
-                ),
-            )
-
-    def test_get_range_corporate_filings_get_forms_contents_error(self) -> None:
-        """Test get range corporate filings get forms contents error."""
-        self.client.http_client = MockHttpClient(
-            responses={
-                "www.sec.gov/files/company": MockHTTPGetResponse(
-                    data={
-                        "0": {
-                            "cik_str": 1123494,
-                            "ticker": "TICKER",
-                        },
-                    },
-                ),
-                "data.sec.gov/submissions": MockHTTPGetResponse(
-                    data={
-                        "filings": {
-                            "recent": {
-                                "accessionNumber": ["0001171843-24-001239"],
-                                "acceptanceDateTime": ["1977-05-26T18:36:45.000Z"],
-                                "form": ["10-K"],
-                            },
-                        },
-                    },
-                ),
-            },
-            exceptions=None,
-        )
-
-        self.client._get_forms_information = mock_get_forms_information_success
-        self.client._get_forms_contents = mock_get_forms_contents_error
-
-        with pytest.raises(Exception, match="get forms contents"):
-            _ = self.client.get_range_corporate_filings(
-                tickers=["TICKER"],
-                start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
-                    tzinfo=config.TIMEZONE,
-                ),
-                end_at=datetime.datetime.strptime("1977-05-28", "%Y-%m-%d").replace(
-                    tzinfo=config.TIMEZONE,
-                ),
-            )
-
-    def test_get_range_corporate_filings_success(self) -> None:
-        """Test get range corporate filings success."""
-        self.client.http_client = MockHttpClient(
-            responses={
-                "www.sec.gov/files/company": MockHTTPGetResponse(
-                    data={
-                        "0": {
-                            "cik_str": 1123494,
-                            "ticker": "TICKER",
-                        },
-                    },
-                ),
-                "data.sec.gov/submissions": MockHTTPGetResponse(
-                    data={
-                        "filings": {
-                            "recent": {
-                                "accessionNumber": ["0001171843-24-001239"],
-                                "acceptanceDateTime": ["1977-05-26T18:36:45.000Z"],
-                                "form": ["10-K"],
-                            },
-                        },
-                    },
-                ),
-            },
-            exceptions=None,
-        )
-
-        self.client._get_forms_information = mock_get_forms_information_success
-        self.client._get_forms_contents = mock_get_forms_contents_success
-
-        corporate_filings = self.client.get_range_corporate_filings(
+    with pytest.raises(Exception, match="get forms information"):
+        _ = client.get_range_corporate_filings(
             tickers=["TICKER"],
             start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
                 tzinfo=config.TIMEZONE,
@@ -537,7 +436,100 @@ class TestGetRangeCorporateFilings(unittest.TestCase):
             ),
         )
 
-        corporate_filing = corporate_filings[0]
 
-        assert corporate_filing["ticker"] == "TICKER"
-        assert len(corporate_filing["corporate_filings"].keys()) == 3
+def test_get_range_corporate_filings_get_forms_contents_error() -> None:
+    client = data.Client(
+        alpaca_api_key=ALPACA_API_KEY,
+        alpaca_api_secret=ALPACA_API_SECRET,
+        edgar_user_agent=EDGAR_USER_AGENT,
+    )
+
+    client.http_client = MockHttpClient(
+        responses={
+            "www.sec.gov/files/company": MockHTTPGetResponse(
+                data={
+                    "0": {
+                        "cik_str": 1123494,
+                        "ticker": "TICKER",
+                    },
+                },
+            ),
+            "data.sec.gov/submissions": MockHTTPGetResponse(
+                data={
+                    "filings": {
+                        "recent": {
+                            "accessionNumber": ["0001171843-24-001239"],
+                            "acceptanceDateTime": ["1977-05-26T18:36:45.000Z"],
+                            "form": ["10-K"],
+                        },
+                    },
+                },
+            ),
+        },
+        exceptions=None,
+    )
+
+    client._get_forms_information = mock_get_forms_information_success
+    client._get_forms_contents = mock_get_forms_contents_error
+
+    with pytest.raises(Exception, match="get forms contents"):
+        _ = client.get_range_corporate_filings(
+            tickers=["TICKER"],
+            start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
+                tzinfo=config.TIMEZONE,
+            ),
+            end_at=datetime.datetime.strptime("1977-05-28", "%Y-%m-%d").replace(
+                tzinfo=config.TIMEZONE,
+            ),
+        )
+
+
+def test_get_range_corporate_filings_success() -> None:
+    client = data.Client(
+        alpaca_api_key=ALPACA_API_KEY,
+        alpaca_api_secret=ALPACA_API_SECRET,
+        edgar_user_agent=EDGAR_USER_AGENT,
+    )
+
+    client.http_client = MockHttpClient(
+        responses={
+            "www.sec.gov/files/company": MockHTTPGetResponse(
+                data={
+                    "0": {
+                        "cik_str": 1123494,
+                        "ticker": "TICKER",
+                    },
+                },
+            ),
+            "data.sec.gov/submissions": MockHTTPGetResponse(
+                data={
+                    "filings": {
+                        "recent": {
+                            "accessionNumber": ["0001171843-24-001239"],
+                            "acceptanceDateTime": ["1977-05-26T18:36:45.000Z"],
+                            "form": ["10-K"],
+                        },
+                    },
+                },
+            ),
+        },
+        exceptions=None,
+    )
+
+    client._get_forms_information = mock_get_forms_information_success
+    client._get_forms_contents = mock_get_forms_contents_success
+
+    corporate_filings = client.get_range_corporate_filings(
+        tickers=["TICKER"],
+        start_at=datetime.datetime.strptime("1977-05-25", "%Y-%m-%d").replace(
+            tzinfo=config.TIMEZONE,
+        ),
+        end_at=datetime.datetime.strptime("1977-05-28", "%Y-%m-%d").replace(
+            tzinfo=config.TIMEZONE,
+        ),
+    )
+
+    corporate_filing = corporate_filings[0]
+
+    assert corporate_filing["ticker"] == "TICKER"
+    assert len(corporate_filing["corporate_filings"].keys()) == 3

--- a/pkg/storage/test_storage.py
+++ b/pkg/storage/test_storage.py
@@ -1,6 +1,5 @@
 import gzip
 import io
-import unittest
 
 import pandas as pd
 
@@ -64,132 +63,127 @@ class MockS3Client:
         }
 
 
-class TestListFileNames(unittest.TestCase):
-    def test_list_file_names_success(self) -> None:
-        client = storage.Client(
-            s3_data_bucket_name="s3_data_bucket_name",
-            s3_artifacts_bucket_name="s3_artifacts_bucket_name",
-        )
+def test_list_file_names_success() -> None:
+    client = storage.Client(
+        s3_data_bucket_name="s3_data_bucket_name",
+        s3_artifacts_bucket_name="s3_artifacts_bucket_name",
+    )
 
-        client.s3_client = MockS3Client(
-            data={
-                "KeyCount": 3,
-                "IsTruncated": False,
-                "Contents": [
-                    {
-                        "Key": "prefix/2021",
-                    },
-                    {
-                        "Key": "prefix/2022",
-                    },
-                    {
-                        "Key": "prefix/first",
-                    },
-                ],
-            },
-        )
+    client.s3_client = MockS3Client(
+        data={
+            "KeyCount": 3,
+            "IsTruncated": False,
+            "Contents": [
+                {
+                    "Key": "prefix/2021",
+                },
+                {
+                    "Key": "prefix/2022",
+                },
+                {
+                    "Key": "prefix/first",
+                },
+            ],
+        },
+    )
 
-        file_names = client.list_file_names(
-            prefix="prefix",
-        )
+    file_names = client.list_file_names(
+        prefix="prefix",
+    )
 
-        assert len(file_names) == 3
-        assert file_names[0] == "2021"
-        assert file_names[1] == "2022"
-        assert file_names[2] == "first"
-
-
-class TestStoreDataframes(unittest.TestCase):
-    def test_store_dataframes_success(self) -> None:
-        client = storage.Client(
-            s3_data_bucket_name="s3_data_bucket_name",
-            s3_artifacts_bucket_name="s3_artifacts_bucket_name",
-        )
-
-        client.s3_client = MockS3Client(
-            data={},
-        )
-
-        first_dataframe = pd.DataFrame(data={"a": [1, 2]})
-        second_dataframe = pd.DataFrame(data={"b": [3, 4]})
-
-        dataframes = {
-            "first": first_dataframe,
-            "second": second_dataframe,
-        }
-
-        client.store_dataframes(
-            prefix="prefix",
-            dataframes_by_file_name=dataframes,
-        )
-
-        assert len(client.s3_client.data) == 2
-        assert first_dataframe.equals(client.s3_client.data["prefix/first"])
-        assert second_dataframe.equals(client.s3_client.data["prefix/second"])
+    assert len(file_names) == 3
+    assert file_names[0] == "2021"
+    assert file_names[1] == "2022"
+    assert file_names[2] == "first"
 
 
-class TestLoadDataframes(unittest.TestCase):
-    def test_load_dataframes_success(self) -> None:
-        client = storage.Client(
-            s3_data_bucket_name="s3_data_bucket_name",
-            s3_artifacts_bucket_name="s3_artifacts_bucket_name",
-        )
+def test_store_dataframes_success() -> None:
+    client = storage.Client(
+        s3_data_bucket_name="s3_data_bucket_name",
+        s3_artifacts_bucket_name="s3_artifacts_bucket_name",
+    )
 
-        client.s3_client = MockS3Client(
-            data={
-                "prefix/first": pd.DataFrame(data={"a": [1, 2]}),
-                "prefix/second": pd.DataFrame(data={"b": [3, 4]}),
-            },
-        )
+    client.s3_client = MockS3Client(
+        data={},
+    )
 
-        dataframes_by_file_name = client.load_dataframes(
-            prefix="prefix",
-            file_names=["first", "second"],
-        )
+    first_dataframe = pd.DataFrame(data={"a": [1, 2]})
+    second_dataframe = pd.DataFrame(data={"b": [3, 4]})
 
-        assert len(dataframes_by_file_name) == 2
-        assert dataframes_by_file_name["first"].equals(client.s3_client.data["prefix/first"])
-        assert dataframes_by_file_name["second"].equals(client.s3_client.data["prefix/second"])
+    dataframes = {
+        "first": first_dataframe,
+        "second": second_dataframe,
+    }
 
+    client.store_dataframes(
+        prefix="prefix",
+        dataframes_by_file_name=dataframes,
+    )
 
-class TestStoreTexts(unittest.TestCase):
-    def test_store_texts_success(self) -> None:
-        client = storage.Client(
-            s3_data_bucket_name="s3_data_bucket_name",
-            s3_artifacts_bucket_name="s3_artifacts_bucket_name",
-        )
-
-        client.s3_client = MockS3Client(
-            data={},
-        )
-
-        text = "text"
-
-        client.store_texts(
-            prefix="prefix",
-            texts_by_file_name={"text.txt": text},
-        )
-
-        assert len(client.s3_client.data) == 1
-        assert text == client.s3_client.data["prefix/text.txt"]
+    assert len(client.s3_client.data) == 2
+    assert first_dataframe.equals(client.s3_client.data["prefix/first"])
+    assert second_dataframe.equals(client.s3_client.data["prefix/second"])
 
 
-class TestLoadTexts(unittest.TestCase):
-    def test_load_texts_success(self) -> None:
-        client = storage.Client(
-            s3_data_bucket_name="s3_data_bucket_name",
-            s3_artifacts_bucket_name="s3_artifacts_bucket_name",
-        )
+def test_load_dataframes_success() -> None:
+    client = storage.Client(
+        s3_data_bucket_name="s3_data_bucket_name",
+        s3_artifacts_bucket_name="s3_artifacts_bucket_name",
+    )
 
-        client.s3_client = MockS3Client(
-            data={
-                "prefix/text.txt": "text",
-            },
-        )
+    client.s3_client = MockS3Client(
+        data={
+            "prefix/first": pd.DataFrame(data={"a": [1, 2]}),
+            "prefix/second": pd.DataFrame(data={"b": [3, 4]}),
+        },
+    )
 
-        texts_by_file_name = client.load_texts(
-            prefix="prefix",
-            file_names=["text.txt"],
-        )
+    dataframes_by_file_name = client.load_dataframes(
+        prefix="prefix",
+        file_names=["first", "second"],
+    )
 
-        assert texts_by_file_name["text.txt"] == "text"
+    assert len(dataframes_by_file_name) == 2
+    assert dataframes_by_file_name["first"].equals(client.s3_client.data["prefix/first"])
+    assert dataframes_by_file_name["second"].equals(client.s3_client.data["prefix/second"])
+
+
+def test_store_texts_success() -> None:
+    client = storage.Client(
+        s3_data_bucket_name="s3_data_bucket_name",
+        s3_artifacts_bucket_name="s3_artifacts_bucket_name",
+    )
+
+    client.s3_client = MockS3Client(
+        data={},
+    )
+
+    text = "text"
+
+    client.store_texts(
+        prefix="prefix",
+        texts_by_file_name={"text.txt": text},
+    )
+
+    assert len(client.s3_client.data) == 1
+    assert text == client.s3_client.data["prefix/text.txt"]
+
+
+def test_load_texts_success() -> None:
+    client = storage.Client(
+        s3_data_bucket_name="s3_data_bucket_name",
+        s3_artifacts_bucket_name="s3_artifacts_bucket_name",
+    )
+
+    client.s3_client = MockS3Client(
+        data={
+            "prefix/text.txt": "text",
+        },
+    )
+
+    texts_by_file_name = client.load_texts(
+        prefix="prefix",
+        file_names=["text.txt"],
+    )
+
+    assert texts_by_file_name["text.txt"] == "text"

--- a/pkg/trade/test_trade.py
+++ b/pkg/trade/test_trade.py
@@ -1,5 +1,4 @@
 import datetime
-import unittest
 from typing import Optional
 
 import pytest
@@ -7,10 +6,12 @@ import pytest
 from pkg.config import config
 from pkg.trade import trade
 
-DARQUBE_API_KEY = "darqube_api_key"  # noqa: S106
-ALPACA_API_KEY = "alpaca_api_key"  # noqa: S106
-ALPACA_API_SECRET = "alpaca_api_secret"  # noqa: S106, S105
-ALPHA_VANTAGE_API_KEY = "alpha_vantage_api_key"  # noqa: S106
+client = trade.Client(
+    darqube_api_key="darqube_api_key",
+    alpaca_api_key="alpaca_api_key",
+    alpaca_api_secret="alpaca_api_secret",  # noqa: S106
+    alpha_vantage_api_key="alpha_vantage_api_key",
+)
 
 
 class MockAlpacaClock:
@@ -271,767 +272,667 @@ def mock_get_risk_free_rate_success() -> float:
     return 0.03
 
 
-class TestCheckSetPositionAvailability(unittest.TestCase):
-    def test_check_position_set_availability_success(self) -> None:
-        client = trade.Client(
-            darqube_api_key=DARQUBE_API_KEY,
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
-        )
+def test_check_position_set_availability_success() -> None:
+    monday_calendar_days = [
+        MockAlpacaCalendar(
+            date_value=datetime.date(1977, 5, 23),
+            open_value=datetime.datetime(1977, 5, 23, 9, 30, tzinfo=config.TIMEZONE),
+            close_value=datetime.datetime(1977, 5, 23, 16, 0, tzinfo=config.TIMEZONE),
+        ),
+        MockAlpacaCalendar(
+            date_value=datetime.date(1977, 5, 24),
+            open_value=datetime.datetime(1977, 5, 24, 9, 30, tzinfo=config.TIMEZONE),
+            close_value=datetime.datetime(1977, 5, 24, 16, 0, tzinfo=config.TIMEZONE),
+        ),
+        MockAlpacaCalendar(
+            date_value=datetime.date(1977, 5, 25),
+            open_value=datetime.datetime(1977, 5, 25, 9, 30, tzinfo=config.TIMEZONE),
+            close_value=datetime.datetime(1977, 5, 25, 16, 0, tzinfo=config.TIMEZONE),
+        ),
+        MockAlpacaCalendar(
+            date_value=datetime.date(1977, 5, 26),
+            open_value=datetime.datetime(1977, 5, 26, 9, 30, tzinfo=config.TIMEZONE),
+            close_value=datetime.datetime(1977, 5, 26, 16, 0, tzinfo=config.TIMEZONE),
+        ),
+        MockAlpacaCalendar(
+            date_value=datetime.date(1977, 5, 27),
+            open_value=datetime.datetime(1977, 5, 27, 9, 30, tzinfo=config.TIMEZONE),
+            close_value=datetime.datetime(1977, 5, 27, 16, 0, tzinfo=config.TIMEZONE),
+        ),
+    ]
 
-        monday_calendar_days = [
-            MockAlpacaCalendar(
-                date_value=datetime.date(1977, 5, 23),
-                open_value=datetime.datetime(1977, 5, 23, 9, 30, tzinfo=config.TIMEZONE),
-                close_value=datetime.datetime(1977, 5, 23, 16, 0, tzinfo=config.TIMEZONE),
-            ),
-            MockAlpacaCalendar(
-                date_value=datetime.date(1977, 5, 24),
-                open_value=datetime.datetime(1977, 5, 24, 9, 30, tzinfo=config.TIMEZONE),
-                close_value=datetime.datetime(1977, 5, 24, 16, 0, tzinfo=config.TIMEZONE),
-            ),
-            MockAlpacaCalendar(
-                date_value=datetime.date(1977, 5, 25),
-                open_value=datetime.datetime(1977, 5, 25, 9, 30, tzinfo=config.TIMEZONE),
-                close_value=datetime.datetime(1977, 5, 25, 16, 0, tzinfo=config.TIMEZONE),
-            ),
-            MockAlpacaCalendar(
-                date_value=datetime.date(1977, 5, 26),
-                open_value=datetime.datetime(1977, 5, 26, 9, 30, tzinfo=config.TIMEZONE),
-                close_value=datetime.datetime(1977, 5, 26, 16, 0, tzinfo=config.TIMEZONE),
-            ),
-            MockAlpacaCalendar(
-                date_value=datetime.date(1977, 5, 27),
-                open_value=datetime.datetime(1977, 5, 27, 9, 30, tzinfo=config.TIMEZONE),
-                close_value=datetime.datetime(1977, 5, 27, 16, 0, tzinfo=config.TIMEZONE),
-            ),
-        ]
+    friday_calendar_days = [
+        MockAlpacaCalendar(
+            date_value=datetime.date(1977, 5, 27),
+            open_value=datetime.datetime(1977, 5, 27, 9, 30, tzinfo=config.TIMEZONE),
+            close_value=datetime.datetime(1977, 5, 27, 16, 0, tzinfo=config.TIMEZONE),
+        ),
+        MockAlpacaCalendar(
+            date_value=datetime.date(1977, 5, 30),
+            open_value=datetime.datetime(1977, 5, 30, 9, 30, tzinfo=config.TIMEZONE),
+            close_value=datetime.datetime(1977, 5, 30, 16, 0, tzinfo=config.TIMEZONE),
+        ),
+        MockAlpacaCalendar(
+            date_value=datetime.date(1977, 5, 31),
+            open_value=datetime.datetime(1977, 5, 31, 9, 30, tzinfo=config.TIMEZONE),
+            close_value=datetime.datetime(1977, 5, 31, 16, 0, tzinfo=config.TIMEZONE),
+        ),
+        MockAlpacaCalendar(
+            date_value=datetime.date(1977, 6, 1),
+            open_value=datetime.datetime(1977, 6, 1, 9, 30, tzinfo=config.TIMEZONE),
+            close_value=datetime.datetime(1977, 6, 1, 16, 0, tzinfo=config.TIMEZONE),
+        ),
+        MockAlpacaCalendar(
+            date_value=datetime.date(1977, 6, 2),
+            open_value=datetime.datetime(1977, 6, 2, 9, 30, tzinfo=config.TIMEZONE),
+            close_value=datetime.datetime(1977, 6, 2, 16, 0, tzinfo=config.TIMEZONE),
+        ),
+    ]
 
-        friday_calendar_days = [
-            MockAlpacaCalendar(
-                date_value=datetime.date(1977, 5, 27),
-                open_value=datetime.datetime(1977, 5, 27, 9, 30, tzinfo=config.TIMEZONE),
-                close_value=datetime.datetime(1977, 5, 27, 16, 0, tzinfo=config.TIMEZONE),
-            ),
-            MockAlpacaCalendar(
-                date_value=datetime.date(1977, 5, 30),
-                open_value=datetime.datetime(1977, 5, 30, 9, 30, tzinfo=config.TIMEZONE),
-                close_value=datetime.datetime(1977, 5, 30, 16, 0, tzinfo=config.TIMEZONE),
-            ),
-            MockAlpacaCalendar(
-                date_value=datetime.date(1977, 5, 31),
-                open_value=datetime.datetime(1977, 5, 31, 9, 30, tzinfo=config.TIMEZONE),
-                close_value=datetime.datetime(1977, 5, 31, 16, 0, tzinfo=config.TIMEZONE),
-            ),
-            MockAlpacaCalendar(
-                date_value=datetime.date(1977, 6, 1),
-                open_value=datetime.datetime(1977, 6, 1, 9, 30, tzinfo=config.TIMEZONE),
-                close_value=datetime.datetime(1977, 6, 1, 16, 0, tzinfo=config.TIMEZONE),
-            ),
-            MockAlpacaCalendar(
-                date_value=datetime.date(1977, 6, 2),
-                open_value=datetime.datetime(1977, 6, 2, 9, 30, tzinfo=config.TIMEZONE),
-                close_value=datetime.datetime(1977, 6, 2, 16, 0, tzinfo=config.TIMEZONE),
-            ),
-        ]
-
-        tests = [
-            {
-                "action": trade.CREATE_ACTION,
-                "current_datetime": datetime.datetime(1977, 5, 23, 9, 15, tzinfo=config.TIMEZONE),
-                "is_market_open": False,
-                "calendar_days": monday_calendar_days,
-                "all_positions": [],
-                "result": False,
-            },
-            {
-                "action": trade.CREATE_ACTION,
-                "current_datetime": datetime.datetime(1977, 5, 26, 9, 45, tzinfo=config.TIMEZONE),
-                "is_market_open": True,
-                "calendar_days": [
-                    MockAlpacaCalendar(
-                        date_value=datetime.date(1977, 5, 26),
-                        open_value=datetime.datetime(1977, 5, 26, 9, 30, tzinfo=config.TIMEZONE),
-                        close_value=datetime.datetime(1977, 5, 26, 16, 0, tzinfo=config.TIMEZONE),
-                    ),
-                ]
-                + friday_calendar_days[1:],
-                "all_positions": [],
-                "result": True,
-            },
-            {
-                "action": trade.CREATE_ACTION,
-                "current_datetime": datetime.datetime(1977, 5, 27, 15, 30, tzinfo=config.TIMEZONE),
-                "is_market_open": True,
-                "calendar_days": friday_calendar_days,
-                "all_positions": [],
-                "result": False,
-            },
-            {
-                "action": trade.CREATE_ACTION,
-                "current_datetime": datetime.datetime(1977, 5, 23, 9, 45, tzinfo=config.TIMEZONE),
-                "is_market_open": True,
-                "calendar_days": monday_calendar_days,
-                "all_positions": [{}],
-                "result": False,
-            },
-            {
-                "action": trade.CREATE_ACTION,
-                "current_datetime": datetime.datetime(1977, 5, 23, 9, 45, tzinfo=config.TIMEZONE),
-                "is_market_open": True,
-                "calendar_days": monday_calendar_days,
-                "all_positions": [],
-                "result": True,
-            },
-            {
-                "action": trade.CLEAR_ACTION,
-                "current_datetime": datetime.datetime(1977, 5, 23, 16, 15, tzinfo=config.TIMEZONE),
-                "is_market_open": False,
-                "calendar_days": monday_calendar_days,
-                "all_positions": [],
-                "result": False,
-            },
-            {
-                "action": trade.CLEAR_ACTION,
-                "current_datetime": datetime.datetime(1977, 5, 26, 15, 30, tzinfo=config.TIMEZONE),
-                "is_market_open": True,
-                "calendar_days": [
-                    MockAlpacaCalendar(
-                        date_value=datetime.date(1977, 5, 26),
-                        open_value=datetime.datetime(1977, 5, 26, 9, 30, tzinfo=config.TIMEZONE),
-                        close_value=datetime.datetime(1977, 5, 26, 16, 0, tzinfo=config.TIMEZONE),
-                    ),
-                ]
-                + friday_calendar_days[1:],
-                "all_positions": [{}],
-                "result": True,
-            },
-            {
-                "action": trade.CLEAR_ACTION,
-                "current_datetime": datetime.datetime(1977, 5, 23, 15, 30, tzinfo=config.TIMEZONE),
-                "is_market_open": True,
-                "calendar_days": monday_calendar_days,
-                "all_positions": [{}],
-                "result": False,
-            },
-            {
-                "action": trade.CLEAR_ACTION,
-                "current_datetime": datetime.datetime(1977, 5, 23, 15, 30, tzinfo=config.TIMEZONE),
-                "is_market_open": True,
-                "calendar_days": monday_calendar_days,
-                "all_positions": [],
-                "result": False,
-            },
-            {
-                "action": trade.CLEAR_ACTION,
-                "current_datetime": datetime.datetime(1977, 5, 27, 15, 30, tzinfo=config.TIMEZONE),
-                "is_market_open": True,
-                "calendar_days": monday_calendar_days,
-                "all_positions": [{}],
-                "result": True,
-            },
-        ]
-
-        for test in tests:
-            client.alpaca_trading_client = MockAlpacaTradingClient(
-                responses={
-                    "get_clock": MockAlpacaClock(
-                        is_open=test["is_market_open"],
-                    ),
-                    "get_calendar": test["calendar_days"],
-                    "get_all_positions": test["all_positions"],
-                },
-                exceptions=None,
-            )
-
-            result = client.check_set_position_availability(
-                action=test["action"],
-                current_datetime=test["current_datetime"],
-            )
-
-            assert test["result"] == result
-
-
-class TestPrivateGetAvailableTickers(unittest.TestCase):
-    def setUp(self) -> None:
-        self.client = trade.Client(
-            darqube_api_key=DARQUBE_API_KEY,
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
-        )
-
-    def tearDown(self) -> None:
-        pass
-
-    def test__get_available_tickers_darqube_get_tickers_error(self) -> None:
-        self.client.http_client = MockHTTPClient(
-            response=None,
-            exception=Exception("darqube get tickers error"),
-        )
-
-        with pytest.raises(Exception) as context:
-            self.client._get_available_tickers()
-
-        assert str(context.value) == "darqube get tickers error"
-
-    def test__get_available_tickers_alpaca_get_all_assets_error(self) -> None:
-        self.client.http_client = MockHTTPClient(
-            response=MockHTTPResponse(
-                data={
-                    "0": {
-                        "Code": "TICKER",
-                    },
-                },
-            ),
-            exception=None,
-        )
-
-        self.client.alpaca_trading_client = MockAlpacaTradingClient(
-            responses=None,
-            exceptions={
-                "get_all_assets": Exception("alpaca get all assets error"),
-            },
-        )
-
-        with pytest.raises(Exception) as context:
-            self.client._get_available_tickers()
-
-        assert str(context.value) == "alpaca get all assets error"
-
-    def test__get_available_tickers_success(self) -> None:
-        self.client.http_client = MockHTTPClient(
-            response=MockHTTPResponse(
-                data={
-                    "0": {
-                        "Code": "TICKER",
-                    },
-                },
-            ),
-            exception=None,
-        )
-
-        self.client.alpaca_trading_client = MockAlpacaTradingClient(
-            responses={
-                "get_all_assets": MockAlpacaGetAllAssetsResponse(
-                    data=[
-                        MockAlpacaAsset(
-                            symbol="TICKER",
-                        ),
-                    ],
+    tests = [
+        {
+            "action": trade.CREATE_ACTION,
+            "current_datetime": datetime.datetime(1977, 5, 23, 9, 15, tzinfo=config.TIMEZONE),
+            "is_market_open": False,
+            "calendar_days": monday_calendar_days,
+            "all_positions": [],
+            "result": False,
+        },
+        {
+            "action": trade.CREATE_ACTION,
+            "current_datetime": datetime.datetime(1977, 5, 26, 9, 45, tzinfo=config.TIMEZONE),
+            "is_market_open": True,
+            "calendar_days": [
+                MockAlpacaCalendar(
+                    date_value=datetime.date(1977, 5, 26),
+                    open_value=datetime.datetime(1977, 5, 26, 9, 30, tzinfo=config.TIMEZONE),
+                    close_value=datetime.datetime(1977, 5, 26, 16, 0, tzinfo=config.TIMEZONE),
                 ),
+            ]
+            + friday_calendar_days[1:],
+            "all_positions": [],
+            "result": True,
+        },
+        {
+            "action": trade.CREATE_ACTION,
+            "current_datetime": datetime.datetime(1977, 5, 27, 15, 30, tzinfo=config.TIMEZONE),
+            "is_market_open": True,
+            "calendar_days": friday_calendar_days,
+            "all_positions": [],
+            "result": False,
+        },
+        {
+            "action": trade.CREATE_ACTION,
+            "current_datetime": datetime.datetime(1977, 5, 23, 9, 45, tzinfo=config.TIMEZONE),
+            "is_market_open": True,
+            "calendar_days": monday_calendar_days,
+            "all_positions": [{}],
+            "result": False,
+        },
+        {
+            "action": trade.CREATE_ACTION,
+            "current_datetime": datetime.datetime(1977, 5, 23, 9, 45, tzinfo=config.TIMEZONE),
+            "is_market_open": True,
+            "calendar_days": monday_calendar_days,
+            "all_positions": [],
+            "result": True,
+        },
+        {
+            "action": trade.CLEAR_ACTION,
+            "current_datetime": datetime.datetime(1977, 5, 23, 16, 15, tzinfo=config.TIMEZONE),
+            "is_market_open": False,
+            "calendar_days": monday_calendar_days,
+            "all_positions": [],
+            "result": False,
+        },
+        {
+            "action": trade.CLEAR_ACTION,
+            "current_datetime": datetime.datetime(1977, 5, 26, 15, 30, tzinfo=config.TIMEZONE),
+            "is_market_open": True,
+            "calendar_days": [
+                MockAlpacaCalendar(
+                    date_value=datetime.date(1977, 5, 26),
+                    open_value=datetime.datetime(1977, 5, 26, 9, 30, tzinfo=config.TIMEZONE),
+                    close_value=datetime.datetime(1977, 5, 26, 16, 0, tzinfo=config.TIMEZONE),
+                ),
+            ]
+            + friday_calendar_days[1:],
+            "all_positions": [{}],
+            "result": True,
+        },
+        {
+            "action": trade.CLEAR_ACTION,
+            "current_datetime": datetime.datetime(1977, 5, 23, 15, 30, tzinfo=config.TIMEZONE),
+            "is_market_open": True,
+            "calendar_days": monday_calendar_days,
+            "all_positions": [{}],
+            "result": False,
+        },
+        {
+            "action": trade.CLEAR_ACTION,
+            "current_datetime": datetime.datetime(1977, 5, 23, 15, 30, tzinfo=config.TIMEZONE),
+            "is_market_open": True,
+            "calendar_days": monday_calendar_days,
+            "all_positions": [],
+            "result": False,
+        },
+        {
+            "action": trade.CLEAR_ACTION,
+            "current_datetime": datetime.datetime(1977, 5, 27, 15, 30, tzinfo=config.TIMEZONE),
+            "is_market_open": True,
+            "calendar_days": monday_calendar_days,
+            "all_positions": [{}],
+            "result": True,
+        },
+    ]
+
+    for test in tests:
+        client.alpaca_trading_client = MockAlpacaTradingClient(
+            responses={
+                "get_clock": MockAlpacaClock(
+                    is_open=test["is_market_open"],
+                ),
+                "get_calendar": test["calendar_days"],
+                "get_all_positions": test["all_positions"],
             },
             exceptions=None,
         )
 
-        tickers = self.client._get_available_tickers()
-
-        assert len(tickers) == 1
-        assert tickers[0] == "TICKER"
-
-
-class TestGetAvailableTickers(unittest.TestCase):
-    def setUp(self) -> None:
-        self.client = trade.Client(
-            darqube_api_key=DARQUBE_API_KEY,
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
+        result = client.check_set_position_availability(
+            action=test["action"],
+            current_datetime=test["current_datetime"],
         )
 
-    def tearDown(self) -> None:
-        pass
-
-    def test_get_available_tickers_error(self) -> None:
-        self.client._get_available_tickers = mock_get_available_tickers_error
-
-        with pytest.raises(Exception) as context:
-            self.client.get_available_tickers()
-
-        assert str(context.value) == "get available tickers error"
-
-    def test_get_available_tickers_success(self) -> None:
-        self.client._get_available_tickers = mock_get_available_tickers_success
-
-        tickers = self.client.get_available_tickers()
-
-        assert len(tickers) == 1
-        assert tickers[0] == "TICKER"
+        assert test["result"] == result
 
 
-class TestSetPositions(unittest.TestCase):
-    def setUp(self) -> None:
-        self.client = trade.Client(
-            darqube_api_key=DARQUBE_API_KEY,
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
-        )
+def test__get_available_tickers_darqube_get_tickers_error() -> None:
+    client.http_client = MockHTTPClient(
+        response=None,
+        exception=Exception("darqube get tickers error"),
+    )
 
-    def tearDown(self) -> None:
-        pass
+    with pytest.raises(Exception) as context:
+        client._get_available_tickers()
 
-    def test_set_positions_get_available_tickers_error(self) -> None:
-        self.client._get_available_tickers = mock_get_available_tickers_error
+    assert str(context.value) == "darqube get tickers error"
 
-        with pytest.raises(Exception) as context:
-            self.client.set_positions(
-                tickers=["TICKER"],
-            )
 
-        assert str(context.value) == "get available tickers error"
-
-    def test_set_positions_get_account_error(self) -> None:
-        self.client._get_available_tickers = mock_get_available_tickers_success
-
-        self.client.alpaca_trading_client = MockAlpacaTradingClient(
-            responses=None,
-            exceptions={
-                "get_account": Exception("alpaca get account error"),
+def test__get_available_tickers_alpaca_get_all_assets_error() -> None:
+    client.http_client = MockHTTPClient(
+        response=MockHTTPResponse(
+            data={
+                "0": {
+                    "Code": "TICKER",
+                },
             },
-        )
+        ),
+        exception=None,
+    )
 
-        with pytest.raises(Exception) as context:
-            self.client.set_positions(
-                tickers=["TICKER"],
-            )
+    client.alpaca_trading_client = MockAlpacaTradingClient(
+        responses=None,
+        exceptions={
+            "get_all_assets": Exception("alpaca get all assets error"),
+        },
+    )
 
-        assert str(context.value) == "alpaca get account error"
+    with pytest.raises(Exception) as context:
+        client._get_available_tickers()
 
-    def test_set_positions_submit_order_error(self) -> None:
-        self.client._get_available_tickers = mock_get_available_tickers_success
+    assert str(context.value) == "alpaca get all assets error"
 
-        self.client.alpaca_trading_client = MockAlpacaTradingClient(
-            responses={
-                "get_account": MockAlpacaAccount(
-                    cash=100.0,
-                    equity=100.0,
-                ),
+
+def test__get_available_tickers_success() -> None:
+    client.http_client = MockHTTPClient(
+        response=MockHTTPResponse(
+            data={
+                "0": {
+                    "Code": "TICKER",
+                },
             },
-            exceptions={
-                "get_account": None,
-                "submit_order": Exception("alpaca submit order error"),
-            },
-        )
+        ),
+        exception=None,
+    )
 
-        with pytest.raises(Exception) as context:
-            self.client.set_positions(
-                tickers=["TICKER"],
-            )
+    client.alpaca_trading_client = MockAlpacaTradingClient(
+        responses={
+            "get_all_assets": MockAlpacaGetAllAssetsResponse(
+                data=[
+                    MockAlpacaAsset(
+                        symbol="TICKER",
+                    ),
+                ],
+            ),
+        },
+        exceptions=None,
+    )
 
-        assert str(context.value) == "alpaca submit order error"
+    tickers = client._get_available_tickers()
 
-    def test_set_positions_success(self) -> None:
-        self.client._get_available_tickers = mock_get_available_tickers_success
+    assert len(tickers) == 1
+    assert tickers[0] == "TICKER"
 
-        self.client.alpaca_trading_client = MockAlpacaTradingClient(
-            responses={
-                "get_account": MockAlpacaAccount(
-                    cash=100.0,
-                    equity=100.0,
-                ),
-            },
-            exceptions={
-                "get_account": None,
-                "submit_order": None,
-            },
-        )
 
-        self.client.set_positions(
+def test_get_available_tickers_error() -> None:
+    client._get_available_tickers = mock_get_available_tickers_error
+
+    with pytest.raises(Exception) as context:
+        client.get_available_tickers()
+
+    assert str(context.value) == "get available tickers error"
+
+
+def test_get_available_tickers_success() -> None:
+    client._get_available_tickers = mock_get_available_tickers_success
+
+    tickers = client.get_available_tickers()
+
+    assert len(tickers) == 1
+    assert tickers[0] == "TICKER"
+
+
+def test_set_positions_get_available_tickers_error() -> None:
+    client._get_available_tickers = mock_get_available_tickers_error
+
+    with pytest.raises(Exception) as context:
+        client.set_positions(
             tickers=["TICKER"],
         )
 
-        last_request = self.client.alpaca_trading_client.last_request
-        assert last_request is not None
-        assert last_request.symbol == "TICKER"
-        assert last_request.notional == 95.0
-        assert last_request.side == "buy"
+    assert str(context.value) == "get available tickers error"
 
 
-class TestClearPositions(unittest.TestCase):
-    def setUp(self) -> None:
-        self.client = trade.Client(
-            darqube_api_key=DARQUBE_API_KEY,
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
+def test_set_positions_get_account_error() -> None:
+    client._get_available_tickers = mock_get_available_tickers_success
+
+    client.alpaca_trading_client = MockAlpacaTradingClient(
+        responses=None,
+        exceptions={
+            "get_account": Exception("alpaca get account error"),
+        },
+    )
+
+    with pytest.raises(Exception) as context:
+        client.set_positions(
+            tickers=["TICKER"],
         )
 
-    def tearDown(self) -> None:
-        pass
-
-    def test_clear_positions_close_all_positions_error(self) -> None:
-        self.client.alpaca_trading_client = MockAlpacaTradingClient(
-            responses=None,
-            exceptions={
-                "close_all_positions": Exception("alpaca close all positions error"),
-            },
-        )
-
-        with pytest.raises(Exception) as context:
-            self.client.clear_positions()
-
-        assert str(context.value) == "alpaca close all positions error"
-
-    def test_clear_positions_success(self) -> None:
-        self.client.alpaca_trading_client = MockAlpacaTradingClient(
-            responses=None,
-            exceptions=None,
-        )
-
-        self.client.clear_positions()
-
-        assert True
+    assert str(context.value) == "alpaca get account error"
 
 
-class TestPrivateGetPortfolioDailyReturns(unittest.TestCase):
-    def setUp(self) -> None:
-        self.client = trade.Client(
-            darqube_api_key=DARQUBE_API_KEY,
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
-        )
+def test_set_positions_submit_order_error() -> None:
+    client._get_available_tickers = mock_get_available_tickers_success
 
-    def tearDown(self) -> None:
-        pass
-
-    def test__get_portfolio_daily_returns_http_client_error(self) -> None:
-        self.client.http_client = MockHTTPClient(
-            response=None,
-            exception=Exception("alpaca get portfolio returns error"),
-        )
-
-        with pytest.raises(Exception) as context:
-            self.client._get_portoflio_daily_returns(
-                week_count=1,
-                end_at=datetime.datetime.now(tz=config.TIMEZONE),
-            )
-
-        assert str(context.value) == "alpaca get portfolio returns error"
-
-    def test__get_portfolio_daily_returns_insufficient_data_error(self) -> None:
-        self.client.http_client = MockHTTPClient(
-            response=MockHTTPResponse(
-                data={"timestamp": []},
+    client.alpaca_trading_client = MockAlpacaTradingClient(
+        responses={
+            "get_account": MockAlpacaAccount(
+                cash=100.0,
+                equity=100.0,
             ),
-            exception=None,
+        },
+        exceptions={
+            "get_account": None,
+            "submit_order": Exception("alpaca submit order error"),
+        },
+    )
+
+    with pytest.raises(Exception) as context:
+        client.set_positions(
+            tickers=["TICKER"],
         )
 
-        with pytest.raises(Exception) as context:
-            self.client._get_portoflio_daily_returns(
-                week_count=1,
-                end_at=datetime.datetime.now(tz=config.TIMEZONE),
-            )
+    assert str(context.value) == "alpaca submit order error"
 
-        assert str(context.value) == "insufficient portfolio data: 0"
 
-    def test__get_portfolio_daily_returns_success(self) -> None:
-        self.client.http_client = MockHTTPClient(
-            response=MockHTTPResponse(
-                data={
-                    "timestamp": [
-                        1708995600,
-                        1709082000,
-                        1709168400,
-                        1709254800,
-                        1709341200,
-                    ],
-                    "profit_loss_pct": [
-                        -0.0082,
-                        -0.0002,
-                        0.0056,
-                        0.0025,
-                        0.0053,
-                    ],
-                },
+def test_set_positions_success() -> None:
+    client._get_available_tickers = mock_get_available_tickers_success
+
+    client.alpaca_trading_client = MockAlpacaTradingClient(
+        responses={
+            "get_account": MockAlpacaAccount(
+                cash=100.0,
+                equity=100.0,
             ),
-            exception=None,
-        )
+        },
+        exceptions={
+            "get_account": None,
+            "submit_order": None,
+        },
+    )
 
-        returns = self.client._get_portoflio_daily_returns(
+    client.set_positions(
+        tickers=["TICKER"],
+    )
+
+    last_request = client.alpaca_trading_client.last_request
+    assert last_request is not None
+    assert last_request.symbol == "TICKER"
+    assert last_request.notional == 95.0
+    assert last_request.side == "buy"
+
+
+def test_clear_positions_close_all_positions_error() -> None:
+    client.alpaca_trading_client = MockAlpacaTradingClient(
+        responses=None,
+        exceptions={
+            "close_all_positions": Exception("alpaca close all positions error"),
+        },
+    )
+
+    with pytest.raises(Exception) as context:
+        client.clear_positions()
+
+    assert str(context.value) == "alpaca close all positions error"
+
+
+def test_clear_positions_success() -> None:
+    client.alpaca_trading_client = MockAlpacaTradingClient(
+        responses=None,
+        exceptions=None,
+    )
+
+    client.clear_positions()
+
+    assert True
+
+
+def test__get_portfolio_daily_returns_http_client_error() -> None:
+    client.http_client = MockHTTPClient(
+        response=None,
+        exception=Exception("alpaca get portfolio returns error"),
+    )
+
+    with pytest.raises(Exception) as context:
+        client._get_portoflio_daily_returns(
             week_count=1,
             end_at=datetime.datetime.now(tz=config.TIMEZONE),
         )
 
-        assert len(returns) == 5
-        assert returns[0] == -0.0082
+    assert str(context.value) == "alpaca get portfolio returns error"
 
 
-class TestPrivateGetBenchmarkDailyReturns(unittest.TestCase):
-    def setUp(self) -> None:
-        self.client = trade.Client(
-            darqube_api_key=DARQUBE_API_KEY,
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
-        )
+def test__get_portfolio_daily_returns_insufficient_data_error() -> None:
+    client.http_client = MockHTTPClient(
+        response=MockHTTPResponse(
+            data={"timestamp": []},
+        ),
+        exception=None,
+    )
 
-    def tearDown(self) -> None:
-        pass
-
-    def test__get_benchmark_daily_returns_alpaca_client_error(self) -> None:
-        self.client.alpaca_historical_client = MockAlpacaHistoricalClient(
-            responses=None,
-            exceptions={
-                "get_stock_bars": Exception("alpaca get benchmark returns error"),
-            },
-        )
-
-        with pytest.raises(Exception) as context:
-            self.client._get_benchmark_daily_returns(
-                week_count=1,
-                end_at=datetime.datetime.now(tz=config.TIMEZONE),
-            )
-
-        assert str(context.value) == "alpaca get benchmark returns error"
-
-    def test__get_benchmark_daily_returns_insufficient_data_error(self) -> None:
-        self.client.alpaca_historical_client = MockAlpacaHistoricalClient(
-            responses={
-                "get_stock_bars": {
-                    "SPY": [],
-                },
-            },
-            exceptions=None,
-        )
-
-        with pytest.raises(Exception) as context:
-            self.client._get_benchmark_daily_returns(
-                week_count=1,
-                end_at=datetime.datetime.now(tz=config.TIMEZONE),
-            )
-
-        assert str(context.value) == "insufficient benchmark data: 0"
-
-    def test__get_benchmark_daily_returns_success(self) -> None:
-        self.client.alpaca_historical_client = MockAlpacaHistoricalClient(
-            responses={
-                "get_stock_bars": MockAlpacaGetStockBarsResponse(
-                    data=[
-                        {
-                            "c": 100.0,
-                        },
-                        {
-                            "c": 101.0,
-                        },
-                        {
-                            "c": 102.0,
-                        },
-                        {
-                            "c": 103.0,
-                        },
-                        {
-                            "c": 104.0,
-                        },
-                        {
-                            "c": 105.0,
-                        },
-                    ],
-                ),
-            },
-            exceptions=None,
-        )
-
-        returns = self.client._get_benchmark_daily_returns(
+    with pytest.raises(Exception) as context:
+        client._get_portoflio_daily_returns(
             week_count=1,
             end_at=datetime.datetime.now(tz=config.TIMEZONE),
         )
 
-        assert len(returns) == 5
-        assert returns == [0.01, 0.0099, 0.0098, 0.0097, 0.0096]
+    assert str(context.value) == "insufficient portfolio data: 0"
 
 
-class TestPrivateCumulativeReturns(unittest.TestCase):
-    def setUp(self) -> None:
-        self.client = trade.Client(
-            darqube_api_key=DARQUBE_API_KEY,
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
+def test__get_portfolio_daily_returns_success() -> None:
+    client.http_client = MockHTTPClient(
+        response=MockHTTPResponse(
+            data={
+                "timestamp": [
+                    1708995600,
+                    1709082000,
+                    1709168400,
+                    1709254800,
+                    1709341200,
+                ],
+                "profit_loss_pct": [
+                    -0.0082,
+                    -0.0002,
+                    0.0056,
+                    0.0025,
+                    0.0053,
+                ],
+            },
+        ),
+        exception=None,
+    )
+
+    returns = client._get_portoflio_daily_returns(
+        week_count=1,
+        end_at=datetime.datetime.now(tz=config.TIMEZONE),
+    )
+
+    assert len(returns) == 5
+    assert returns[0] == -0.0082
+
+
+def test__get_benchmark_daily_returns_alpaca_client_error() -> None:
+    client.alpaca_historical_client = MockAlpacaHistoricalClient(
+        responses=None,
+        exceptions={
+            "get_stock_bars": Exception("alpaca get benchmark returns error"),
+        },
+    )
+
+    with pytest.raises(Exception) as context:
+        client._get_benchmark_daily_returns(
+            week_count=1,
+            end_at=datetime.datetime.now(tz=config.TIMEZONE),
         )
 
-    def tearDown(self) -> None:
-        pass
+    assert str(context.value) == "alpaca get benchmark returns error"
 
-    def test__cumulative_returns_success(self) -> None:
-        returns = [0.01, 0.0099, 0.0098, 0.0097, 0.0096]
 
-        cumulative_returns = self.client._cumulative_returns(
-            returns=returns,
+def test__get_benchmark_daily_returns_insufficient_data_error() -> None:
+    client.alpaca_historical_client = MockAlpacaHistoricalClient(
+        responses={
+            "get_stock_bars": {
+                "SPY": [],
+            },
+        },
+        exceptions=None,
+    )
+
+    with pytest.raises(Exception) as context:
+        client._get_benchmark_daily_returns(
+            week_count=1,
+            end_at=datetime.datetime.now(tz=config.TIMEZONE),
         )
 
-        assert cumulative_returns == 0.05
+    assert str(context.value) == "insufficient benchmark data: 0"
 
 
-class TestPrivateGetRiskFreeRate(unittest.TestCase):
-    def setUp(self) -> None:
-        self.client = trade.Client(
-            darqube_api_key=DARQUBE_API_KEY,
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
-        )
-
-    def tearDown(self) -> None:
-        pass
-
-    def test__get_risk_free_rate_http_client_error(self) -> None:
-        self.client.http_client = MockHTTPClient(
-            response=None,
-            exception=Exception("get risk free rate error"),
-        )
-
-        with pytest.raises(Exception) as context:
-            self.client._get_risk_free_rate()
-
-        assert str(context.value) == "get risk free rate error"
-
-    def test__get_risk_free_rate_success(self) -> None:
-        self.client.http_client = MockHTTPClient(
-            response=MockHTTPResponse(
-                data={
-                    "data": [
-                        {
-                            "date": "2021-01-01",
-                            "value": "1.0",
-                        },
-                        {
-                            "date": "2021-02-01",
-                            "value": "2.0",
-                        },
-                        {
-                            "date": "2021-03-01",
-                            "value": "3.0",
-                        },
-                    ],
-                },
+def test__get_benchmark_daily_returns_success() -> None:
+    client.alpaca_historical_client = MockAlpacaHistoricalClient(
+        responses={
+            "get_stock_bars": MockAlpacaGetStockBarsResponse(
+                data=[
+                    {
+                        "c": 100.0,
+                    },
+                    {
+                        "c": 101.0,
+                    },
+                    {
+                        "c": 102.0,
+                    },
+                    {
+                        "c": 103.0,
+                    },
+                    {
+                        "c": 104.0,
+                    },
+                    {
+                        "c": 105.0,
+                    },
+                ],
             ),
-            exception=None,
-        )
+        },
+        exceptions=None,
+    )
 
-        risk_free_rate = self.client._get_risk_free_rate()
+    returns = client._get_benchmark_daily_returns(
+        week_count=1,
+        end_at=datetime.datetime.now(tz=config.TIMEZONE),
+    )
 
-        assert risk_free_rate == 0.03
+    assert len(returns) == 5
+    assert returns == [0.01, 0.0099, 0.0098, 0.0097, 0.0096]
 
 
-class TestGetPerformanceMetrics(unittest.TestCase):
-    def setUp(self) -> None:
-        self.client = trade.Client(
-            darqube_api_key=DARQUBE_API_KEY,
-            alpaca_api_key=ALPACA_API_KEY,
-            alpaca_api_secret=ALPACA_API_SECRET,
-            alpha_vantage_api_key=ALPHA_VANTAGE_API_KEY,
-        )
+def test__cumulative_returns_success() -> None:
+    returns = [0.01, 0.0099, 0.0098, 0.0097, 0.0096]
 
-    def tearDown(self) -> None:
-        pass
+    cumulative_returns = client._cumulative_returns(
+        returns=returns,
+    )
 
-    def test_get_performance_metrics_get_account_error(self) -> None:
-        self.client.alpaca_trading_client = MockAlpacaTradingClient(
-            responses=None,
-            exceptions={
-                "get_account": Exception("alpaca get account error"),
+    assert cumulative_returns == 0.05
+
+
+def test__get_risk_free_rate_http_client_error() -> None:
+    client.http_client = MockHTTPClient(
+        response=None,
+        exception=Exception("get risk free rate error"),
+    )
+
+    with pytest.raises(Exception) as context:
+        client._get_risk_free_rate()
+
+    assert str(context.value) == "get risk free rate error"
+
+
+def test__get_risk_free_rate_success() -> None:
+    client.http_client = MockHTTPClient(
+        response=MockHTTPResponse(
+            data={
+                "data": [
+                    {
+                        "date": "2021-01-01",
+                        "value": "1.0",
+                    },
+                    {
+                        "date": "2021-02-01",
+                        "value": "2.0",
+                    },
+                    {
+                        "date": "2021-03-01",
+                        "value": "3.0",
+                    },
+                ],
             },
-        )
+        ),
+        exception=None,
+    )
 
-        with pytest.raises(Exception) as context:
-            self.client.get_performance_metrics(
-                week_count=1,
-                end_at=datetime.datetime.now(tz=config.TIMEZONE),
-            )
+    risk_free_rate = client._get_risk_free_rate()
 
-        assert str(context.value) == "alpaca get account error"
+    assert risk_free_rate == 0.03
 
-    def test_get_performance_metrics_get_portfolio_returns_error(self) -> None:
-        self.client.alpaca_trading_client = MockAlpacaTradingClient(
-            responses={
-                "get_account": MockAlpacaAccount(
-                    cash=100.0,
-                    equity=100.0,
-                ),
-            },
-            exceptions=None,
-        )
 
-        self.client._get_portoflio_daily_returns = mock_get_portoflio_daily_returns_error
+def test_get_performance_metrics_get_account_error() -> None:
+    client.alpaca_trading_client = MockAlpacaTradingClient(
+        responses=None,
+        exceptions={
+            "get_account": Exception("alpaca get account error"),
+        },
+    )
 
-        with pytest.raises(Exception) as context:
-            self.client.get_performance_metrics(
-                week_count=1,
-                end_at=datetime.datetime.now(tz=config.TIMEZONE),
-            )
-
-        assert str(context.value) == "get portfolio returns error"
-
-    def test_get_performance_metrics_get_benchmark_daily_returns_error(self) -> None:
-        self.client.alpaca_trading_client = MockAlpacaTradingClient(
-            responses={
-                "get_account": MockAlpacaAccount(
-                    cash=100.0,
-                    equity=100.0,
-                ),
-            },
-            exceptions=None,
-        )
-
-        self.client._get_portoflio_daily_returns = mock_get_portfolio_returns_success
-        self.client._get_benchmark_daily_returns = mock_get_benchmark_daily_returns_error
-
-        with pytest.raises(Exception) as context:
-            self.client.get_performance_metrics(
-                week_count=1,
-                end_at=datetime.datetime.now(tz=config.TIMEZONE),
-            )
-
-        assert str(context.value) == "get benchmark returns error"
-
-    def test_get_performance_metrics_get_risk_free_rate_error(self) -> None:
-        self.client.alpaca_trading_client = MockAlpacaTradingClient(
-            responses={
-                "get_account": MockAlpacaAccount(
-                    cash=100.0,
-                    equity=100.0,
-                ),
-            },
-            exceptions=None,
-        )
-
-        self.client._get_portoflio_daily_returns = mock_get_portfolio_returns_success
-        self.client._get_benchmark_daily_returns = mock_get_benchmark_daily_returns_success
-        self.client._get_risk_free_rate = mock_get_risk_free_rate_error
-
-        with pytest.raises(Exception) as context:
-            self.client.get_performance_metrics(
-                week_count=1,
-                end_at=datetime.datetime.now(tz=config.TIMEZONE),
-            )
-
-        assert str(context.value) == "get risk free rate error"
-
-    def test_get_performance_metrics_success(self) -> None:
-        self.client.alpaca_trading_client = MockAlpacaTradingClient(
-            responses={
-                "get_account": MockAlpacaAccount(
-                    cash=100.0,
-                    equity=100.0,
-                ),
-            },
-            exceptions=None,
-        )
-
-        self.client._get_portoflio_daily_returns = mock_get_portfolio_returns_success
-        self.client._get_benchmark_daily_returns = mock_get_benchmark_daily_returns_success
-        self.client._get_risk_free_rate = mock_get_risk_free_rate_success
-
-        metrics = self.client.get_performance_metrics(
+    with pytest.raises(Exception) as context:
+        client.get_performance_metrics(
             week_count=1,
             end_at=datetime.datetime.now(tz=config.TIMEZONE),
         )
 
-        assert metrics["current_portfolio_value"] == 100.0
-        assert metrics["cumulative_portfolio_returns"] == 0.0049
-        assert metrics["cumulative_benchmark_returns"] == 0.05
-        assert metrics["risk_free_rate"] == 0.03
-        assert metrics["risk_free_rate"] == 0.03
+    assert str(context.value) == "alpaca get account error"
+
+
+def test_get_performance_metrics_get_portfolio_returns_error() -> None:
+    client.alpaca_trading_client = MockAlpacaTradingClient(
+        responses={
+            "get_account": MockAlpacaAccount(
+                cash=100.0,
+                equity=100.0,
+            ),
+        },
+        exceptions=None,
+    )
+
+    client._get_portoflio_daily_returns = mock_get_portoflio_daily_returns_error
+
+    with pytest.raises(Exception) as context:
+        client.get_performance_metrics(
+            week_count=1,
+            end_at=datetime.datetime.now(tz=config.TIMEZONE),
+        )
+
+    assert str(context.value) == "get portfolio returns error"
+
+
+def test_get_performance_metrics_get_benchmark_daily_returns_error() -> None:
+    client.alpaca_trading_client = MockAlpacaTradingClient(
+        responses={
+            "get_account": MockAlpacaAccount(
+                cash=100.0,
+                equity=100.0,
+            ),
+        },
+        exceptions=None,
+    )
+
+    client._get_portoflio_daily_returns = mock_get_portfolio_returns_success
+    client._get_benchmark_daily_returns = mock_get_benchmark_daily_returns_error
+
+    with pytest.raises(Exception) as context:
+        client.get_performance_metrics(
+            week_count=1,
+            end_at=datetime.datetime.now(tz=config.TIMEZONE),
+        )
+
+    assert str(context.value) == "get benchmark returns error"
+
+
+def test_get_performance_metrics_get_risk_free_rate_error() -> None:
+    client.alpaca_trading_client = MockAlpacaTradingClient(
+        responses={
+            "get_account": MockAlpacaAccount(
+                cash=100.0,
+                equity=100.0,
+            ),
+        },
+        exceptions=None,
+    )
+
+    client._get_portoflio_daily_returns = mock_get_portfolio_returns_success
+    client._get_benchmark_daily_returns = mock_get_benchmark_daily_returns_success
+    client._get_risk_free_rate = mock_get_risk_free_rate_error
+
+    with pytest.raises(Exception) as context:
+        client.get_performance_metrics(
+            week_count=1,
+            end_at=datetime.datetime.now(tz=config.TIMEZONE),
+        )
+
+    assert str(context.value) == "get risk free rate error"
+
+
+def test_get_performance_metrics_success() -> None:
+    client.alpaca_trading_client = MockAlpacaTradingClient(
+        responses={
+            "get_account": MockAlpacaAccount(
+                cash=100.0,
+                equity=100.0,
+            ),
+        },
+        exceptions=None,
+    )
+
+    client._get_portoflio_daily_returns = mock_get_portfolio_returns_success
+    client._get_benchmark_daily_returns = mock_get_benchmark_daily_returns_success
+    client._get_risk_free_rate = mock_get_risk_free_rate_success
+
+    metrics = client.get_performance_metrics(
+        week_count=1,
+        end_at=datetime.datetime.now(tz=config.TIMEZONE),
+    )
+
+    assert metrics["current_portfolio_value"] == 100.0
+    assert metrics["cumulative_portfolio_returns"] == 0.0049
+    assert metrics["cumulative_benchmark_returns"] == 0.05
+    assert metrics["risk_free_rate"] == 0.03
+    assert metrics["risk_free_rate"] == 0.03


### PR DESCRIPTION
### Changes

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

- deprecate `unittest` unit test implementation
- convert all tests to `pytest` format

### Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
Keep the text below to alert the maintainer.
-->

Not exactly necessary but hey, why not.
