### PR TITLE
Add datetime to stored data file name

### DIFF
--- a/bin/helpers/backfill_data.py
+++ b/bin/helpers/backfill_data.py
@@ -53,13 +53,13 @@ available_tickers: list[str] = trade_client.get_available_tickers()
 
 print("tickers count: ", len(available_tickers))  # noqa: T201
 
-full_end_at = datetime.datetime.now(tz=config.TIMEZONE)
-full_start_at = full_end_at - datetime.timedelta(days=365 * 7)
+end_at = datetime.datetime.now(tz=config.TIMEZONE)
+start_at = end_at - datetime.timedelta(days=365 * 7)
 
 equity_raw_data = data_client.get_range_equities_bars(
     tickers=available_tickers,
-    start_at=full_start_at,
-    end_at=full_end_at,
+    start_at=start_at,
+    end_at=end_at,
 )
 
 null_values_check = equity_raw_data.isna().any().any()
@@ -68,9 +68,11 @@ if null_values_check:
     msg = "data contains null values"
     raise Exception(msg)  # noqa: TRY002
 
+file_name_prefix = end_at.strftime("%Y-%m-%d-%H-%M-%S")
+
 storage_client.store_dataframes(
     prefix=storage.PREFIX_EQUITY_BARS_RAW_PATH,
-    dataframes_by_file_name={"all.csv": equity_raw_data},
+    dataframes_by_file_name={f"{file_name_prefix}-all.csv": equity_raw_data},
 )
 
 print("backfill data complete")  # noqa: T201

--- a/bin/helpers/download_data.py
+++ b/bin/helpers/download_data.py
@@ -13,11 +13,19 @@ storage_client = storage.Client(
     s3_artifacts_bucket_name=samconfig_file.get_parameter("S3ArtifactsBucketName"),
 )
 
-equity_bars_raw_data_by_file_name = storage_client.load_dataframes(
+file_names = storage_client.list_file_names(
     prefix=storage.PREFIX_EQUITY_BARS_RAW_PATH,
-    file_names=["all.csv"],
 )
 
-equity_bars_raw_data_by = equity_bars_raw_data_by_file_name["all.csv"]
+file_names = sorted(file_names, reverse=True)
 
-equity_bars_raw_data_by.to_csv("equity_bars_raw_data.csv", index=False)
+file_name = f"{file_names[0]}-all.csv"
+
+equity_bars_raw_data_by_file_name = storage_client.load_dataframes(
+    prefix=storage.PREFIX_EQUITY_BARS_RAW_PATH,
+    file_names=[file_name],
+)
+
+equity_bars_raw_data_by = equity_bars_raw_data_by_file_name[file_name]
+
+equity_bars_raw_data_by.to_csv(file_name, index=False)

--- a/exec/pipeline/predictprice/main.py
+++ b/exec/pipeline/predictprice/main.py
@@ -19,12 +19,20 @@ def download_data(
         s3_artifacts_bucket_name=s3_artifacts_bucket_name,
     )
 
-    equity_bars_raw_dataframes = storage_client.load_dataframes(
+    file_names = storage_client.list_file_names(
         prefix=storage.PREFIX_EQUITY_BARS_RAW_PATH,
-        file_names=["all.csv"],
     )
 
-    return equity_bars_raw_dataframes["all.csv"]
+    file_names = sorted(file_names, reverse=True)
+
+    file_name = f"{file_names[0]}-all.csv"
+
+    equity_bars_raw_dataframes = storage_client.load_dataframes(
+        prefix=storage.PREFIX_EQUITY_BARS_RAW_PATH,
+        file_names=[file_name],
+    )
+
+    return equity_bars_raw_dataframes[file_name]
 
 
 @task


### PR DESCRIPTION
### Changes

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

- add `datetime` values to stored equity data file names

### Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
Keep the text below to alert the maintainer.
-->

This is basically a quick workaround to avoiding overwriting stored data. It's not super robust but not something that we need to spend a ton of time on just yet.