### PR TITLE
Remove `log_interval` parameter to fix model GUI error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tft_model.ckpt
 .python-version
 .mise.toml
 *-all.csv
+*.ckpt

--- a/exec/pipeline/predictprice/main.py
+++ b/exec/pipeline/predictprice/main.py
@@ -54,7 +54,9 @@ def save_model(
     price_prediction_model: model.Model,
 ) -> None:
     """Save the price prediction model to local file."""
-    price_prediction_model.save_model()
+    price_prediction_model.save_model(
+        file_path="model.ckpt",
+    )
 
 
 @flow

--- a/pkg/model/model.py
+++ b/pkg/model/model.py
@@ -71,16 +71,20 @@ class Model:
             dropout=0.1,
             hidden_continuous_size=8,
             loss=RMSE(),
-            log_interval=10,
             optimizer="Ranger",
             reduce_on_plateau_patience=4,
         )
 
+        del train_dataset
+
         trainer.fit(
-            model,
+            model=model,
             train_dataloaders=train_dataloader,
             val_dataloaders=validation_dataloader,
         )
+
+        del train_dataloader
+        del validation_dataloader
 
         self.model = model
 
@@ -216,8 +220,8 @@ class Model:
         train_dataset: TimeSeriesDataSet,
     ) -> DataLoader:
         validation = TimeSeriesDataSet.from_dataset(
-            train_dataset,
-            data,
+            dataset=train_dataset,
+            data=data,
             predict=True,
             stop_randomization=True,
         )


### PR DESCRIPTION
### Changes

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

- remove `log_interval` from model definition
- include model checkpoint files in `.gitignore`

### Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
Keep the text below to alert the maintainer.
-->

There might be a better way to fix this but it's completing a model training run when running this command:

```bash
python exec/pipeline/predictprice/main.py
```
