### PR TITLE
Create "always write" implementation for data "write" method

### DIFF
--- a/platform/datacollector/src/main.rs
+++ b/platform/datacollector/src/main.rs
@@ -22,7 +22,7 @@ async fn data_handler() -> impl Responder {
         std::env::var("S3_DATA_BUCKET_NAME").unwrap(),
     );
 
-    let mut old_bars = data_client.load_equities_bars().await.unwrap();
+    let old_bars = data_client.load_equities_bars().await.unwrap();
 
     let most_recent_datetime = old_bars.iter().max_by_key(|bar| bar.timestamp).unwrap();
 
@@ -36,9 +36,7 @@ async fn data_handler() -> impl Responder {
         current_datetime,
     ).await.unwrap();
 
-    old_bars.extend(new_bars);
-
-    data_client.write_equities_bars(old_bars).await.unwrap();
+    data_client.write_equities_bars(new_bars).await.unwrap();
 
     HttpResponse::Ok().body("OK")
 }


### PR DESCRIPTION
### Changes

- create private helper "load" method
- refactor public "load" method with private helper
- update "write" method with "always write" logic
- update `datacollector` with new "write" method
- fixes #350

### Comments

Instead of having callers be responsible for updating what gets written to S3, this moves the logic to "always write" or "always append" whatever is provided to the "write" `Bars` method.