### PR TITLE
Change all services/libraries to version 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "apca",
  "tokio",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "chronos"
-version = "202409.3.0"
+version = "1.0.0"
 dependencies = [
  "actix-web",
  "cargo-machete",
@@ -1129,7 +1129,7 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "datacollector"
-version = "202409.11.0"
+version = "1.0.0"
 dependencies = [
  "actix-web",
  "async-trait",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "dataprovider"
-version = "202409.11.0"
+version = "1.0.0"
 dependencies = [
  "actix-web",
  "async-trait",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "discord"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "actix-web",
  "cloudevents-sdk",
@@ -2474,7 +2474,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "pocketsizefund"
-version = "0.1.6"
+version = "1.0.0"
 dependencies = [
  "apca",
  "async-trait",

--- a/libraries/python/pyproject.toml
+++ b/libraries/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pocketsizefund"
-version = "20240831.0"
+version = "1.0.0"
 description = "Open source quantitative trading"
 authors = [
   {name="forstmeier", email="john.forstmeier@gmail.com"},

--- a/libraries/rust/Cargo.toml
+++ b/libraries/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocketsizefund"
-version = "0.1.6"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 

--- a/platform/broker/Cargo.toml
+++ b/platform/broker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "broker"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 

--- a/platform/chronos/Cargo.toml
+++ b/platform/chronos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chronos"
-version = "202409.3.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 

--- a/platform/datacollector/Cargo.toml
+++ b/platform/datacollector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datacollector"
-version = "202409.11.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 

--- a/platform/dataprovider/Cargo.toml
+++ b/platform/dataprovider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dataprovider"
-version = "202409.11.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 

--- a/platform/discord/Cargo.toml
+++ b/platform/discord/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "discord"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT"
 

--- a/platform/pricemodel/pyproject.toml
+++ b/platform/pricemodel/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pricemodel"
-version = "20240903.0"
+version = "1.0.0"
 description = "PSF Price Model"
 requires-python = ">=3.9, <3.11"
 dependencies = [


### PR DESCRIPTION
### Changes

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

- update all versions to `1.0.0`
- contributes to #401

### Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
Keep the text below to alert the maintainer.
-->

This just unifies all of our versioning and since we're not going to be publishing anything I don't see any issue with just pinning everything at 1.0.0 until further notice.