### PR TITLE
dockerize haskell

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -24,5 +24,30 @@ run = "uvx ruff format"
 depends = ["python:check", "python:dead-code", "python:format"]
 description="run python code quality checks across the full repository"
 
+[tasks."platform:run"]
+description = "run platform in docker compose"
+run = "cd platform && docker compose up"
 
+[tasks."platform:build"]
+description = "build platform image to dockerhub"
+run = """
+TIMESTAMP=$(date +%Y%m%d) 
+cd platform
+docker build -t pocketsizefund/platform:latest \
+    -t pocketsizefund/platform:${TIMESTAMP} \
+    .
+"""
 
+[tasks."platform:push"]
+description = "push platform image to dockerhub"
+depends = ["platform:build"]
+run = """
+TIMESTAMP=$(date +%Y%m%d) 
+cd platform
+docker push pocketsizefund/platform:latest
+docker push pocketsizefund/platform:${TIMESTAMP}
+"""
+
+[tasks."infrastructure:up"]
+description = "launch infrastructure"
+run = "cd infrastructure && uv run pulumi up"

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -1,0 +1,21 @@
+FROM haskell:9.8.4 AS builder
+
+WORKDIR /app
+
+RUN mkdir -p src app test && touch README.md
+
+COPY stack.yaml stack.yaml.lock package.yaml ./
+RUN stack setup && stack build --only-dependencies
+
+COPY . .
+
+RUN stack build
+RUN cp "$(stack path --local-install-root)/bin/platform-exe" /app/platform-exe
+
+FROM debian:bullseye-slim AS production
+
+RUN apt-get update && apt-get install -y libgmp10 ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/platform-exe /usr/local/bin/app
+
+ENTRYPOINT ["/usr/local/bin/app"]

--- a/platform/compose.yaml
+++ b/platform/compose.yaml
@@ -1,0 +1,10 @@
+services:
+  platform:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    container_name: platform
+    ports:
+      - "8080:8080"
+    restart: unless-stopped


### PR DESCRIPTION
### TL;DR

Added Docker support for the platform service with a new mise task to run it.

### What changed?

- Added a new mise task `platform:run` to run the platform in Docker Compose
- Created a Dockerfile for the platform service that:
  - Uses a multi-stage build with Haskell 9.8.4 as the builder
  - Builds the platform executable
  - Creates a slim Debian-based runtime image
- Added a Docker Compose configuration file that:
  - Exposes port 8080
  - Sets the platform to run on linux/amd64
  - Configures the container to restart unless stopped

### How to test?

Run the platform using the new mise task:
```bash
mise run platform:run
```

The platform should be accessible at http://localhost:8080

### Why make this change?

This change containerizes the platform service, making it easier to run consistently across different development environments and simplifying the deployment process. It also provides a standardized way to run the platform without requiring developers to install Haskell locally.