### PR TITLE
add github action for linting

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,21 @@
+name: format check
+
+on:
+  pull_request
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install mise
+        uses: jdx/mise-action@v2
+      - name: run formatter
+        run: mise run fmt
+      - name: check for changes
+        run: |
+          if [[ -n $(git status --porcelain) ]]; then
+            echo "code formatting issues found. please run 'mise run fmt' locally and commit the changes."
+            git diff
+            exit 1
+          fi


### PR DESCRIPTION
### TL;DR

Added a GitHub workflow to check code formatting on pull requests and updated the gitignore file.

### What changed?

- Added a new GitHub workflow file `.github/workflows/format.yml` that:
  - Runs on pull requests
  - Uses mise to run the project's formatter
  - Fails the check if any formatting issues are found, prompting the developer to run the formatter locally
- Added `infrastructure/Pulumi.infrastructure.yaml` to the `.gitignore` file

### How to test?

1. Create a pull request with code that doesn't match the project's formatting standards
2. Verify that the GitHub workflow fails and shows the formatting issues
3. Run `mise run fmt` locally, commit the changes, and verify the workflow passes

### Why make this change?

This change enforces consistent code formatting across the project by automatically checking pull requests. It helps maintain code quality and reduces time spent on formatting discussions during code reviews.