### PR TITLE
Remove parallel mode from Coveralls check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,5 +23,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: .python_coverage.xml
-          flag-name: python
-          parallel: true


### PR DESCRIPTION
### Changes

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

- remove unused Actions configuration

### Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
-->

I think this was preventing the check from reporting correctly in Coveralls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified the test workflow configuration for uploading coverage reports, with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->