### PR TITLE
add claude code settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mkdir:*)",
+      "Bash(gh issue create:*)",
+      "Bash(gh issue view:*)",
+      "Bash(mise run test:*)",
+      "Bash(mise ls:*)",
+      "Bash(mise tasks:*)",
+      "Bash(pre-commit:*)",
+      "Bash(git add:*)",
+      "Bash(rm:*)",
+      "WebFetch(domain:docs.github.com)",
+      "Bash(git add:*)",
+      "Bash(python -m pytest application/datamanager/tests -v)",
+      "Bash(uv pip:*)",
+      "Bash(cat:*)",
+      "Bash(mise run:*)",
+      "Bash(gh issue close:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -43,6 +43,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T04:19:31.165669Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -72,6 +73,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T04:37:29.329193Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -101,6 +103,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T04:54:31.864641Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -130,6 +133,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T05:16:05.941930Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -159,6 +163,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T04:20:01.303799Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -188,6 +193,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T04:38:18.124702Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -217,6 +223,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T04:55:01.974104Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -246,6 +253,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T05:16:57.964005Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -275,6 +283,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T04:20:25.534043Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -304,6 +313,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T04:38:52.133165Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -333,6 +343,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T04:55:26.025989Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -362,6 +373,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T05:17:33.646871Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -391,6 +403,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T04:19:56.681364Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -421,6 +434,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T04:38:11.017366Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -451,6 +465,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T04:54:57.351040Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,
@@ -481,6 +496,7 @@
       "rev_date": "2025-05-04T03:14:55Z",
       "scrape_date": "2025-05-05T05:16:50.153939Z",
       "stabilities": [
+        "staging",
         "unstable"
       ],
       "unfree": false,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# PocketSizeFund Assistant Memory
+
+Always use mise tasks for running tests, linting, formatting. If there is not a command already present in .mise.toml, suggest creating one.
+
+## Code Style Guidelines
+
+Unless the code is complex, never use comments in the code. The code should speak for itself.
+
+## GitHub Issue Creation
+
+When asked to create a new GitHub issue:
+
+1. Follow the structure in template files:
+  - `.github/ISSUE_TEMPLATE/BUG.md.md` for bugs
+  - `.github/ISSUE_TEMPLATE/FEATURE.md` for new features
+2. Include:
+  - A descriptive title (without [FEATURE|BUG] prefix)
+  - Explain why the feature is needed
+  - Detail the benefits it will bring
+  - Propose two implementation options (after considering at least five)
+  - For each option, include:
+    - Files that need updating
+    - Code diff of proposed changes
+    - Cost-benefit analysis
+
+## GitHub Issue Workflow
+
+1. After creating a ticket, it will be reviewed and possibly modified
+2. Issues with "todo" status are prepared for implementation
+3. When asked to look at ready tickets ready for implementation, search for Github issues with "in progress" status


### PR DESCRIPTION
This pull request introduces a new local settings file for `.claude` to configure permissions for specific Bash commands and web fetch operations. The key change is the addition of an explicit list of allowed commands and domains, with no denied permissions specified.

### Configuration of permissions:

* [`.claude/settings.local.json`](diffhunk://#diff-fca16cae5b0e32edfa6b55eaa32a98ffbf4a0c7d885fb585785fc83b6ea2d9c3R1-R23): Added a `permissions` object to define an "allow" list of Bash commands (e.g., `mkdir`, `gh issue create`, `mise run test`, etc.) and a web fetch permission for the domain `docs.github.com`. The "deny" list is currently empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a new configuration file to define permissions for command execution and web access, specifying allowed commands and restricting web access to a specific domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->