### PR TITLE
Fix GitHub spelling in CLAUDE instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,4 +27,4 @@ When asked to create a new GitHub issue:
 
 1. After creating a ticket, it will be reviewed and possibly modified
 2. Issues with "todo" status are prepared for implementation
-3. When asked to look at ready tickets ready for implementation, search for Github issues with "in progress" status
+3. When asked to look at ready tickets ready for implementation, search for GitHub issues with "in progress" status


### PR DESCRIPTION
## Summary
- correct the spelling of GitHub in CLAUDE instructions

## Testing
- `mise run lint` *(fails: `mise: command not found`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected capitalization of "GitHub" in the documentation for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->