### PR TITLE
Fix duplicated word in CLAUDE instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,4 +27,4 @@ When asked to create a new GitHub issue:
 
 1. After creating a ticket, it will be reviewed and possibly modified
 2. Issues with "todo" status are prepared for implementation
-3. When asked to look at ready tickets ready for implementation, search for Github issues with "in progress" status
+3. When asked to look at tickets ready for implementation, search for Github issues with "in progress" status


### PR DESCRIPTION
## Summary
- remove duplicated word from ticket workflow instructions

## Testing
- `pre-commit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a duplicated word in the GitHub Issue Workflow section for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->