### PR TITLE
Fix Cloud Run cron job schedule

### DIFF
--- a/infrastructure/cloud_run.py
+++ b/infrastructure/cloud_run.py
@@ -47,7 +47,7 @@ subscription = pubsub.Subscription(
 
 job = cloudscheduler.Job(
     "datamanager-job",
-    schedule="0 * * * *",
+    schedule="0 0 * * *",
     time_zone="UTC",
     pubsub_target=cloudscheduler.JobPubsubTargetArgs(
         topic_name=topics.datamanager_ping.id,


### PR DESCRIPTION
## Summary
- run the datamanager Cloud Scheduler job once per day at midnight UTC

## Testing
- `ruff check infrastructure/cloud_run.py`
- `ruff format --check infrastructure/cloud_run.py`
- ❌ `pre-commit` *(failed: `pre-commit: command not found`)*