### PR TITLE
Add prod bucket

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -1,2 +1,3 @@
 import topics  # noqa: F401
+import buckets  # noqa: F401
 import cloud_run  # noqa: F401

--- a/infrastructure/buckets.py
+++ b/infrastructure/buckets.py
@@ -1,0 +1,15 @@
+from pulumi import Config
+from pulumi_gcp import storage
+import project
+
+
+config = Config()
+
+prod_bucket_name = config.require_secret("prod_bucket_name")
+
+prod_data_bucket = storage.Bucket(
+    "prod-data-bucket",
+    name=prod_bucket_name,
+    location=project.REGION,
+    uniform_bucket_level_access=True,
+)

--- a/infrastructure/cloud_run.py
+++ b/infrastructure/cloud_run.py
@@ -3,6 +3,7 @@ import base64
 from pulumi import Config
 import project
 import topics
+import buckets
 
 config = Config()
 
@@ -26,6 +27,9 @@ service = cloudrun.Service(
                         ),
                         cloudrun.ServiceTemplateSpecContainerEnvArgs(
                             name="ALPACA_API_SECRET_KEY", value=alpaca_api_secret
+                        ),
+                        cloudrun.ServiceTemplateSpecContainerEnvArgs(
+                            name="GCP_GCS_BUCKET", value=buckets.prod_data_bucket.name
                         ),
                     ],
                 )


### PR DESCRIPTION
## Summary
- configure prod GCS bucket via Pulumi secret
- wire bucket into Cloud Run service environment

## Testing
- `ruff format infrastructure/buckets.py infrastructure/cloud_run.py infrastructure/__main__.py`
- `ruff check infrastructure/buckets.py infrastructure/cloud_run.py infrastructure/__main__.py`
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `mise run python:lint` *(fails: command not found)*
- `mise run python:test` *(fails: command not found)*
- `mise run python:format` *(fails: command not found)*