### PR TITLE
Add integration tests and lifespan config

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -45,6 +45,26 @@ uv run coverage xml \
     -o .python_coverage.xml
 """
 
+[tasks."python:test:integration"]
+description = "Run integration tests"
+run = """
+uv run coverage run \
+    --parallel-mode \
+    --omit '*/__init__.py,**/test_*.py' \
+    --data-file .python_coverage.output \
+    -m pytest -m integration
+
+uv run coverage combine \
+    --data-file .python_coverage.output
+
+uv run coverage report \
+    --data-file .python_coverage.output
+
+uv run coverage xml \
+    --data-file .python_coverage.output \
+    -o .python_coverage.xml
+"""
+
 [tasks."application:service:build"]
 description = "Build the application service"
 run = """

--- a/application/datamanager/src/datamanager/config.py
+++ b/application/datamanager/src/datamanager/config.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class Settings(BaseModel):
+    polygon_api_key: str | None = None
+    polygon_base_url: str = "https://api.polygon.io"
+    gcp_key_id: str | None = None
+    gcp_secret: str | None = None
+    gcp_gcs_bucket: str | None = None

--- a/application/datamanager/src/datamanager/fetchbars.sql
+++ b/application/datamanager/src/datamanager/fetchbars.sql
@@ -1,0 +1,1 @@
+SELECT * FROM read_parquet({filepaths})

--- a/application/datamanager/src/datamanager/models.py
+++ b/application/datamanager/src/datamanager/models.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+
+class DateRange(BaseModel):
+    start: date
+    end: date
+
+    @field_validator("end")
+    @classmethod
+    def check_end_after_start(cls, end_value, info):
+        start_value = info.data.get("start")
+        if start_value and end_value <= start_value:
+            raise ValueError("End date must be after start date.")
+        return end_value
+
+
+class BarsResult(BaseModel):
+    date: str
+    count: int

--- a/application/datamanager/tests/test_fetch.py
+++ b/application/datamanager/tests/test_fetch.py
@@ -1,0 +1,36 @@
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+import pytest
+
+from application.datamanager.src.datamanager.main import application
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = json.dumps({"results": []}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_fetch_equity_bars(monkeypatch, tmp_path):
+    server = HTTPServer(("localhost", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    url = f"http://{server.server_address[0]}:{server.server_address[1]}"
+    monkeypatch.setenv("POLYGON_API_KEY", "dummy")
+    monkeypatch.setenv("POLYGON_BASE_URL", url)
+    monkeypatch.chdir(tmp_path)
+    async with application.router.lifespan_context(application):
+        async with httpx.AsyncClient(app=application, base_url="http://test") as client:
+            response = await client.post("/fetch-equity-bars")
+    server.shutdown()
+    thread.join()
+    assert response.status_code == 200
+    assert "date" in response.json()

--- a/application/datamanager/tests/test_health.py
+++ b/application/datamanager/tests/test_health.py
@@ -1,8 +1,13 @@
-from fastapi.testclient import TestClient
+import httpx
+import pytest
+
 from application.datamanager.src.datamanager.main import application
 
-client = TestClient(application)
 
-def test_health_endpoint():
-    response = client.get("/health")
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_health_endpoint():
+    async with application.router.lifespan_context(application):
+        async with httpx.AsyncClient(app=application, base_url="http://test") as client:
+            response = await client.get("/health")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- load env vars during startup via lifespan
- return `BarsResult` dataclass from `/fetch-equity-bars`
- write and read parquet via DuckDB using SQL template
- mark `test_fetch` and `test_health` as integration tests
- add `python:test:integration` task

## Testing
- `ruff format application/datamanager/src/datamanager/main.py application/datamanager/tests/test_fetch.py application/datamanager/tests/test_health.py application/datamanager/src/datamanager/config.py .mise.toml`
- `ruff check .`
- `PYTHONPATH=. uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'duckdb')*