### PR TITLE
Remove Ubuntu runner from test workflow

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -3,6 +3,9 @@
   "manifest": {
     "version": 1,
     "install": {
+      "libpqxx": {
+        "pkg-path": "libpqxx"
+      },
       "mise": {
         "pkg-path": "mise"
       },
@@ -35,6 +38,130 @@
     }
   },
   "packages": [
+    {
+      "attr_path": "libpqxx",
+      "broken": false,
+      "derivation": "/nix/store/w9lvn6s828mpwq6b3pqv0hizsfzwhgjm-libpqxx-7.10.1.drv",
+      "description": "C++ library to access PostgreSQL databases",
+      "install_id": "libpqxx",
+      "license": "BSD-3-Clause",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "name": "libpqxx-7.10.1",
+      "pname": "libpqxx",
+      "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "rev_count": 793735,
+      "rev_date": "2025-05-04T03:14:55Z",
+      "scrape_date": "2025-05-05T04:19:30.069215Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "7.10.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dev": "/nix/store/zhxb9605ws89rzy1rh7c43a5q6l2fksd-libpqxx-7.10.1-dev",
+        "out": "/nix/store/qznww33gb7ym7jnd3i4raxwagd059fir-libpqxx-7.10.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "libpqxx",
+      "broken": false,
+      "derivation": "/nix/store/yv2vasrkh611sh8liv2lx361n9bn82ag-libpqxx-7.10.1.drv",
+      "description": "C++ library to access PostgreSQL databases",
+      "install_id": "libpqxx",
+      "license": "BSD-3-Clause",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "name": "libpqxx-7.10.1",
+      "pname": "libpqxx",
+      "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "rev_count": 793735,
+      "rev_date": "2025-05-04T03:14:55Z",
+      "scrape_date": "2025-05-05T04:37:23.298189Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "7.10.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dev": "/nix/store/4fafh1bc0varik2d6wngd20mn3fwkzmc-libpqxx-7.10.1-dev",
+        "out": "/nix/store/d727l5xl8khnzrkgd8x7p7hy7v1apn4q-libpqxx-7.10.1"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "libpqxx",
+      "broken": false,
+      "derivation": "/nix/store/l8bwf0cl29np6xi1kyvgkvb5jnv4a1w3-libpqxx-7.10.1.drv",
+      "description": "C++ library to access PostgreSQL databases",
+      "install_id": "libpqxx",
+      "license": "BSD-3-Clause",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "name": "libpqxx-7.10.1",
+      "pname": "libpqxx",
+      "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "rev_count": 793735,
+      "rev_date": "2025-05-04T03:14:55Z",
+      "scrape_date": "2025-05-05T04:54:30.752025Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "7.10.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dev": "/nix/store/72i3bj360rp5kp2rbfkrb9267raqpbxi-libpqxx-7.10.1-dev",
+        "out": "/nix/store/xlzlkln61251vl4vdhzcgiv03krq4d7s-libpqxx-7.10.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "libpqxx",
+      "broken": false,
+      "derivation": "/nix/store/3cnj26fkyk7yvkzbkq9ricckz2x3lg46-libpqxx-7.10.1.drv",
+      "description": "C++ library to access PostgreSQL databases",
+      "install_id": "libpqxx",
+      "license": "BSD-3-Clause",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "name": "libpqxx-7.10.1",
+      "pname": "libpqxx",
+      "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+      "rev_count": 793735,
+      "rev_date": "2025-05-04T03:14:55Z",
+      "scrape_date": "2025-05-05T05:15:58.462220Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "7.10.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dev": "/nix/store/n3rb5ag633fj1fpkkb17dc826g3k2yh7-libpqxx-7.10.1-dev",
+        "out": "/nix/store/dxbnd3lixj1273hdfqpdvyb7v9w4da6m-libpqxx-7.10.1"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
     {
       "attr_path": "mise",
       "broken": false,

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -8,6 +8,7 @@ ruff.pkg-path = "ruff"
 uv.pkg-path = "uv"
 vulture.pkg-path = "python313Packages.vulture"
 yamllint.pkg-path = "yamllint"
+# libpqxx.pkg-path = "libpqxx"
 
 [options]
 systems = [

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,12 +8,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # os: [macos-latest] # ubuntu-latest should be included once C++ dependencies are fixed
+        os: [ubuntu-latest] # ubuntu-latest should be included once C++ dependencies are fixed
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Flox
         uses: flox/install-flox-action@v2
+      # - name: Install libstdc++
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install -y lib32stdc++6
       - name: Install Python dependencies
         uses: flox/activate-action@v1
         with:

--- a/application/positionmanager/pyproject.toml
+++ b/application/positionmanager/pyproject.toml
@@ -2,7 +2,7 @@
 name = "positionmanager"
 version = "0.1.0"
 description = "Position management service"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115.12",
     "uvicorn>=0.34.2",
@@ -12,6 +12,9 @@ dependencies = [
     "polars>=1.29.0",
     "pandas>=2.1.0",
     "pyportfolioopt>=1.5.6",
+    "ecos>=2.0.14",
+    # "scipy>=1.12.0",
+    # "scikit-learn>=1.4.1",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -587,24 +587,30 @@ version = "0.1.0"
 source = { editable = "application/positionmanager" }
 dependencies = [
     { name = "alpaca-py" },
+    { name = "ecos" },
     { name = "fastapi" },
     { name = "pandas" },
     { name = "polars" },
     { name = "pydantic" },
     { name = "pyportfolioopt" },
     { name = "requests" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
     { name = "uvicorn" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "alpaca-py", specifier = ">=0.15.0" },
+    { name = "ecos", specifier = ">=2.0.13" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "pandas", specifier = ">=2.1.0" },
     { name = "polars", specifier = ">=1.29.0" },
     { name = "pydantic", specifier = ">=2.8.2" },
     { name = "pyportfolioopt", specifier = ">=1.5.6" },
     { name = "requests", specifier = ">=2.31.0" },
+    { name = "scikit-learn", specifier = ">=1.4.1" },
+    { name = "scipy", specifier = ">=1.12.0" },
     { name = "uvicorn", specifier = ">=0.34.2" },
 ]
 
@@ -808,6 +814,29 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/a5/4ae3b3a0755f7b35a280ac90b28817d1f380318973cff14075ab41ef50d9/scikit_learn-1.6.1.tar.gz", hash = "sha256:b4fc2525eca2c69a59260f583c56a7557c6ccdf8deafdba6e060f94c1c59738e", size = 7068312, upload-time = "2025-01-10T08:07:55.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/59/8eb1872ca87009bdcdb7f3cdc679ad557b992c12f4b61f9250659e592c63/scikit_learn-1.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2ffa1e9e25b3d93990e74a4be2c2fc61ee5af85811562f1288d5d055880c4322", size = 12010001, upload-time = "2025-01-10T08:06:58.613Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/05/f2fc4effc5b32e525408524c982c468c29d22f828834f0625c5ef3d601be/scikit_learn-1.6.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:dc5cf3d68c5a20ad6d571584c0750ec641cc46aeef1c1507be51300e6003a7e1", size = 11096360, upload-time = "2025-01-10T08:07:01.556Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e4/4195d52cf4f113573fb8ebc44ed5a81bd511a92c0228889125fac2f4c3d1/scikit_learn-1.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c06beb2e839ecc641366000ca84f3cf6fa9faa1777e29cf0c04be6e4d096a348", size = 12209004, upload-time = "2025-01-10T08:07:06.931Z" },
+    { url = "https://files.pythonhosted.org/packages/94/be/47e16cdd1e7fcf97d95b3cb08bde1abb13e627861af427a3651fcb80b517/scikit_learn-1.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8ca8cb270fee8f1f76fa9bfd5c3507d60c6438bbee5687f81042e2bb98e5a97", size = 13171776, upload-time = "2025-01-10T08:07:11.715Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b0/ca92b90859070a1487827dbc672f998da95ce83edce1270fc23f96f1f61a/scikit_learn-1.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:7a1c43c8ec9fde528d664d947dc4c0789be4077a3647f232869f41d9bf50e0fb", size = 11071865, upload-time = "2025-01-10T08:07:16.088Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ae/993b0fb24a356e71e9a894e42b8a9eec528d4c70217353a1cd7a48bc25d4/scikit_learn-1.6.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a17c1dea1d56dcda2fac315712f3651a1fea86565b64b48fa1bc090249cbf236", size = 11955804, upload-time = "2025-01-10T08:07:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/32fa2ee591af44507eac86406fa6bba968d1eb22831494470d0a2e4a1eb1/scikit_learn-1.6.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6a7aa5f9908f0f28f4edaa6963c0a6183f1911e63a69aa03782f0d924c830a35", size = 11100530, upload-time = "2025-01-10T08:07:23.675Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/55856da1adec655bdce77b502e94a267bf40a8c0b89f8622837f89503b5a/scikit_learn-1.6.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0650e730afb87402baa88afbf31c07b84c98272622aaba002559b614600ca691", size = 12433852, upload-time = "2025-01-10T08:07:26.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4f/c83853af13901a574f8f13b645467285a48940f185b690936bb700a50863/scikit_learn-1.6.1-cp313-cp313t-win_amd64.whl", hash = "sha256:3f59fe08dc03ea158605170eb52b22a105f238a5d512c4470ddeca71feae8e5f", size = 11337256, upload-time = "2025-01-10T08:07:31.084Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
@@ -918,6 +947,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Overview

## Changes

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

- move `ubuntu-latest` to temporary comment

## Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
-->

The C++ dependency(ies) break on Ubuntu so I'm just moving it here for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated automated test workflow to run Python tests only on Ubuntu; macOS testing temporarily disabled.
  - Added installation of GNU C++ compiler in the test workflow.
  - Disabled registration for the libpqxx package in the environment configuration.
  - Temporarily removed ecos, scipy, and scikit-learn dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->