### PR TITLE
Add Docker build task and workflow updates

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,42 @@
+---
+name: Build and push Docker images
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - id: generate
+        run: |
+          services=$(find application -name Dockerfile -printf '%h\n' | sed 's|application/||')
+          matrix=$(echo "$services" | jq -R . | jq -s -c '[.[] | {service:.}]')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  build_and_push:
+    needs: set-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Flox
+        uses: flox/install-flox-action@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push service
+        uses: flox/activate-action@v1
+        with:
+          command: mise tasks run application:build service_name=${{ matrix.service }}
+

--- a/.mise.toml
+++ b/.mise.toml
@@ -56,6 +56,19 @@ docker build \
 .
 """
 
+[tasks."application:build"]
+description = "Build and push the application service"
+run = """
+TIMESTAMP=$(date +%Y%m%d)
+docker build \
+    --file application/{{arg(name="service_name")}}/Dockerfile \
+    --tag pocketsizefund/{{arg(name="service_name")}}:latest \
+    --tag pocketsizefund/{{arg(name="service_name")}}:${TIMESTAMP} \
+    .
+docker push pocketsizefund/{{arg(name="service_name")}}:latest
+docker push pocketsizefund/{{arg(name="service_name")}}:${TIMESTAMP}
+"""
+
 [tasks."application:service:run"]
 description = "Run the application service"
 run = """


### PR DESCRIPTION
This pull request introduces a workflow for building and pushing Docker images for application services and defines a new task for managing Docker builds and pushes in the `.mise.toml` configuration file.

### CI/CD Workflow Updates:
* [`.github/workflows/docker.yaml`](diffhunk://#diff-17e3400d876978d12bbad517dcf82312b54fa62723408b1ce011b2755458bdafR1-R42): Added a GitHub Actions workflow to automate building and pushing Docker images for all application services. The workflow dynamically generates a matrix of services based on the `Dockerfile` locations and performs builds and pushes for each service.

### Docker Build Task:
* [`.mise.toml`](diffhunk://#diff-1bac9641068b68e6b60d0166663560d45b271c427fd863f8d56ed36964f99ee2R59-R71): Added a new task `application:build` to handle Docker image building and pushing. The task tags images with both `latest` and a timestamp, and pushes them to the `pocketsizefund` Docker Hub repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced automated workflow to build and push Docker images for application services on every push to the master branch.
  - Added a new task to streamline building and pushing Docker images for individual application services.

- **Chores**
  - Updated configuration to support automated Docker image management for improved deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->