### PR TITLE
Add Docker image build workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,51 @@
+---
+name: Build and push Docker images
+on:
+  push:
+    branches:
+      - master
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  generate_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Generate service matrix
+        id: generate
+        shell: bash
+        run: |
+          services=$(find application -name Dockerfile -exec dirname {} \; | sed 's|application/||')
+          matrix=$(echo "$services" | jq -R . | jq -s -c '[.[] | {service:.}]')
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+  build_and_push:
+    name: Build and push application images
+    needs: generate_matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.generate_matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set build timestamp
+        run: echo "TIMESTAMP=$(date +%Y%m%d)" >> $GITHUB_ENV
+      - name: Build and push service
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: application/${{ matrix.service }}/Dockerfile
+          push: true
+          tags: |
+            pocketsizefund/${{ matrix.service }}:latest
+            pocketsizefund/${{ matrix.service }}:${{ env.TIMESTAMP }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.mise.toml
+++ b/.mise.toml
@@ -65,6 +65,22 @@ docker run \
 pocketsizefund/{{arg(name="service_name")}}:latest \
 """
 
+[tasks."application:build"]
+description = "Build and push the application service image"
+run = """
+set -euxo pipefail
+TIMESTAMP=$(date +%Y%m%d)
+docker build \
+  --file application/{{arg(name="service_name")}}/Dockerfile \
+  --tag ${REGISTRY}/{{arg(name="service_name")}}:latest \
+  --tag ${REGISTRY}/{{arg(name="service_name")}}:${TIMESTAMP} \
+  .
+docker push ${REGISTRY}/{{arg(name="service_name")}}:latest
+docker push ${REGISTRY}/{{arg(name="service_name")}}:${TIMESTAMP}
+"""
+[args]
+registry = "pocketsizefund"
+
 
 [tasks."lint"]
 depends = ["python:lint"]


### PR DESCRIPTION
## Overview
- build all application images on push to `master`
- push each image to Docker Hub
- add `application:build` task for deploying images
- use Docker cache for faster builds

## Comments
- mise and pre-commit are not available in the environment, so checks could not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced automated workflow to build and push Docker images for all services on every push to the master branch.
  - Added a reusable task to build and push Docker images for individual application services, with configurable registry support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->