### PR TITLE
Fix YAML indentation in compose file

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile.test
     volumes:
-       - .:/tests
+      - .:/tests
     command:
       - /bin/sh
       - -euxc


### PR DESCRIPTION
## Summary
- fix volume mount indentation in compose.yaml

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*