### PR TITLE
Update datamanager backfill workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,13 @@ members = [
     "infrastructure",
     "application/datamanager",
     "application/positionmanager",
+    "workflows",
 ]
 
 [tool.uv.sources]
 datamanager = { workspace = true }
 positionmanager = { workspace = true }
+workflows = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["pocketsizefund"]

--- a/workflows/backfill_datamanager.py
+++ b/workflows/backfill_datamanager.py
@@ -1,0 +1,22 @@
+from datetime import date, timedelta
+from typing import List
+
+import httpx
+from flytekit import task, workflow
+
+
+@task(retries=3)
+def backfill_single_date(base_url: str, day: date) -> int:
+    response = httpx.get(f"{base_url}/equity-bars", params={"date": day.isoformat()})
+    response.raise_for_status()
+    return response.json().get("count", 0)
+
+
+@workflow
+def backfill_equity_bars(base_url: str, start_date: date, end_date: date) -> List[int]:
+    results: List[int] = []
+    current = start_date
+    while current <= end_date:
+        results.append(backfill_single_date(base_url=base_url, day=current))
+        current += timedelta(days=1)
+    return results

--- a/workflows/pyproject.toml
+++ b/workflows/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "workflows"
+version = "0.1.0"
+requires-python = ">=3.13"
+dependencies = [
+    "flytekit>=1.10.0",
+    "httpx>=0.28.1",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["workflows"]


### PR DESCRIPTION
## Summary
- call datamanager with GET instead of POST
- add retries to `backfill_single_date`
- iterate from start to end date inside the workflow

## Testing
- `ruff format workflows/backfill_datamanager.py`
- `ruff check workflows/backfill_datamanager.py`
- `ruff check .` *(fails: F401 etc.)*
- `vulture --min-confidence 80 --exclude '.flox,.venv,target' .` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*