### PR TITLE
Add infrastructure for new services

### DIFF
--- a/infrastructure/images.py
+++ b/infrastructure/images.py
@@ -42,4 +42,8 @@ for dockerfile in dockerfile_paths:
 
     pulumi.export(f"{service_name}-ref", images[service_name].ref)
 
+datamanager_image = images.get("datamanager")
+positionmanager_image = images.get("positionmanager")
+predictionengine_image = images.get("predictionengine")
+
 print(f"Available image services: {list(images.keys())}")

--- a/infrastructure/prometheus.yaml
+++ b/infrastructure/prometheus.yaml
@@ -8,3 +8,4 @@ scrape_configs:
       - targets:
           - datamanager
           - positionmanager
+          - predictionengine


### PR DESCRIPTION
## Summary
- build images for all services and expose variables
- deploy Cloud Run services for positionmanager and predictionengine
- monitor predictionengine in Prometheus

## Testing
- `ruff format infrastructure/cloud_run.py infrastructure/images.py`
- `ruff check infrastructure/cloud_run.py infrastructure/images.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683a701b8bd4832b9aace3a977805064