### PR TITLE
smoke test for datamanager

### DIFF
--- a/application/datamanager/src/datamanager/models.py
+++ b/application/datamanager/src/datamanager/models.py
@@ -1,4 +1,5 @@
 import datetime
+from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, Field, field_validator
 from pydantic_core import core_schema
@@ -6,7 +7,9 @@ from pydantic_core import core_schema
 
 class SummaryDate(BaseModel):
     date: datetime.date = Field(
-        default_factory=lambda: datetime.datetime.now(tz=datetime.UTC).date(),
+        default_factory=lambda: datetime.datetime.now(
+            ZoneInfo("America/New_York")
+        ).date(),
     )
 
     @field_validator("date", mode="before")
@@ -17,7 +20,7 @@ class SummaryDate(BaseModel):
             try:
                 return (
                     datetime.datetime.strptime(value, fmt)
-                    .replace(tzinfo=datetime.UTC)
+                    .replace(tzinfo=ZoneInfo("America/New_York"))
                     .date()
                 )
             except ValueError:

--- a/infrastructure/ping.nu
+++ b/infrastructure/ping.nu
@@ -9,6 +9,12 @@ let services = gcloud run services list --format=json
   }
 }
 
+services
+| each {|service| http get --full --headers $headers $"($service)/health" }
+
+
 let datamanager_url = ($services | where service == "datamanager" | get url.0)
 
-http get --full --headers $headers $"($datamanager_url)/health"
+{date: "2025-01-04"}
+| to json
+| http post --full --headers $headers $"($datamanager_url)/equity-bars" 


### PR DESCRIPTION
This pull request introduces changes to the `datamanager` service, focusing on timezone handling and adding a new HTTP request example in the infrastructure script. The most important changes include updating the default timezone for the `SummaryDate` model and adding a new HTTP POST example for the `/equity-bars` endpoint.

### Timezone Handling:
* [`application/datamanager/src/datamanager/models.py`](diffhunk://#diff-9ecf7ade73a62c23463e49d8137818d637c8924f8d41f0b0120e159f6d207f14R2-R13): Changed the default timezone for the `SummaryDate` model from UTC to `America/New_York` using the `ZoneInfo` module. This ensures that default dates are generated in the specified timezone.

### Infrastructure Script Enhancements:
* [`infrastructure/ping.nu`](diffhunk://#diff-2d2aa000a96987f0577a9bfaec6162128b01a5b05e455235ad75c4b6c235d5fcR15-R21): Added a new HTTP POST example to send JSON data to the `/equity-bars` endpoint of the `datamanager` service. This example demonstrates how to use the `http post` command with headers and a sample payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted date handling to use the "America/New_York" timezone when generating current dates, ensuring consistency with local time.

- **Chores**
  - Enhanced internal scripts to send test data with a fixed date to the relevant service endpoint for improved monitoring and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->