### PR TITLE
Add memory configuration for datamanager service

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -28,6 +28,7 @@ datamanager_service = create_service(
         DUCKDB_SECRET,
         POLYGON_API_KEY,
     ],
+    memory="32Gi",
 )
 
 DATAMANAGER_BASE_URL = create_environment_variable(

--- a/infrastructure/services.py
+++ b/infrastructure/services.py
@@ -11,6 +11,7 @@ from pulumi_gcp.cloudrun import (
     ServiceTemplateArgs,
     ServiceTemplateSpecArgs,
     ServiceTemplateSpecContainerArgs,
+    ServiceTemplateSpecContainerResourcesArgs,
     ServiceTemplateSpecContainerStartupProbeArgs,
     ServiceTemplateSpecContainerStartupProbeHttpGetArgs,
 )
@@ -19,7 +20,9 @@ config = Config()
 
 
 def create_service(
-    name: str, envs: list[ENVIRONMENT_VARIABLE] | None = None
+    name: str,
+    envs: list[ENVIRONMENT_VARIABLE] | None = None,
+    memory: str | None = None,
 ) -> Service:
     if envs is None:
         envs = []
@@ -67,6 +70,11 @@ def create_service(
                     ServiceTemplateSpecContainerArgs(
                         image=f"pocketsizefund/{name}:{version}",
                         envs=envs,
+                        resources=ServiceTemplateSpecContainerResourcesArgs(
+                            limits={"memory": memory}
+                        )
+                        if memory
+                        else None,
                         startup_probe=ServiceTemplateSpecContainerStartupProbeArgs(
                             initial_delay_seconds=60,
                             period_seconds=60,


### PR DESCRIPTION
## Summary
- allow custom memory limit when creating Cloud Run services
- configure datamanager service to use 32Gi memory

## Testing
- `mise run python:install` *(fails: command not found)*
- `mise run python:format` *(fails: command not found)*
- `mise run python:lint` *(fails: command not found)*
- `mise run python:test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485b488510832bae330c5d53ba51ea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to specify memory allocation for services.
  - Set the memory limit for the datamanager service to 32Gi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->