### PR TITLE
Gate deployment triggers by market hours

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,6 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     environment: pulumi
     steps:
+      - name: Check market hours
+        run: |
+          current_time=$(TZ='America/New_York' date '+%H%M')
+          current_day=$(TZ='America/New_York' date '+%u')  # 1=Monday, 7=Sunday
+          
+          if [ "$current_day" -gt 5 ]; then
+            echo "Deployment blocked - allowed on weekdays (Monday-Friday)"
+            exit 1
+          fi
+          
+          if [ "$current_time" -lt 930 ] || [ "$current_time" -ge 1600 ]; then
+            echo "Deployments blocked - allowed during market hours: 9:30 AM - 4:00 PM EST"
+            exit 1
+          fi
+          
+          echo "Deployment permitted - within market hours"
+          echo "Current time: $(TZ='America/New_York' date '+%I:%M %p %Z')"
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Flox


### PR DESCRIPTION
# Overview

## Changes

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

- add rough gate around market hours (does not account for holidays)

## Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
-->

No idea if this actually works so we'll have to see.