### PR TITLE
Expand initial Grafana metrics resources and upload script

### DIFF
--- a/application/positionmanager/src/positionmanager/main.py
+++ b/application/positionmanager/src/positionmanager/main.py
@@ -7,6 +7,7 @@ import polars as pl
 import requests
 from alpaca.common.exceptions import APIError
 from fastapi import FastAPI, HTTPException
+from prometheus_client import Gauge
 from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import ValidationError
 
@@ -20,10 +21,89 @@ trading_days_per_year = 252
 application = FastAPI()
 Instrumentator().instrument(application).expose(application)
 
+portfolio_value_gauge = Gauge(
+    "portfolio_total_value",
+    "Current total portfolio value from Alpaca",
+)
+
+portfolio_cash_balance_gauge = Gauge(
+    "portfolio_cash_balance",
+    "Current cash balance in portfolio",
+)
+
+portfolio_positions_count_gauge = Gauge(
+    "portfolio_positions_count",
+    "Number of current positions in portfolio",
+)
+
+portfolio_position_value_gauge = Gauge(
+    "portfolio_position_value",
+    "Value of specific position",
+    ["symbol"],
+)
+
+portfolio_position_profit_and_loss_gauge = Gauge(
+    "portfolio_position_profit_and_loss",
+    "Unrealized P&L for specific position",
+    ["symbol"],
+)
+
 
 @application.get("/health")
 def get_health() -> dict[str, str]:
     return {"status": "healthy"}
+
+
+@application.get("/metrics")
+def update_metrics() -> dict[str, Any]:
+    alpaca_client = AlpacaClient(
+        api_key=os.getenv("ALPACA_API_KEY", ""),
+        api_secret=os.getenv("ALPACA_API_SECRET", ""),
+        paper=os.getenv("ALPACA_PAPER", "true").lower() == "true",
+    )
+
+    try:
+        account_information = alpaca_client.get_account_information()
+        positions = alpaca_client.get_positions()
+
+        portfolio_value_gauge.set(account_information["portfolio_value"])
+        portfolio_cash_balance_gauge.set(account_information["cash"])
+        portfolio_positions_count_gauge.set(len(positions))
+
+        position_metrics = []
+        for position in positions:
+            symbol = position["symbol"]
+            portfolio_position_value_gauge.labels(symbol=symbol).set(
+                position["market_value"]
+            )
+            portfolio_position_profit_and_loss_gauge.labels(symbol=symbol).set(
+                position["unrealized_profit_and_loss"]
+            )
+
+            position_metrics.append(
+                {
+                    "symbol": symbol,
+                    "market_value": position["market_value"],
+                    "unrealized_profit_and_loss": position[
+                        "unrealized_profit_and_loss"
+                    ],
+                    "cost_basis": position["cost_basis"],
+                    "current_price": position["current_price"],
+                }
+            )
+
+        return {
+            "portfolio_value": account_information["portfolio_value"],
+            "cash_balance": account_information["cash"],
+            "positions_count": len(positions),
+            "positions": position_metrics,
+        }
+
+    except (requests.RequestException, APIError, ValidationError) as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error updating metrics: {e!r}",
+        ) from e
 
 
 @application.post("/positions")

--- a/application/predictionengine/src/predictionengine/dataset.py
+++ b/application/predictionengine/src/predictionengine/dataset.py
@@ -208,7 +208,8 @@ class DataSet:
                 )
 
             targets = batch_data[: self.batch_size, close_price_idx].reshape(
-                self.batch_size, 1
+                self.batch_size,
+                1,
             )
 
             yield tickers, historical_features, targets

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -72,3 +72,13 @@ datamanager_job = cloudscheduler.Job(
 
 
 export("DATAMANAGER_BASE_URL", datamanager_service.statuses[0].url)
+
+export(
+    "DATAMANAGER_METRICS_URL",
+    datamanager_service.statuses[0].url.apply(lambda url: f"{url}/metrics"),
+)
+
+export(
+    "POSITIONMANAGER_METRICS_URL",
+    positionmanager_service.statuses[0].url.apply(lambda url: f"{url}/metrics"),
+)

--- a/infrastructure/grafana_dashboard.json
+++ b/infrastructure/grafana_dashboard.json
@@ -1,0 +1,270 @@
+{
+  "dashboard": {
+    "id": null,
+    "title": "Pocket Size Fund Metrics",
+    "tags": ["pocketsizefund", "open-source", "quantitative", "hedge-fund"],
+    "timezone": "browser",
+    "panels": [
+      {
+        "id": 1,
+        "title": "Equity Bars Data Volume",
+        "type": "stat",
+        "targets": [
+          {
+            "expr": "equity_bars_total_rows",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "decimals": 0
+          }
+        },
+        "options": {
+          "colorMode": "background",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto"
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 0,
+          "y": 0
+        }
+      },
+      {
+        "id": 2,
+        "title": "Portfolio Total Value",
+        "type": "stat",
+        "targets": [
+          {
+            "expr": "portfolio_total_value",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "currencyUSD",
+            "decimals": 2
+          }
+        },
+        "options": {
+          "colorMode": "background",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto"
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 6,
+          "y": 0
+        }
+      },
+      {
+        "id": 3,
+        "title": "Cash Balance",
+        "type": "stat",
+        "targets": [
+          {
+            "expr": "portfolio_cash_balance",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "currencyUSD",
+            "decimals": 2
+          }
+        },
+        "options": {
+          "colorMode": "background",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto"
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 12,
+          "y": 0
+        }
+      },
+      {
+        "id": 4,
+        "title": "Number of Positions",
+        "type": "stat",
+        "targets": [
+          {
+            "expr": "portfolio_positions_count",
+            "refId": "A"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "decimals": 0
+          }
+        },
+        "options": {
+          "colorMode": "background",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto"
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 6,
+          "x": 18,
+          "y": 0
+        }
+      },
+      {
+        "id": 5,
+        "title": "Portfolio Value Over Time",
+        "type": "timeseries",
+        "targets": [
+          {
+            "expr": "portfolio_total_value",
+            "refId": "A",
+            "legendFormat": "Total Portfolio Value"
+          },
+          {
+            "expr": "portfolio_cash_balance",
+            "refId": "B",
+            "legendFormat": "Cash Balance"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "currencyUSD",
+            "decimals": 2
+          }
+        },
+        "options": {
+          "legend": {
+            "displayMode": "visible",
+            "placement": "bottom"
+          }
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        }
+      },
+      {
+        "id": 6,
+        "title": "Position Values by Symbol",
+        "type": "barchart",
+        "targets": [
+          {
+            "expr": "portfolio_position_value",
+            "refId": "A",
+            "legendFormat": "{{symbol}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "currencyUSD",
+            "decimals": 2
+          }
+        },
+        "options": {
+          "legend": {
+            "displayMode": "visible",
+            "placement": "right"
+          }
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        }
+      },
+      {
+        "id": 7,
+        "title": "Position Profit and Loss by Symbol",
+        "type": "barchart",
+        "targets": [
+          {
+            "expr": "portfolio_position_profit_and_loss",
+            "refId": "A",
+            "legendFormat": "{{symbol}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "currencyUSD",
+            "decimals": 2,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "green",
+                  "value": 0
+                }
+              ]
+            }
+          }
+        },
+        "options": {
+          "legend": {
+            "displayMode": "visible",
+            "placement": "right"
+          }
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 17
+        }
+      },
+      {
+        "id": 8,
+        "title": "Data Volume Trend",
+        "type": "timeseries",
+        "targets": [
+          {
+            "expr": "equity_bars_total_rows",
+            "refId": "A",
+            "legendFormat": "Total Rows"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "decimals": 0
+          }
+        },
+        "options": {
+          "legend": {
+            "displayMode": "visible",
+            "placement": "bottom"
+          }
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 17
+        }
+      }
+    ],
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "refresh": "5m"
+  },
+  "overwrite": true
+}

--- a/infrastructure/upload_grafana_dashboard.nu
+++ b/infrastructure/upload_grafana_dashboard.nu
@@ -1,0 +1,48 @@
+#!/usr/bin/env nu
+
+# upload Grafana dashboard to Grafana Cloud
+# Usage: nu upload_grafana_dashboard.nu
+
+let grafana_url = $env.GRAFANA_CLOUD_URL? | default ""
+let grafana_api_key = $env.GRAFANA_API_KEY? | default ""
+
+if ($grafana_api_key | is-empty) {
+    print "GRAFANA_API_KEY environment variable is required"
+    exit 1
+}
+
+if ($grafana_url == "") {
+    print "GRAFANA_CLOUD_URL environment variable is required"
+    exit 1
+}
+
+let dashboard_file = "grafana_dashboard.json"
+
+if not ($dashboard_file | path exists) {
+    print $"dashboard file '($dashboard_file)' not found"
+    exit 1
+}
+
+let dashboard_content = open $dashboard_file | from json
+
+let upload_payload = {
+    dashboard: $dashboard_content.dashboard
+    overwrite: true
+    message: "uploaded via Nu script"
+}
+
+let headers = [
+    "Authorization" $"Bearer ($grafana_api_key)"
+    "Content-Type" "application/json"
+]
+
+try {
+    let response = $upload_payload 
+    | to json 
+    | http post --headers $headers $"($grafana_url)/api/dashboards/db"
+    
+    print "dashboard uploaded successfully!"
+    
+} catch { |error|
+    print $"failed to upload dashboard: ($error)"
+}


### PR DESCRIPTION
# Overview

## Changes

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

- add initial Grafana dashboard JSON definition
- add `/metrics` handlers for overloading scraping invocations to get application data
- Nu uploader script for Grafana dashboard definition

## Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
-->

I _think_ this might work since it basically just adds in additional data to be collected for Grafana under the initial scraping configuration. I imagine we can adjust the frequency of scrapes in order to keep costs low. Also, these are just initial stabs at additional data to include and I'm open to changing them (e.g. rows of data).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Prometheus metrics endpoints to monitor equity bars data and portfolio statistics.
  - Introduced a Grafana dashboard for visualizing key hedge fund metrics, including portfolio value, cash balance, positions, and profit/loss.
  - Provided a script for uploading the Grafana dashboard to Grafana Cloud.
- **Improvements**
  - Enhanced access to account and position data from the Alpaca API.
- **Chores**
  - Exported new environment variables for metrics endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->