### PR TITLE
Update DuckDB connection with S3 credentials

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -6,8 +6,9 @@ from cluster import (
     create_kubernetes_provider,
     update_kubernetes_cluster_access,
 )
-from environment_variables import environment_variables
+from environment_variables import create_environment_variables
 from images import build_image
+from keys import create_duckdb_user_access_key
 from monitors import create_prometheus_scraper
 from publishers_subscribers import (
     create_knative_broker,
@@ -64,6 +65,10 @@ datamanager_image = build_image(
     service_version=version,
 )
 
+
+duckdb_user_access_key = create_duckdb_user_access_key()
+
+environment_variables = create_environment_variables(duckdb_user_access_key)
 
 datamanager_service = create_knative_service(
     kubernetes_provider=kubernetes_provider,

--- a/infrastructure/environment_variables.py
+++ b/infrastructure/environment_variables.py
@@ -1,4 +1,5 @@
 import pulumi
+import pulumi_aws as aws
 from pulumi.config import Config
 
 configuration = Config()
@@ -10,14 +11,22 @@ data_bucket_name = configuration.require_secret("DATA_BUCKET_NAME")
 polygon_api_key = configuration.require_secret("POLYGON_API_KEY")
 duckdb_access_key = configuration.require_secret("DUCKDB_ACCESS_KEY")
 duckdb_secret = configuration.require_secret("DUCKDB_SECRET")
+aws_region = configuration.get("aws:region") or "us-east-1"
 
-environment_variables = pulumi.Output.all(
-    [
-        ("ALPACA_API_KEY", alpaca_api_key),
-        ("ALPACA_API_SECRET", alpaca_api_secret),
-        ("DATA_BUCKET_NAME", data_bucket_name),
-        ("POLYGON_API_KEY", polygon_api_key),
-        ("DUCKDB_ACCESS_KEY", duckdb_access_key),
-        ("DUCKDB_SECRET", duckdb_secret),
-    ]
-).apply(lambda secrets: dict(secrets))
+
+def create_environment_variables(
+    duckdb_user_access_key: aws.iam.AccessKey,
+) -> pulumi.Output[dict[str, str]]:
+    return pulumi.Output.all(
+        [
+            ("ALPACA_API_KEY", alpaca_api_key),
+            ("ALPACA_API_SECRET", alpaca_api_secret),
+            ("DATA_BUCKET_NAME", data_bucket_name),
+            ("POLYGON_API_KEY", polygon_api_key),
+            ("DUCKDB_ACCESS_KEY", duckdb_access_key),
+            ("DUCKDB_SECRET", duckdb_secret),
+            ("AWS_REGION", aws_region),
+            ("DUCKDB_USER_ACCESS_KEY_ID", duckdb_user_access_key.id),
+            ("DUCKDB_USER_ACCESS_KEY_SECRET", duckdb_user_access_key.secret),
+        ]
+    ).apply(lambda secrets: dict(secrets))

--- a/infrastructure/keys.py
+++ b/infrastructure/keys.py
@@ -1,0 +1,52 @@
+import json
+
+import pulumi_aws as aws
+from environment_variables import data_bucket_name
+from tags import common_tags
+
+
+def create_duckdb_user_access_key() -> aws.iam.AccessKey:
+    duckdb_user = aws.iam.User(
+        resource_name="pocketsizefund-duckdb-user",
+        name="pocketsizefund-duckdb-user",
+        tags=common_tags,
+    )
+
+    duckdb_policy = aws.iam.Policy(
+        resource_name="pocketsizefund-duckdb-policy",
+        name="pocketsizefund-duckdb-policy",
+        description="Policy for DuckDB access",
+        policy=json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:GetObject",
+                            "s3:ListBucket",
+                            "s3:PutObject",
+                            "s3:DeleteObject",
+                        ],
+                        "Resource": [
+                            f"arn:aws:s3:::{data_bucket_name}/*",
+                            f"arn:aws:s3:::{data_bucket_name}",
+                        ],
+                    }
+                ],
+            }
+        ),
+        tags=common_tags,
+    )
+
+    aws.iam.UserPolicyAttachment(
+        resource_name="pocketsizefund-duckdb-user-policy",
+        user=duckdb_user.name,
+        policy_arn=duckdb_policy.arn,
+    )
+
+    return aws.iam.AccessKey(
+        resource_name="pocketsizefund-duckdb-user-access-key",
+        user=duckdb_user.name,
+        status="Active",
+    )


### PR DESCRIPTION
# Overview

## Changes

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

- add IAM user/keys for DuckDB in `infrastructure`
- pass IAM key into `datamanager` environment variables
- update DuckDB connection configuration with new values

## Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
-->

I think there are alternative ways of connecting (e.g. `credential_chain`) that might does stuff directly with the AWS SDK that's cleaner but this should work too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migrated storage integration from Google Cloud Storage (GCS) to Amazon S3 for equity bars data and metrics.
  * Updated environment variable handling to use AWS S3 credentials and region configuration.
  * Automated provisioning of AWS IAM user, policy, and access key for secure S3 access.

* **Chores**
  * Refactored infrastructure code to support dynamic AWS credential management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->