### PR TITLE
add secrets to cluster

### DIFF
--- a/infrastructure/stack.yml
+++ b/infrastructure/stack.yml
@@ -19,8 +19,29 @@ configs:
     name: prometheus.yml
     file: ./prometheus.yml
 
+secrets:
+  ALPACA_API_KEY:
+    external: true
+  ALPACA_API_SECRET:
+    external: true
+  ALPACA_BASE_URL:
+    external: true
+  EDGAR_USER_AGENT:
+    external: true
+  DATA_BUCKET:
+    external: true
+  POLYGON_API_KEY:
+    external: true
+  DUCKDB_ACCESS_KEY:
+    external: true
+  DUCKDB_SECRET:
+    external: true
+  GRAFANA_ADMIN_PASSWORD:
+    external: true
+  WEIGHTS_AND_BIASES_API_KEY:
+    external: true
+
 services:
-  # Network Services
   traefik:
     image: traefik:v3.1
     command:


### PR DESCRIPTION
# Overview

Added external secrets configuration to the Docker Compose stack file for secure credential management.

## Changes

- Added `secrets` section with external secrets for:
    - Alpaca API credentials (key, secret, base URL)
    - Edgar user agent
    - Data bucket configuration
    - Polygon API key
    - DuckDB credentials (access key, secret)
    - Grafana admin password
    - Weights and Biases API key
- Removed unnecessary comment in services section

## Comments

These external secrets will be used by various services in the stack to securely access APIs and data sources without hardcoding credentials in the configuration files.