### PR TITLE
Add conditional GitHub workflow trigger based on file type

### DIFF
--- a/.github/workflows/check_code_quality.yaml
+++ b/.github/workflows/check_code_quality.yaml
@@ -2,11 +2,18 @@
 name: Code quality check
 on:
   push:
+    paths:
+      - '**/*.rs'
+      - '**/*.py'
   pull_request:
+    paths:
+      - '**/*.rs'
+      - '**/*.py'
 jobs:
   run_python_quality_checks:
     name: Run Python quality checks
     runs-on: ubuntu-latest
+    if: contains(github.event.commits.*.added, '*.py') || contains(github.event.commits.*.modified, '*.py') || contains(github.event.pull_request.files.*.filename, '*.py')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -19,6 +26,7 @@ jobs:
   run_rust_quality_checks:
     name: Run Rust quality checks
     runs-on: ubuntu-latest
+    if: contains(github.event.commits.*.added, '*.rs') || contains(github.event.commits.*.modified, '*.rs') || contains(github.event.pull_request.files.*.filename, '*.rs')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -2,11 +2,18 @@
 name: Test and coverage check
 on:
   push:
+    paths:
+      - '**/*.rs'
+      - '**/*.py'
   pull_request:
+    paths:
+      - '**/*.rs'
+      - '**/*.py'
 jobs:
   run_python_tests_and_coverage:
     name: Run Python tests
     runs-on: ubuntu-latest
+    if: contains(github.event.commits.*.added, '*.py') || contains(github.event.commits.*.modified, '*.py') || contains(github.event.pull_request.files.*.filename, '*.py')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -20,10 +27,11 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: coverage_output/.python_coverage.xml
+          path-to-lcov: coverage_output/.python_cov<D-s>erage.xml
   run_rust_tests_and_coverage:
     name: Run Rust tests
     runs-on: ubuntu-latest
+    if: contains(github.event.commits.*.added, '*.rs') || contains(github.event.commits.*.modified, '*.rs') || contains(github.event.pull_request.files.*.filename, '*.rs')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
# Overview

## Changes

- add `path` keys to workflow trigger
- add `if` check to language-specific jobs

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

## Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
-->

The more proper way to do this would be to build separate files based on language but we can do that later potentially.