### PR TITLE
Add environment variables required by "download artifacts" script

### DIFF
--- a/.github/workflows/launch_infrastructure.yaml
+++ b/.github/workflows/launch_infrastructure.yaml
@@ -37,7 +37,6 @@ jobs:
         if: ${{ matrix.service == 'equitypricemodel' }}
         uses: flox/activate-action@v1
         env:
-          AWS_IAM_DEVELOPMENT_ROLE_ARN: ${{ secrets.AWS_IAM_DEVELOPMENT_ROLE_ARN }}
           AWS_S3_ARTIFACTS_BUCKET_NAME: ${{ secrets.AWS_S3_ARTIFACTS_BUCKET_NAME }}
         with:
           command: mask models artifacts download equitypricemodel

--- a/tools/run_training_job.py
+++ b/tools/run_training_job.py
@@ -10,30 +10,17 @@ from sagemaker.session import Session
 logger = structlog.get_logger()
 
 
-def run_training_job(  # noqa: PLR0913
+def run_training_job(
     application_name: str,
     trainer_image_uri: str,
     s3_data_path: str,
     iam_sagemaker_role_arn: str,
     s3_artifact_path: str,
-    iam_development_role_arn: str,
 ) -> None:
     logger.info("Starting training job", application_name=application_name)
 
     try:
-        sts = boto3.client("sts")
-        assume_role_response = sts.assume_role(
-            RoleArn=iam_development_role_arn,
-            RoleSessionName="sagemaker-training-job-session",
-        )
-        credentials = assume_role_response["Credentials"]
-
-        session = boto3.Session(
-            aws_access_key_id=credentials["AccessKeyId"],
-            aws_secret_access_key=credentials["SecretAccessKey"],
-            aws_session_token=credentials["SessionToken"],
-        )
-
+        session = boto3.Session()
         sagemaker_session = Session(boto_session=session)
 
     except Exception as e:
@@ -76,7 +63,6 @@ if __name__ == "__main__":
     s3_data_path = os.getenv("AWS_S3_EQUITY_PRICE_MODEL_TRAINING_DATA_PATH", "")
     iam_sagemaker_role_arn = os.getenv("AWS_IAM_SAGEMAKER_ROLE_ARN", "")
     s3_artifact_path = os.getenv("AWS_S3_EQUITY_PRICE_MODEL_ARTIFACT_OUTPUT_PATH", "")
-    iam_development_role_arn = os.getenv("AWS_IAM_DEVELOPMENT_ROLE_ARN", "")
 
     environment_variables = {
         "APPLICATION_NAME": application_name,
@@ -84,7 +70,6 @@ if __name__ == "__main__":
         "AWS_S3_EQUITY_PRICE_MODEL_TRAINING_DATA_PATH": s3_data_path,
         "AWS_IAM_SAGEMAKER_ROLE_ARN": iam_sagemaker_role_arn,
         "AWS_S3_EQUITY_PRICE_MODEL_ARTIFACT_OUTPUT_PATH": s3_artifact_path,
-        "AWS_IAM_DEVELOPMENT_ROLE_ARN": iam_development_role_arn,
     }
 
     missing_environment_variables = [
@@ -105,7 +90,6 @@ if __name__ == "__main__":
             s3_data_path=s3_data_path,
             iam_sagemaker_role_arn=iam_sagemaker_role_arn,
             s3_artifact_path=s3_artifact_path,
-            iam_development_role_arn=iam_development_role_arn,
         )
 
     except Exception as e:


### PR DESCRIPTION
# Overview

## Changes

- add workflow environment variables required by "download artifacts" script

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

## Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
-->

I'm just doing a straight duplication of what's local even though the environment variable/role name aren't exactly accurate ("development") but we can update that later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to source AWS S3 artifacts bucket name from environment secrets, enabling flexible deployment management.

* **Refactor**
  * Simplified AWS credential handling across artifact download and model training workflows by removing role assumption logic and adopting default credential chains for streamlined operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->