### PR TITLE
Remove unused Pulumi environment

### DIFF
--- a/infrastructure/Pulumi.production.yaml
+++ b/infrastructure/Pulumi.production.yaml
@@ -1,2 +1,0 @@
-environment:
-  - pocketsizefund/production


### PR DESCRIPTION
# Overview

## Changes

- remove Pulumi environment reference from stack configuration file

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

## Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
-->

This is in favor of using the AWS credentials GitHub Action directly. That should be what Pulumi uses when executing the infrastructure commands. In the future, we might move it back into Pulumi environments but this is fine for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production environment configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->