### PR TITLE
Remove non-ECR tag on "build image" Mask command

### DIFF
--- a/maskfile.md
+++ b/maskfile.md
@@ -67,7 +67,6 @@ docker build \
     --platform linux/amd64 \
     --target ${stage_name} \
     --file applications/${application_name}/Dockerfile \
-    --tag pocketsizefund/${application_name}-${stage_name}:latest \
     --tag ${aws_account_id}.dkr.ecr.us-east-1.amazonaws.com/pocketsizefund/${application_name}-${stage_name}:latest \
     .
 


### PR DESCRIPTION
# Overview

## Changes

- remove non-ECR tag from "build image" Mask command

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
-->

## Comments

<!-- 
Provide additional information as needed.
Delete header if it isn't used.
-->

This seems to be causing an issue in the GitHub Actions workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to optimize container image tagging, removing redundant local tags while maintaining remote registry functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->