### PR TITLE
Add training data tagging/inference data logging

### DIFF
--- a/applications/ensemble_manager/src/ensemble_manager/server.py
+++ b/applications/ensemble_manager/src/ensemble_manager/server.py
@@ -436,6 +436,8 @@ def parse_responses(
 ) -> pl.DataFrame:
     equity_bars_data = pl.read_parquet(io.BytesIO(equity_bars_response.content))
 
+    fetched_tickers = equity_bars_data["ticker"].n_unique()
+
     equity_bars_data = equity_bars_data.unique(
         subset=["ticker", "timestamp"],
         keep="last",
@@ -458,6 +460,8 @@ def parse_responses(
 
     equity_bars_data = filter_equity_bars(equity_bars_data)
 
+    filtered_tickers = equity_bars_data["ticker"].n_unique()
+
     equity_details_data = pl.read_csv(io.BytesIO(equity_details_response.content))
 
     equity_details_validated = equity_details_schema.validate(equity_details_data)
@@ -470,6 +474,15 @@ def parse_responses(
 
     consolidated_data = equity_details_data.join(
         equity_bars_data, on="ticker", how="inner"
+    )
+
+    consolidated_tickers = consolidated_data["ticker"].n_unique()
+
+    logger.info(
+        "Inference data consolidated",
+        fetched_tickers=fetched_tickers,
+        filtered_tickers=filtered_tickers,
+        consolidated_tickers=consolidated_tickers,
     )
 
     retained_columns = (

--- a/models/tide/src/tide/tasks.py
+++ b/models/tide/src/tide/tasks.py
@@ -222,7 +222,7 @@ def prepare_training_data(  # noqa: PLR0913
     end_date: datetime,
     output_key: str = "training/filtered_tide_training_data.parquet",
     s3_client: "S3Client | None" = None,
-) -> str:
+) -> tuple[str, dict]:
     """Main function to prepare training data."""
     logger.info(
         "Preparing training data",
@@ -242,6 +242,9 @@ def prepare_training_data(  # noqa: PLR0913
         end_date=end_date,
     )
 
+    raw_rows = equity_bars.height
+    raw_tickers = equity_bars["ticker"].n_unique()
+
     categories = read_categories_from_s3(
         s3_client=s3_client,
         bucket_name=data_bucket_name,
@@ -251,14 +254,31 @@ def prepare_training_data(  # noqa: PLR0913
 
     equity_bars_schema.validate(filtered_bars)
 
+    filtered_rows = filtered_bars.height
+    filtered_tickers = filtered_bars["ticker"].n_unique()
+
     consolidated = consolidate_data(
         equity_bars=filtered_bars,
         categories=categories,
     )
 
-    return write_training_data_to_s3(
+    consolidated_rows = consolidated.height
+    consolidated_tickers = consolidated["ticker"].n_unique()
+
+    stage_counts = {
+        "raw_rows": raw_rows,
+        "raw_tickers": raw_tickers,
+        "filtered_rows": filtered_rows,
+        "filtered_tickers": filtered_tickers,
+        "consolidated_rows": consolidated_rows,
+        "consolidated_tickers": consolidated_tickers,
+    }
+
+    uri = write_training_data_to_s3(
         s3_client=s3_client,
         bucket_name=model_artifacts_bucket_name,
         data=consolidated,
         output_key=output_key,
     )
+
+    return uri, stage_counts

--- a/models/tide/src/tide/tasks.py
+++ b/models/tide/src/tide/tasks.py
@@ -222,7 +222,7 @@ def prepare_training_data(  # noqa: PLR0913
     end_date: datetime,
     output_key: str = "training/filtered_tide_training_data.parquet",
     s3_client: "S3Client | None" = None,
-) -> tuple[str, dict]:
+) -> tuple[str, dict[str, int]]:
     """Main function to prepare training data."""
     logger.info(
         "Preparing training data",

--- a/models/tide/src/tide/workflow.py
+++ b/models/tide/src/tide/workflow.py
@@ -6,7 +6,7 @@ import tarfile
 import tempfile
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 # Required for Prefect's ECS managed runner: after git-cloning the repo,
 # models/tide/src/ is not on sys.path, so tide.* imports would fail.
@@ -45,7 +45,7 @@ def prepare_data(
     start_date: datetime,
     end_date: datetime,
     artifact_timestamp: str,
-) -> tuple[str, dict]:
+) -> tuple[str, dict[str, int]]:
     """Read equity bars + categories from S3, filter, write consolidated parquet."""
     try:
         data_block = cast("S3Bucket", S3Bucket.load(DATA_BLOCK_NAME))
@@ -94,7 +94,7 @@ def prepare_data(
 @task(name="train-tide-model", timeout_seconds=14400)
 def train_tide_model(
     training_data_key: str,
-    training_summary: dict,
+    training_summary: dict[str, Any],
     artifact_timestamp: str,
 ) -> str:
     """Download training data from S3, train model, upload artifact to S3."""

--- a/models/tide/src/tide/workflow.py
+++ b/models/tide/src/tide/workflow.py
@@ -1,4 +1,5 @@
 import io
+import json
 import os
 import sys
 import tarfile
@@ -19,7 +20,11 @@ from prefect import flow, task  # noqa: E402
 from prefect_aws.s3 import S3Bucket  # noqa: E402
 
 from tide.notifications import send_training_notification  # noqa: E402
-from tide.tasks import prepare_training_data  # noqa: E402
+from tide.tasks import (  # noqa: E402
+    MINIMUM_CLOSE_PRICE,
+    MINIMUM_VOLUME,
+    prepare_training_data,
+)
 from tide.tracking import end_run, log_model_artifact, start_run  # noqa: E402
 
 logger = structlog.get_logger()
@@ -39,8 +44,8 @@ def get_training_date_range(lookback_days: int) -> tuple[datetime, datetime]:
 def prepare_data(
     start_date: datetime,
     end_date: datetime,
-    output_key: str = "training/filtered_tide_training_data.parquet",
-) -> str:
+    artifact_timestamp: str,
+) -> tuple[str, dict]:
     """Read equity bars + categories from S3, filter, write consolidated parquet."""
     try:
         data_block = cast("S3Bucket", S3Bucket.load(DATA_BLOCK_NAME))
@@ -54,15 +59,18 @@ def prepare_data(
         raise ValueError(message) from err
     s3_client = data_block.credentials.get_boto3_session().client("s3")
 
+    output_key = f"data/tide/{artifact_timestamp}/filtered_data.parquet"
+
     logger.info(
         "Preparing training data",
         data_bucket=data_block.bucket_name,
         artifacts_bucket=artifact_block.bucket_name,
         start_date=start_date.isoformat(),
         end_date=end_date.isoformat(),
+        output_key=output_key,
     )
 
-    training_data_uri = prepare_training_data(
+    training_data_uri, stage_counts = prepare_training_data(
         s3_client=s3_client,
         data_bucket_name=data_block.bucket_name,
         model_artifacts_bucket_name=artifact_block.bucket_name,
@@ -73,19 +81,21 @@ def prepare_data(
 
     bucket_prefix = f"s3://{artifact_block.bucket_name}/"
     if training_data_uri.startswith(bucket_prefix):
-        return training_data_uri.removeprefix(bucket_prefix)
+        return training_data_uri.removeprefix(bucket_prefix), stage_counts
 
     logger.warning(
         "Prepared training data URI did not match expected bucket",
         expected_bucket=artifact_block.bucket_name,
         training_data_uri=training_data_uri,
     )
-    return output_key
+    return output_key, stage_counts
 
 
 @task(name="train-tide-model", timeout_seconds=14400)
 def train_tide_model(
-    training_data_key: str = "training/filtered_tide_training_data.parquet",
+    training_data_key: str,
+    training_summary: dict,
+    artifact_timestamp: str,
 ) -> str:
     """Download training data from S3, train model, upload artifact to S3."""
     from tide.trainer import DEFAULT_CONFIGURATION, train_model  # noqa: PLC0415
@@ -132,9 +142,9 @@ def train_tide_model(
                 checkpoint_directory=checkpoint_directory,
             )
 
-        timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%d-%H-%M-%S-%f")[:-3]
-        artifact_folder = f"artifacts/tide/{timestamp}"
+        artifact_folder = f"artifacts/tide/{artifact_timestamp}"
         artifact_key = f"{artifact_folder}/output/model.tar.gz"
+        metadata_key = f"{artifact_folder}/run_metadata.json"
 
         with tempfile.TemporaryDirectory() as tmpdir:
             tide_model.save(directory_path=tmpdir)
@@ -167,6 +177,19 @@ def train_tide_model(
             artifact_path=f"s3://{artifacts_bucket}/{artifact_key}",
         )
 
+        metadata_bytes = json.dumps(training_summary, indent=2).encode()
+        s3_client.put_object(
+            Bucket=artifacts_bucket,
+            Key=metadata_key,
+            Body=metadata_bytes,
+            ContentType="application/json",
+        )
+
+        logger.info(
+            "Run metadata uploaded",
+            artifact_path=f"s3://{artifacts_bucket}/{metadata_key}",
+        )
+
         end_run()
     except Exception:
         end_run(status="FAILED")
@@ -189,15 +212,25 @@ def training_pipeline(
         message = "lookback_days must be positive"
         raise ValueError(message)
 
-    training_data_key = "training/filtered_tide_training_data.parquet"
+    artifact_timestamp = datetime.now(tz=UTC).strftime("%Y-%m-%d-%H-%M-%S-%f")[:-3]
     start_date, end_date = get_training_date_range(lookback_days)
 
-    prepared_key = prepare_data(
-        start_date,
-        end_date,
-        training_data_key,
-    )
-    return train_tide_model(prepared_key)
+    training_key, stage_counts = prepare_data(start_date, end_date, artifact_timestamp)
+
+    training_summary = {
+        "artifact_timestamp": artifact_timestamp,
+        "training_data_key": training_key,
+        "start_date": start_date.date().isoformat(),
+        "end_date": end_date.date().isoformat(),
+        "lookback_days": lookback_days,
+        "filter_thresholds": {
+            "minimum_close_price": MINIMUM_CLOSE_PRICE,
+            "minimum_volume": MINIMUM_VOLUME,
+        },
+        "stage_counts": stage_counts,
+    }
+
+    return train_tide_model(training_key, training_summary, artifact_timestamp)
 
 
 if __name__ == "__main__":

--- a/models/tide/tests/test_tasks.py
+++ b/models/tide/tests/test_tasks.py
@@ -371,8 +371,9 @@ def test_prepare_training_data_returns_stage_counts() -> None:
             end_date=_TARGET_DATE,
         )
 
+    total_input_rows = 2
     total_input_tickers = 2
-    assert stage_counts["raw_rows"] == total_input_tickers
+    assert stage_counts["raw_rows"] == total_input_rows
     assert stage_counts["raw_tickers"] == total_input_tickers
     assert stage_counts["filtered_rows"] == 1
     assert stage_counts["filtered_tickers"] == 1

--- a/models/tide/tests/test_tasks.py
+++ b/models/tide/tests/test_tasks.py
@@ -292,14 +292,14 @@ def test_prepare_training_data_succeeds_when_raw_data_contains_preferred_tickers
     ]
 
     with patch("tide.tasks.boto3.client", return_value=mock_s3_client):
-        result = prepare_training_data(
+        uri, _stage_counts = prepare_training_data(
             data_bucket_name="test-data-bucket",
             model_artifacts_bucket_name="test-artifacts-bucket",
             start_date=_TARGET_DATE,
             end_date=_TARGET_DATE,
         )
 
-    assert result.startswith("s3://test-artifacts-bucket/")
+    assert uri.startswith("s3://test-artifacts-bucket/")
     uploaded_bytes = mock_s3_client.put_object.call_args.kwargs["Body"]
     uploaded_df = pl.read_parquet(io.BytesIO(uploaded_bytes))
     assert list(uploaded_df["ticker"].unique().sort()) == ["AAPL"]
@@ -321,12 +321,60 @@ def test_prepare_training_data_returns_s3_uri() -> None:
     ]
 
     with patch("tide.tasks.boto3.client", return_value=mock_s3_client):
-        result = prepare_training_data(
+        uri, _stage_counts = prepare_training_data(
             data_bucket_name="test-data-bucket",
             model_artifacts_bucket_name="test-artifacts-bucket",
             start_date=_TARGET_DATE,
             end_date=_TARGET_DATE,
         )
 
-    assert result.startswith("s3://test-artifacts-bucket/")
+    assert uri.startswith("s3://test-artifacts-bucket/")
     mock_s3_client.put_object.assert_called_once()
+
+
+def test_prepare_training_data_returns_stage_counts() -> None:
+    extra_bars = pl.DataFrame(
+        {
+            "ticker": ["AAPL", "LOW_PRICE"],
+            "timestamp": [
+                int(_TARGET_DATE.timestamp()) * 1000,
+                int(_TARGET_DATE.timestamp()) * 1000,
+            ],
+            "open_price": [148.0, 0.5],
+            "high_price": [152.0, 0.6],
+            "low_price": [147.0, 0.4],
+            "close_price": [150.0, 0.5],
+            "volume": [1_000_000, 50_000],
+            "volume_weighted_average_price": [151.0, 0.5],
+            "transactions": [5_000, 100],
+        }
+    )
+    parquet_bytes = _to_parquet_bytes(extra_bars)
+    csv_bytes = _to_csv_bytes(_SAMPLE_CATEGORIES)
+
+    mock_body_bars = MagicMock()
+    mock_body_bars.read.return_value = parquet_bytes
+    mock_body_categories = MagicMock()
+    mock_body_categories.read.return_value = csv_bytes
+
+    mock_s3_client = MagicMock()
+    mock_s3_client.get_object.side_effect = [
+        {"Body": mock_body_bars},
+        {"Body": mock_body_categories},
+    ]
+
+    with patch("tide.tasks.boto3.client", return_value=mock_s3_client):
+        _uri, stage_counts = prepare_training_data(
+            data_bucket_name="test-data-bucket",
+            model_artifacts_bucket_name="test-artifacts-bucket",
+            start_date=_TARGET_DATE,
+            end_date=_TARGET_DATE,
+        )
+
+    total_input_tickers = 2
+    assert stage_counts["raw_rows"] == total_input_tickers
+    assert stage_counts["raw_tickers"] == total_input_tickers
+    assert stage_counts["filtered_rows"] == 1
+    assert stage_counts["filtered_tickers"] == 1
+    assert stage_counts["consolidated_rows"] == 1
+    assert stage_counts["consolidated_tickers"] == 1

--- a/models/tide/tests/test_workflow.py
+++ b/models/tide/tests/test_workflow.py
@@ -1,6 +1,6 @@
 import io
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import polars as pl
 import pytest
@@ -28,18 +28,20 @@ def test_prepare_data_calls_prepare_training_data(
 
     start_date = datetime(2024, 1, 1, tzinfo=UTC)
     end_date = datetime(2024, 1, 31, tzinfo=UTC)
-    mock_prepare.return_value = "s3://artifacts-bucket/training/output.parquet"
-    result = prepare_data.fn(
+    mock_prepare.return_value = ("s3://artifacts-bucket/training/output.parquet", {})
+    result_key, result_counts = prepare_data.fn(
         start_date=start_date,
         end_date=end_date,
+        artifact_timestamp="2024-01-31-00-00-00-000",
     )
     mock_prepare.assert_called_once()
-    assert result == "training/output.parquet"
+    assert result_key == "training/output.parquet"
+    assert result_counts == {}
 
 
 @patch("tide.workflow.S3Bucket")
 @patch("tide.workflow.prepare_training_data")
-def test_prepare_data_passes_output_key(
+def test_prepare_data_uses_versioned_output_key(
     mock_prepare: MagicMock,
     mock_s3_bucket: MagicMock,
 ) -> None:
@@ -52,14 +54,21 @@ def test_prepare_data_passes_output_key(
 
     start_date = datetime(2024, 1, 1, tzinfo=UTC)
     end_date = datetime(2024, 1, 31, tzinfo=UTC)
-    mock_prepare.return_value = "s3://artifacts-bucket/custom/key.parquet"
+    artifact_timestamp = "2024-01-31-00-00-00-000"
+    mock_prepare.return_value = (
+        f"s3://artifacts-bucket/data/tide/{artifact_timestamp}/filtered_data.parquet",
+        {},
+    )
     prepare_data.fn(
         start_date=start_date,
         end_date=end_date,
-        output_key="custom/key.parquet",
+        artifact_timestamp=artifact_timestamp,
     )
     call_kwargs = mock_prepare.call_args.kwargs
-    assert call_kwargs["output_key"] == "custom/key.parquet"
+    assert (
+        call_kwargs["output_key"]
+        == f"data/tide/{artifact_timestamp}/filtered_data.parquet"
+    )
 
 
 @patch("tide.workflow.end_run")
@@ -103,11 +112,16 @@ def test_train_tide_model_downloads_trains_uploads(
         mock_train.return_value = (mock_model, mock_data, [0.5, 0.3, 0.2])
         result = train_tide_model.fn(
             training_data_key="training/data.parquet",
+            training_summary={"artifact_timestamp": "2024-01-31-00-00-00-000"},
+            artifact_timestamp="2024-01-31-00-00-00-000",
         )
 
-    assert result.startswith("s3://artifacts-bucket/artifacts/")
+    assert result.startswith(
+        "s3://artifacts-bucket/artifacts/tide/2024-01-31-00-00-00-000/"
+    )
     mock_s3.get_object.assert_called_once()
-    mock_s3.put_object.assert_called_once()
+    expected_put_object_calls = 2  # model.tar.gz + run_metadata.json
+    assert mock_s3.put_object.call_count == expected_put_object_calls
     mock_train.assert_called_once()
     assert "checkpoint_directory" in mock_train.call_args.kwargs
     mock_start_run.assert_called_once()
@@ -151,7 +165,11 @@ def test_train_tide_model_calls_end_run_failed_on_error(
     with patch("tide.trainer.train_model") as mock_train:
         mock_train.side_effect = RuntimeError("Training failed")
         with pytest.raises(RuntimeError, match="Training failed"):
-            train_tide_model.fn(training_data_key="training/data.parquet")
+            train_tide_model.fn(
+                training_data_key="training/data.parquet",
+                training_summary={},
+                artifact_timestamp="2024-01-31-00-00-00-000",
+            )
 
     mock_start_run.assert_called_once()
     mock_end_run.assert_called_once_with(status="FAILED")
@@ -166,11 +184,12 @@ def test_prepare_data_raises_on_missing_blocks(
         prepare_data.fn(
             start_date=datetime(2024, 1, 1, tzinfo=UTC),
             end_date=datetime(2024, 1, 31, tzinfo=UTC),
+            artifact_timestamp="2024-01-31-00-00-00-000",
         )
 
 
 @patch("tide.workflow.train_tide_model", return_value="s3://bucket/model")
-@patch("tide.workflow.prepare_data", return_value="training/data.parquet")
+@patch("tide.workflow.prepare_data", return_value=("training/data.parquet", {}))
 @patch("tide.workflow.get_training_date_range")
 def test_training_pipeline_threads_data_key(
     mock_date_range: MagicMock,
@@ -186,14 +205,8 @@ def test_training_pipeline_threads_data_key(
     )
 
     mock_date_range.assert_called_once_with(LOOKBACK_DAYS)
-    mock_prepare.assert_called_once_with(
-        start_date,
-        end_date,
-        "training/filtered_tide_training_data.parquet",
-    )
-    mock_train.assert_called_once_with(
-        "training/data.parquet",
-    )
+    mock_prepare.assert_called_once_with(start_date, end_date, ANY)
+    mock_train.assert_called_once_with("training/data.parquet", ANY, ANY)
     assert result == "s3://bucket/model"
 
 


### PR DESCRIPTION
# Description

- add training metadata to S3 model output
- add logging for model inference data

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Training artifacts now organized with timestamp-based versioning for improved artifact management
  * Model artifacts now include training metadata and preparation stage metrics stored as run metadata
  * Data preparation metrics captured at multiple processing stages and included in training summaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->