### PR TITLE
Add "fix" flags for language formatting Mask commands

### DIFF
--- a/maskfile.md
+++ b/maskfile.md
@@ -472,16 +472,33 @@ echo "Rust packages checked successfully"
 
 #### format
 
-> Format Rust code
+> Check Rust code formatting
+
+<!-- markdownlint-disable MD036 MD032 MD007 -->
+**OPTIONS**
+* fix
+    * flags: --fix
+    * type: boolean
+    * desc: Apply formatting fixes instead of checking
+<!-- markdownlint-enable MD036 MD032 MD007 -->
 
 ```bash
 set -euo pipefail
 
-echo "Formatting Rust code"
+FIX="${fix:-"false"}"
+if [ -n "${fix+x}" ] && [ -z "$fix" ]; then
+    FIX="true"
+fi
 
-cargo fmt --all
-
-echo "Rust code formatted successfully"
+if [ "$FIX" == "true" ]; then
+    echo "Fixing Rust code formatting"
+    cargo fmt --all
+    echo "Rust code formatted successfully"
+else
+    echo "Checking Rust code formatting"
+    cargo fmt --all -- --check
+    echo "Rust code formatting check passed"
+fi
 ```
 
 #### lint
@@ -598,16 +615,33 @@ echo "Python dependencies installed successfully"
 
 #### format
 
-> Format Python code
+> Check Python code formatting
+
+<!-- markdownlint-disable MD036 MD032 MD007 -->
+**OPTIONS**
+* fix
+    * flags: --fix
+    * type: boolean
+    * desc: Apply formatting fixes instead of checking
+<!-- markdownlint-enable MD036 MD032 MD007 -->
 
 ```bash
 set -euo pipefail
 
-echo "Formatting Python code"
+FIX="${fix:-"false"}"
+if [ -n "${fix+x}" ] && [ -z "$fix" ]; then
+    FIX="true"
+fi
 
-ruff format
-
-echo "Python code formatted successfully"
+if [ "$FIX" == "true" ]; then
+    echo "Fixing Python code formatting"
+    ruff format
+    echo "Python code formatted successfully"
+else
+    echo "Checking Python code formatting"
+    ruff format --check
+    echo "Python code formatting check passed"
+fi
 ```
 
 #### dead-code


### PR DESCRIPTION
# Overview

## Changes

- add optional `--fix` flag for formatting commands

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
Apply relevant labels currently available on the repository.
-->

## Context

<!-- 
Provide additional information as needed.
-->

Nitpick.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `fix` option to formatting workflows for Rust and Python, allowing developers to toggle between checking and automatically fixing code formatting.

* **Chores**
  * Enhanced formatting workflow messaging and section titles for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->