### PR TITLE
Add inference ticker filtering

### DIFF
--- a/applications/ensemble_manager/src/ensemble_manager/preprocess.py
+++ b/applications/ensemble_manager/src/ensemble_manager/preprocess.py
@@ -8,8 +8,9 @@ def filter_to_trained_tickers(
     data: pl.DataFrame,
     trained_tickers: set[str],
 ) -> pl.DataFrame:
-    input_tickers = set(data["ticker"].unique().to_list())
-    dropped_tickers = input_tickers - trained_tickers
+    normalized_trained_tickers = {ticker.upper() for ticker in trained_tickers}
+    input_tickers = set(data["ticker"].str.to_uppercase().unique().to_list())
+    dropped_tickers = input_tickers - normalized_trained_tickers
 
     if dropped_tickers:
         logger.warning(
@@ -18,7 +19,9 @@ def filter_to_trained_tickers(
             dropped_tickers=sorted(dropped_tickers),
         )
 
-    return data.filter(pl.col("ticker").is_in(trained_tickers))
+    return data.filter(
+        pl.col("ticker").str.to_uppercase().is_in(normalized_trained_tickers)
+    )
 
 
 def filter_equity_bars(

--- a/applications/ensemble_manager/src/ensemble_manager/preprocess.py
+++ b/applications/ensemble_manager/src/ensemble_manager/preprocess.py
@@ -21,7 +21,7 @@ def filter_to_trained_tickers(
 
     return data.filter(
         pl.col("ticker").str.to_uppercase().is_in(normalized_trained_tickers)
-    )
+    ).with_columns(pl.col("ticker").str.to_uppercase())
 
 
 def filter_equity_bars(

--- a/applications/ensemble_manager/src/ensemble_manager/preprocess.py
+++ b/applications/ensemble_manager/src/ensemble_manager/preprocess.py
@@ -1,4 +1,23 @@
 import polars as pl
+import structlog
+
+logger = structlog.get_logger()
+
+
+def filter_to_trained_tickers(
+    data: pl.DataFrame,
+    trained_tickers: set[str],
+) -> pl.DataFrame:
+    input_tickers = set(data["ticker"].unique().to_list())
+    dropped_tickers = input_tickers - trained_tickers
+
+    if dropped_tickers:
+        logger.warning(
+            "Dropping tickers not in trained set",
+            dropped_count=len(dropped_tickers),
+        )
+
+    return data.filter(pl.col("ticker").is_in(trained_tickers))
 
 
 def filter_equity_bars(

--- a/applications/ensemble_manager/src/ensemble_manager/preprocess.py
+++ b/applications/ensemble_manager/src/ensemble_manager/preprocess.py
@@ -15,6 +15,7 @@ def filter_to_trained_tickers(
         logger.warning(
             "Dropping tickers not in trained set",
             dropped_count=len(dropped_tickers),
+            dropped_tickers=sorted(dropped_tickers),
         )
 
     return data.filter(pl.col("ticker").is_in(trained_tickers))

--- a/applications/ensemble_manager/src/ensemble_manager/server.py
+++ b/applications/ensemble_manager/src/ensemble_manager/server.py
@@ -341,15 +341,26 @@ def create_predictions(request: Request) -> Response:  # noqa: PLR0911, PLR0915
     tide_data = Data.load(directory_path=request.app.state.model_directory)
 
     trained_tickers = cast("set[str]", set(tide_data.mappings["ticker"].keys()))
+    input_ticker_count = data.select(pl.col("ticker").n_unique()).item()
     data = filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
 
     if data.is_empty():
         prediction_errors_total.labels(stage="ticker_filtering").inc()
-        logger.error("No trained tickers available for prediction")
+        logger.error(
+            "No input tickers matched trained set",
+            input_ticker_count=input_ticker_count,
+            trained_ticker_count=len(trained_tickers),
+        )
         observe_duration(timer_start)
         return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    tide_data.apply_and_set_data(data=data)
+    try:
+        tide_data.apply_and_set_data(data=data)
+    except ValueError:
+        prediction_errors_total.labels(stage="apply_preprocessing").inc()
+        logger.exception("Failed to apply preprocessing to inference data")
+        observe_duration(timer_start)
+        return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     from tinygrad.tensor import Tensor  # noqa: PLC0415
 

--- a/applications/ensemble_manager/src/ensemble_manager/server.py
+++ b/applications/ensemble_manager/src/ensemble_manager/server.py
@@ -343,7 +343,7 @@ def create_predictions(request: Request) -> Response:  # noqa: PLR0915
     trained_tickers = cast("set[str]", set(tide_data.mappings["ticker"].keys()))
     data = filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
 
-    tide_data.preprocess_and_set_data(data=data)
+    tide_data.apply_and_set_data(data=data)
 
     from tinygrad.tensor import Tensor  # noqa: PLC0415
 

--- a/applications/ensemble_manager/src/ensemble_manager/server.py
+++ b/applications/ensemble_manager/src/ensemble_manager/server.py
@@ -39,7 +39,7 @@ from .metrics import (
     start_timer,
 )
 from .predictions_schema import predictions_schema
-from .preprocess import filter_equity_bars
+from .preprocess import filter_equity_bars, filter_to_trained_tickers
 
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
@@ -339,6 +339,9 @@ def create_predictions(request: Request) -> Response:  # noqa: PLR0915
     current_timestamp = datetime.now(tz=UTC)
 
     tide_data = Data.load(directory_path=request.app.state.model_directory)
+
+    trained_tickers = cast("set[str]", set(tide_data.mappings["ticker"].keys()))
+    data = filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
 
     tide_data.preprocess_and_set_data(data=data)
 

--- a/applications/ensemble_manager/src/ensemble_manager/server.py
+++ b/applications/ensemble_manager/src/ensemble_manager/server.py
@@ -272,7 +272,7 @@ def metrics_endpoint() -> Response:
 
 @application.post("/model/predictions")
 @application.post("/predictions")
-def create_predictions(request: Request) -> Response:  # noqa: PLR0915
+def create_predictions(request: Request) -> Response:  # noqa: PLR0911, PLR0915
     prediction_requests_total.inc()
     timer_start = start_timer()
     logger.info("Starting prediction generation process")
@@ -342,6 +342,12 @@ def create_predictions(request: Request) -> Response:  # noqa: PLR0915
 
     trained_tickers = cast("set[str]", set(tide_data.mappings["ticker"].keys()))
     data = filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
+
+    if data.is_empty():
+        prediction_errors_total.labels(stage="ticker_filtering").inc()
+        logger.error("No trained tickers available for prediction")
+        observe_duration(timer_start)
+        return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     tide_data.apply_and_set_data(data=data)
 

--- a/applications/ensemble_manager/tests/test_preprocess.py
+++ b/applications/ensemble_manager/tests/test_preprocess.py
@@ -282,7 +282,7 @@ def test_filter_to_trained_tickers_lowercase_input_passes_through() -> None:
     result = filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
 
     assert result.height == 3  # noqa: PLR2004 all rows retained despite lowercase input
-    assert set(result["ticker"].unique().to_list()) == {"aapl", "msft"}
+    assert set(result["ticker"].unique().to_list()) == {"AAPL", "MSFT"}
 
 
 def test_filter_to_trained_tickers_mixed_case_warning_uses_normalized() -> None:

--- a/applications/ensemble_manager/tests/test_preprocess.py
+++ b/applications/ensemble_manager/tests/test_preprocess.py
@@ -268,3 +268,40 @@ def test_filter_to_trained_tickers_no_warning_when_all_known() -> None:
         filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
 
     assert not any("Dropping tickers" in log["event"] for log in logs)
+
+
+def test_filter_to_trained_tickers_lowercase_input_passes_through() -> None:
+    data = pl.DataFrame(
+        {
+            "ticker": ["aapl", "aapl", "msft"],
+            "close_price": [15.0, 20.0, 25.0],
+        }
+    )
+    trained_tickers = {"AAPL", "MSFT"}
+
+    result = filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
+
+    assert result.height == 3  # noqa: PLR2004 all rows retained despite lowercase input
+    assert set(result["ticker"].unique().to_list()) == {"aapl", "msft"}
+
+
+def test_filter_to_trained_tickers_mixed_case_warning_uses_normalized() -> None:
+    data = pl.DataFrame(
+        {
+            "ticker": ["aapl", "tsla"],
+            "close_price": [15.0, 25.0],
+        }
+    )
+    trained_tickers = {"AAPL"}
+
+    with capture_logs() as logs:
+        filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
+
+    warning_logs = [
+        log
+        for log in logs
+        if log["event"] == "Dropping tickers not in trained set"
+        and log.get("log_level") == "warning"
+    ]
+    assert len(warning_logs) == 1
+    assert "TSLA" in warning_logs[0]["dropped_tickers"]

--- a/applications/ensemble_manager/tests/test_preprocess.py
+++ b/applications/ensemble_manager/tests/test_preprocess.py
@@ -1,6 +1,6 @@
 import polars as pl
-import pytest
 from ensemble_manager.preprocess import filter_equity_bars, filter_to_trained_tickers
+from structlog.testing import capture_logs
 
 
 def test_filter_equity_bars_above_thresholds() -> None:
@@ -236,9 +236,7 @@ def test_filter_to_trained_tickers_unknown_tickers_dropped() -> None:
     assert result["ticker"].unique().to_list() == ["AAPL"]
 
 
-def test_filter_to_trained_tickers_warning_logged_when_dropping(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_filter_to_trained_tickers_warning_logged_when_dropping() -> None:
     data = pl.DataFrame(
         {
             "ticker": ["AAPL", "TSLA"],
@@ -247,18 +245,17 @@ def test_filter_to_trained_tickers_warning_logged_when_dropping(
     )
     trained_tickers = {"AAPL"}
 
-    with caplog.at_level("WARNING"):
+    with capture_logs() as logs:
         filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
 
     assert any(
-        "Dropping tickers not in trained set" in record.message
-        for record in caplog.records
+        log["event"] == "Dropping tickers not in trained set"
+        and log.get("log_level") == "warning"
+        for log in logs
     )
 
 
-def test_filter_to_trained_tickers_no_warning_when_all_known(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_filter_to_trained_tickers_no_warning_when_all_known() -> None:
     data = pl.DataFrame(
         {
             "ticker": ["AAPL", "MSFT"],
@@ -267,7 +264,7 @@ def test_filter_to_trained_tickers_no_warning_when_all_known(
     )
     trained_tickers = {"AAPL", "MSFT"}
 
-    with caplog.at_level("WARNING"):
+    with capture_logs() as logs:
         filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
 
-    assert not any("Dropping tickers" in record.message for record in caplog.records)
+    assert not any("Dropping tickers" in log["event"] for log in logs)

--- a/applications/ensemble_manager/tests/test_preprocess.py
+++ b/applications/ensemble_manager/tests/test_preprocess.py
@@ -1,5 +1,6 @@
 import polars as pl
-from ensemble_manager.preprocess import filter_equity_bars
+import pytest
+from ensemble_manager.preprocess import filter_equity_bars, filter_to_trained_tickers
 
 
 def test_filter_equity_bars_above_thresholds() -> None:
@@ -203,3 +204,70 @@ def test_filter_equity_bars_data_immutability() -> None:
     assert original_data["ticker"].to_list() == original_tickers
     assert original_data["close_price"].to_list() == original_close_prices
     assert original_data["volume"].to_list() == original_volumes
+
+
+def test_filter_to_trained_tickers_known_tickers_pass_through() -> None:
+    data = pl.DataFrame(
+        {
+            "ticker": ["AAPL", "AAPL", "MSFT", "MSFT"],
+            "close_price": [15.0, 20.0, 25.0, 30.0],
+        }
+    )
+    trained_tickers = {"AAPL", "MSFT", "GOOGL"}
+
+    result = filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
+
+    assert result.height == 4  # noqa: PLR2004 all rows retained
+    assert set(result["ticker"].unique().to_list()) == {"AAPL", "MSFT"}
+
+
+def test_filter_to_trained_tickers_unknown_tickers_dropped() -> None:
+    data = pl.DataFrame(
+        {
+            "ticker": ["AAPL", "AAPL", "TSLA", "TSLA"],
+            "close_price": [15.0, 20.0, 25.0, 30.0],
+        }
+    )
+    trained_tickers = {"AAPL", "MSFT"}
+
+    result = filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
+
+    assert result.height == 2  # noqa: PLR2004 only AAPL rows retained
+    assert result["ticker"].unique().to_list() == ["AAPL"]
+
+
+def test_filter_to_trained_tickers_warning_logged_when_dropping(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    data = pl.DataFrame(
+        {
+            "ticker": ["AAPL", "TSLA"],
+            "close_price": [15.0, 25.0],
+        }
+    )
+    trained_tickers = {"AAPL"}
+
+    with caplog.at_level("WARNING"):
+        filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
+
+    assert any(
+        "Dropping tickers not in trained set" in record.message
+        for record in caplog.records
+    )
+
+
+def test_filter_to_trained_tickers_no_warning_when_all_known(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    data = pl.DataFrame(
+        {
+            "ticker": ["AAPL", "MSFT"],
+            "close_price": [15.0, 25.0],
+        }
+    )
+    trained_tickers = {"AAPL", "MSFT"}
+
+    with caplog.at_level("WARNING"):
+        filter_to_trained_tickers(data=data, trained_tickers=trained_tickers)
+
+    assert not any("Dropping tickers" in record.message for record in caplog.records)

--- a/applications/ensemble_manager/tests/test_server.py
+++ b/applications/ensemble_manager/tests/test_server.py
@@ -1,8 +1,18 @@
+import io
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 import polars as pl
+import pytest
 from botocore.exceptions import ClientError
-from ensemble_manager.server import _resolve_artifact_key, application
+from ensemble_manager.server import (
+    _resolve_artifact_key,
+    application,
+    cleanup_model_directory,
+    find_latest_artifact_key,
+    parse_responses,
+)
 from fastapi import status
 from fastapi.testclient import TestClient
 
@@ -37,8 +47,9 @@ def test_create_predictions_some_tickers_dropped_continues() -> None:
         mock_tide_data.get_dataset.return_value = MagicMock(__len__=lambda _: 0)
 
         client = TestClient(application, raise_server_exceptions=False)
-        client.post("/predictions")
+        response = client.post("/predictions")
 
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert call(stage="ticker_filtering") not in mock_errors.labels.call_args_list
 
 
@@ -161,3 +172,235 @@ def test_resolve_artifact_key_explicit_tar_gz_path() -> None:
         )
 
     assert result == "artifacts/specific/model.tar.gz"
+
+
+def test_create_predictions_fetch_equity_bars_fails_returns_500() -> None:
+    application.state.model_directory = "/fake/model/dir"
+
+    with (
+        patch("ensemble_manager.server.requests.get") as mock_requests_get,
+        patch("ensemble_manager.server.prediction_errors_total") as mock_errors,
+    ):
+        mock_errors_instance = MagicMock()
+        mock_errors.labels.return_value = mock_errors_instance
+        mock_requests_get.side_effect = Exception("connection refused")
+
+        client = TestClient(application, raise_server_exceptions=False)
+        response = client.post("/predictions")
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    mock_errors.labels.assert_called_with(stage="fetch_equity_bars")
+    mock_errors_instance.inc.assert_called_once()
+
+
+def test_create_predictions_fetch_equity_details_fails_returns_500() -> None:
+    application.state.model_directory = "/fake/model/dir"
+
+    with (
+        patch("ensemble_manager.server.requests.get") as mock_requests_get,
+        patch("ensemble_manager.server.prediction_errors_total") as mock_errors,
+    ):
+        mock_errors_instance = MagicMock()
+        mock_errors.labels.return_value = mock_errors_instance
+
+        equity_bars_response = MagicMock()
+        equity_bars_response.raise_for_status.return_value = None
+        mock_requests_get.side_effect = [
+            equity_bars_response,
+            Exception("equity details unavailable"),
+        ]
+
+        client = TestClient(application, raise_server_exceptions=False)
+        response = client.post("/predictions")
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    mock_errors.labels.assert_called_with(stage="fetch_equity_details")
+    mock_errors_instance.inc.assert_called_once()
+
+
+def test_create_predictions_parse_responses_fails_returns_500() -> None:
+    application.state.model_directory = "/fake/model/dir"
+
+    with (
+        patch("ensemble_manager.server.requests.get") as mock_requests_get,
+        patch("ensemble_manager.server.parse_responses") as mock_parse,
+        patch("ensemble_manager.server.prediction_errors_total") as mock_errors,
+    ):
+        mock_errors_instance = MagicMock()
+        mock_errors.labels.return_value = mock_errors_instance
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_requests_get.return_value = mock_response
+        mock_parse.side_effect = Exception("parse failed")
+
+        client = TestClient(application, raise_server_exceptions=False)
+        response = client.post("/predictions")
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    mock_errors.labels.assert_called_with(stage="parse_responses")
+    mock_errors_instance.inc.assert_called_once()
+
+
+def test_create_predictions_apply_preprocessing_fails_returns_500() -> None:
+    data = pl.DataFrame(
+        {
+            "ticker": ["AAPL", "AAPL"],
+            "close_price": [15.0, 20.0],
+        }
+    )
+    mock_tide_data = MagicMock()
+    mock_tide_data.mappings = {"ticker": {"AAPL": 0, "MSFT": 1}}
+    mock_tide_data.apply_and_set_data.side_effect = ValueError("unknown category")
+
+    application.state.model_directory = "/fake/model/dir"
+
+    with (
+        patch("ensemble_manager.server.requests.get") as mock_requests_get,
+        patch("ensemble_manager.server.parse_responses") as mock_parse,
+        patch("ensemble_manager.server.Data.load") as mock_data_load,
+        patch("ensemble_manager.server.Model.load"),
+        patch("ensemble_manager.server.filter_to_trained_tickers") as mock_filter,
+        patch("ensemble_manager.server.prediction_errors_total") as mock_errors,
+    ):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_requests_get.return_value = mock_response
+        mock_parse.return_value = data
+        mock_data_load.return_value = mock_tide_data
+        mock_filter.return_value = data
+
+        mock_errors_instance = MagicMock()
+        mock_errors.labels.return_value = mock_errors_instance
+
+        client = TestClient(application, raise_server_exceptions=False)
+        response = client.post("/predictions")
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    mock_errors.labels.assert_called_with(stage="apply_preprocessing")
+    mock_errors_instance.inc.assert_called_once()
+
+
+def test_health_check_returns_200() -> None:
+    client = TestClient(application, raise_server_exceptions=False)
+    with patch("ensemble_manager.server.Model.load"):
+        response = client.get("/health")
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_metrics_endpoint_returns_200() -> None:
+    client = TestClient(application, raise_server_exceptions=False)
+    with patch("ensemble_manager.server.Model.load"):
+        response = client.get("/metrics")
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_find_latest_artifact_key_no_folders_raises() -> None:
+    mock_s3 = MagicMock()
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [{"CommonPrefixes": []}]
+    mock_s3.get_paginator.return_value = mock_paginator
+
+    with pytest.raises(ValueError, match="No artifact folders found"):
+        find_latest_artifact_key(
+            s3_client=mock_s3,
+            bucket="test-bucket",
+            prefix="artifacts/",
+        )
+
+
+def test_find_latest_artifact_key_no_artifact_in_folders_raises() -> None:
+    mock_s3 = MagicMock()
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [
+        {"CommonPrefixes": [{"Prefix": "artifacts/2026-01-01/"}]}
+    ]
+    mock_s3.get_paginator.return_value = mock_paginator
+    mock_s3.head_object.side_effect = ClientError(
+        error_response={"Error": {"Code": "404", "Message": "Not Found"}},
+        operation_name="HeadObject",
+    )
+
+    with pytest.raises(ValueError, match=r"No model\.tar\.gz found"):
+        find_latest_artifact_key(
+            s3_client=mock_s3,
+            bucket="test-bucket",
+            prefix="artifacts/",
+        )
+
+
+def test_find_latest_artifact_key_returns_latest_folder_artifact() -> None:
+    mock_s3 = MagicMock()
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [
+        {
+            "CommonPrefixes": [
+                {"Prefix": "artifacts/2026-01-01/"},
+                {"Prefix": "artifacts/2026-02-01/"},
+            ]
+        }
+    ]
+    mock_s3.get_paginator.return_value = mock_paginator
+    mock_s3.head_object.return_value = {}
+
+    result = find_latest_artifact_key(
+        s3_client=mock_s3,
+        bucket="test-bucket",
+        prefix="artifacts/",
+    )
+
+    assert result == "artifacts/2026-02-01/output/model.tar.gz"
+
+
+def test_cleanup_model_directory_removes_existing_directory() -> None:
+    with tempfile.TemporaryDirectory() as parent_dir:
+        target = Path(parent_dir) / "model_artifacts"
+        target.mkdir()
+        (target / "model.bin").write_text("data")
+
+        cleanup_model_directory(str(target))
+
+        assert not target.exists()
+
+
+def test_cleanup_model_directory_skips_dot() -> None:
+    cleanup_model_directory(".")
+
+
+def test_parse_responses_returns_consolidated_dataframe() -> None:
+    equity_bars = pl.DataFrame(
+        {
+            "ticker": ["AAPL", "AAPL", "MSFT"],
+            "timestamp": [1_700_000_000_000, 1_700_086_400_000, 1_700_000_000_000],
+            "open_price": [150.0, 151.0, 300.0],
+            "high_price": [155.0, 156.0, 305.0],
+            "low_price": [149.0, 150.0, 299.0],
+            "close_price": [152.0, 153.0, 302.0],
+            "volume": [2_000_000, 2_100_000, 1_500_000],
+            "volume_weighted_average_price": [151.5, 152.5, 301.0],
+            "transactions": [100, 110, 90],
+        }
+    )
+    equity_bars_bytes = io.BytesIO()
+    equity_bars.write_parquet(equity_bars_bytes)
+
+    equity_details_csv = (
+        b"ticker,sector,industry\nAAPL,TECHNOLOGY,SOFTWARE\nMSFT,TECHNOLOGY,SOFTWARE\n"
+    )
+
+    equity_bars_response = MagicMock()
+    equity_bars_response.content = equity_bars_bytes.getvalue()
+
+    equity_details_response = MagicMock()
+    equity_details_response.content = equity_details_csv
+
+    result = parse_responses(
+        equity_bars_response=equity_bars_response,
+        equity_details_response=equity_details_response,
+    )
+
+    assert "ticker" in result.columns
+    assert "close_price" in result.columns
+    assert "sector" in result.columns
+    assert "industry" in result.columns
+    assert set(result["ticker"].to_list()).issubset({"AAPL", "MSFT"})

--- a/applications/ensemble_manager/tests/test_server.py
+++ b/applications/ensemble_manager/tests/test_server.py
@@ -23,6 +23,7 @@ def test_create_predictions_some_tickers_dropped_continues() -> None:
         patch("ensemble_manager.server.requests.get") as mock_requests_get,
         patch("ensemble_manager.server.parse_responses") as mock_parse,
         patch("ensemble_manager.server.Data.load") as mock_data_load,
+        patch("ensemble_manager.server.Model.load"),
         patch("ensemble_manager.server.filter_to_trained_tickers") as mock_filter,
         patch("ensemble_manager.server.prediction_errors_total") as mock_errors,
     ):
@@ -58,6 +59,7 @@ def test_create_predictions_all_tickers_dropped_returns_500() -> None:
         patch("ensemble_manager.server.requests.get") as mock_requests_get,
         patch("ensemble_manager.server.parse_responses") as mock_parse,
         patch("ensemble_manager.server.Data.load") as mock_data_load,
+        patch("ensemble_manager.server.Model.load"),
         patch("ensemble_manager.server.filter_to_trained_tickers") as mock_filter,
         patch("ensemble_manager.server.prediction_errors_total") as mock_errors,
     ):

--- a/applications/ensemble_manager/tests/test_server.py
+++ b/applications/ensemble_manager/tests/test_server.py
@@ -1,7 +1,82 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
+import polars as pl
 from botocore.exceptions import ClientError
-from ensemble_manager.server import _resolve_artifact_key
+from ensemble_manager.server import _resolve_artifact_key, application
+from fastapi import status
+from fastapi.testclient import TestClient
+
+
+def test_create_predictions_some_tickers_dropped_continues() -> None:
+    data = pl.DataFrame(
+        {
+            "ticker": ["AAPL", "AAPL"],
+            "close_price": [15.0, 20.0],
+        }
+    )
+    mock_tide_data = MagicMock()
+    mock_tide_data.mappings = {"ticker": {"AAPL": 0, "MSFT": 1}}
+
+    application.state.model_directory = "/fake/model/dir"
+
+    with (
+        patch("ensemble_manager.server.requests.get") as mock_requests_get,
+        patch("ensemble_manager.server.parse_responses") as mock_parse,
+        patch("ensemble_manager.server.Data.load") as mock_data_load,
+        patch("ensemble_manager.server.filter_to_trained_tickers") as mock_filter,
+        patch("ensemble_manager.server.prediction_errors_total") as mock_errors,
+    ):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_requests_get.return_value = mock_response
+        mock_parse.return_value = data
+        mock_data_load.return_value = mock_tide_data
+        mock_filter.return_value = data
+
+        mock_tide_data.get_dataset.return_value = MagicMock(__len__=lambda _: 0)
+
+        client = TestClient(application, raise_server_exceptions=False)
+        client.post("/predictions")
+
+    assert call(stage="ticker_filtering") not in mock_errors.labels.call_args_list
+
+
+def test_create_predictions_all_tickers_dropped_returns_500() -> None:
+    data = pl.DataFrame(
+        {
+            "ticker": ["TSLA", "TSLA"],
+            "close_price": [15.0, 20.0],
+        }
+    )
+    empty_data = pl.DataFrame({"ticker": pl.Series([], dtype=pl.Utf8)})
+    mock_tide_data = MagicMock()
+    mock_tide_data.mappings = {"ticker": {"AAPL": 0, "MSFT": 1}}
+
+    application.state.model_directory = "/fake/model/dir"
+
+    with (
+        patch("ensemble_manager.server.requests.get") as mock_requests_get,
+        patch("ensemble_manager.server.parse_responses") as mock_parse,
+        patch("ensemble_manager.server.Data.load") as mock_data_load,
+        patch("ensemble_manager.server.filter_to_trained_tickers") as mock_filter,
+        patch("ensemble_manager.server.prediction_errors_total") as mock_errors,
+    ):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_requests_get.return_value = mock_response
+        mock_parse.return_value = data
+        mock_data_load.return_value = mock_tide_data
+        mock_filter.return_value = empty_data
+
+        mock_errors_instance = MagicMock()
+        mock_errors.labels.return_value = mock_errors_instance
+
+        client = TestClient(application, raise_server_exceptions=False)
+        response = client.post("/predictions")
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    mock_errors.labels.assert_called_with(stage="ticker_filtering")
+    mock_errors_instance.inc.assert_called_once()
 
 
 def test_resolve_artifact_key_uses_latest_by_default() -> None:

--- a/maskfile.md
+++ b/maskfile.md
@@ -892,9 +892,11 @@ esac
 echo "Deployment complete: ${model_name}"
 ```
 
-### download (model_name)
+### download (model_name) [run_id]
 
 > Download model artifacts
+>
+> Optionally pass a run_id to skip interactive selection and download a specific run.
 
 ```bash
 set -euo pipefail
@@ -902,6 +904,7 @@ set -euo pipefail
 case "${model_name}" in
     tide)
         export APPLICATION_NAME="${model_name}"
+        export FUND_ARTIFACT_RUN_ID="${run_id:-}"
         uv run python -m tools.download_model_artifacts
         ;;
     *)

--- a/models/tide/src/tide/data.py
+++ b/models/tide/src/tide/data.py
@@ -361,6 +361,15 @@ class Data:
             ]
         )
 
+        for col in self.continuous_columns:
+            nan_count = data.filter(pl.col(col).is_nan()).height
+            if nan_count > 0:
+                message = (
+                    f"NaN values after scaling column '{col}': "
+                    f"{nan_count}/{data.height} rows"
+                )
+                raise ValueError(message)
+
         for column, mapping in self.mappings.items():
             unknown_values = set(data[column].unique().to_list()) - set(mapping)
             if unknown_values:

--- a/models/tide/src/tide/data.py
+++ b/models/tide/src/tide/data.py
@@ -349,6 +349,25 @@ class Data:
         self.scaler = cast("Scaler", scale_and_encode.scaler)
         self.mappings = cast("FeatureMappings", scale_and_encode.mappings)
 
+    def apply_and_set_data(self, data: pl.DataFrame) -> None:
+        pipeline = Pipeline(stages=[ValidateColumns(), EngineerFeatures(), CleanData()])
+        data = pipeline.run(data)
+
+        data = data.with_columns(
+            *[
+                (pl.col(col) - self.scaler.means[col])
+                / self.scaler.standard_deviations[col]
+                for col in self.continuous_columns
+            ]
+        )
+
+        for column, mapping in self.mappings.items():
+            data = data.with_columns(
+                pl.col(column).replace(mapping).cast(pl.Int32).alias(column)
+            )
+
+        self.data = data
+
     def _get_training_and_validation_data(
         self,
         validation_split: float = 0.8,

--- a/models/tide/src/tide/data.py
+++ b/models/tide/src/tide/data.py
@@ -362,6 +362,14 @@ class Data:
         )
 
         for column, mapping in self.mappings.items():
+            unknown_values = set(data[column].unique().to_list()) - set(mapping)
+            if unknown_values:
+                message = (
+                    f"Unknown categories for column '{column}': "
+                    f"{sorted(unknown_values)}"
+                )
+                raise ValueError(message)
+
             data = data.with_columns(
                 pl.col(column).replace(mapping).cast(pl.Int32).alias(column)
             )

--- a/models/tide/src/tide/evaluate.py
+++ b/models/tide/src/tide/evaluate.py
@@ -1,0 +1,239 @@
+from dataclasses import dataclass
+from typing import cast
+
+import numpy as np
+import polars as pl
+import structlog
+from tinygrad.tensor import Tensor
+
+from tide.data import TrainingDataset
+from tide.model import Model
+
+logger = structlog.get_logger()
+
+
+@dataclass
+class DriftResult:
+    status: str  # "insufficient_history" | "no_drift" | "drift_detected"
+    message: str
+    current_crps: float
+    baseline_crps: float | None
+
+
+def compute_crps(predictions: pl.DataFrame, actuals: pl.DataFrame) -> float:
+    """Compute CRPS via pinball loss across quantile_10, quantile_50, quantile_90.
+
+    predictions schema: quantile_10, quantile_50, quantile_90
+    actuals schema: daily_return
+    Both DataFrames must be aligned by row index.
+    """
+    actual_values = actuals["daily_return"]
+
+    quantile_pairs = [
+        (0.1, predictions["quantile_10"]),
+        (0.5, predictions["quantile_50"]),
+        (0.9, predictions["quantile_90"]),
+    ]
+
+    combined = predictions.with_columns(actual_values.alias("daily_return"))
+
+    total_loss = pl.lit(0.0)
+    for quantile, predicted_column in quantile_pairs:
+        column_name = predicted_column.name
+        error = pl.col("daily_return") - pl.col(column_name)
+        pinball = (
+            pl.when(error >= 0)
+            .then(quantile * error)
+            .otherwise((quantile - 1.0) * error)
+        )
+        total_loss = total_loss + pinball
+
+    result = combined.select(total_loss.alias("row_loss"))
+    return cast("float", result["row_loss"].mean())
+
+
+def compute_directional_accuracy(
+    predictions: pl.DataFrame, actuals: pl.DataFrame
+) -> float:
+    """Compute fraction of rows where sign(quantile_50) == sign(daily_return).
+
+    predictions schema: quantile_50 (at minimum)
+    actuals schema: daily_return
+    Both DataFrames must be aligned by row index.
+    """
+    combined = predictions.with_columns(actuals["daily_return"].alias("daily_return"))
+
+    matches = combined.select(
+        ((pl.col("quantile_50") >= 0) == (pl.col("daily_return") >= 0)).alias(
+            "direction_match"
+        )
+    )
+
+    return cast("float", matches["direction_match"].mean())
+
+
+def compute_quantile_coverage(
+    predictions: pl.DataFrame, actuals: pl.DataFrame
+) -> float:
+    """Compute fraction where quantile_10 <= daily_return <= quantile_90.
+
+    Well-calibrated model should produce ~0.80 coverage.
+
+    predictions schema: quantile_10, quantile_90 (at minimum)
+    actuals schema: daily_return
+    Both DataFrames must be aligned by row index.
+    """
+    combined = predictions.with_columns(actuals["daily_return"].alias("daily_return"))
+
+    coverage = combined.select(
+        (
+            (pl.col("daily_return") >= pl.col("quantile_10"))
+            & (pl.col("daily_return") <= pl.col("quantile_90"))
+        ).alias("within_interval")
+    )
+
+    return cast("float", coverage["within_interval"].mean())
+
+
+def check_drift(
+    current_metrics: dict[str, float],
+    prior_evaluations: list[dict[str, float]],
+    minimum_runs: int = 3,
+    degradation_threshold: float = 0.20,
+) -> DriftResult:
+    """Check whether the current CRPS has degraded relative to the historical baseline.
+
+    Returns a DriftResult with status "insufficient_history", "no_drift", or
+    "drift_detected".
+    """
+    current_crps = current_metrics["crps"]
+
+    if len(prior_evaluations) < minimum_runs:
+        message = (
+            f"Insufficient evaluation history: {len(prior_evaluations)} run(s) "
+            f"recorded, {minimum_runs} required for baseline."
+        )
+        logger.info(
+            "Insufficient evaluation history for drift check",
+            prior_runs=len(prior_evaluations),
+            minimum_runs=minimum_runs,
+        )
+        return DriftResult(
+            status="insufficient_history",
+            message=message,
+            current_crps=current_crps,
+            baseline_crps=None,
+        )
+
+    baseline_crps = float(
+        np.mean([evaluation["crps"] for evaluation in prior_evaluations])
+    )
+    degradation_limit = max(baseline_crps, 1e-8) * (1.0 + degradation_threshold)
+
+    if current_crps > degradation_limit:
+        message = (
+            f"Drift detected: current CRPS {current_crps:.6f} exceeds baseline "
+            f"{baseline_crps:.6f} by more than {degradation_threshold * 100:.0f}%."
+        )
+        logger.warning(
+            "Model drift detected",
+            current_crps=current_crps,
+            baseline_crps=baseline_crps,
+            degradation_threshold=degradation_threshold,
+        )
+        return DriftResult(
+            status="drift_detected",
+            message=message,
+            current_crps=current_crps,
+            baseline_crps=baseline_crps,
+        )
+
+    message = (
+        f"No drift detected: current CRPS {current_crps:.6f} is within "
+        f"{degradation_threshold * 100:.0f}% of baseline {baseline_crps:.6f}."
+    )
+    return DriftResult(
+        status="no_drift",
+        message=message,
+        current_crps=current_crps,
+        baseline_crps=baseline_crps,
+    )
+
+
+def evaluate(
+    model: Model,
+    validation_dataset: TrainingDataset,
+) -> dict[str, float]:
+    """Run the model on the validation dataset and return evaluation metrics.
+
+    Metrics returned: crps, directional_accuracy, quantile_coverage.
+    All computations are performed in scaled space so that CRPS values are
+    comparable across runs trained on the same scaler.
+    """
+    if len(validation_dataset) == 0:
+        logger.warning("Empty validation dataset; returning zero metrics")
+        return {"crps": 0.0, "directional_accuracy": 0.0, "quantile_coverage": 0.0}
+
+    if validation_dataset.targets is None:
+        message = "Validation dataset must include targets for evaluation"
+        raise ValueError(message)
+
+    previous_training = Tensor.training
+    Tensor.training = False
+
+    try:
+        inputs = {
+            "past_continuous_features": Tensor(validation_dataset.past_continuous),
+            "past_categorical_features": Tensor(validation_dataset.past_categorical),
+            "future_categorical_features": Tensor(
+                validation_dataset.future_categorical
+            ),
+            "static_categorical_features": Tensor(
+                validation_dataset.static_categorical
+            ),
+        }
+
+        raw_predictions = model.predict(inputs)
+        predictions_array = cast("np.ndarray", raw_predictions.numpy())
+    finally:
+        Tensor.training = previous_training
+
+    # predictions_array shape: [N, output_length, 3]
+    # targets shape: [N, output_length, 1]
+    samples_count, output_length, _ = predictions_array.shape
+    total_steps = samples_count * output_length
+
+    predictions_flat = predictions_array.reshape(total_steps, 3)
+    targets_flat = validation_dataset.targets.reshape(total_steps)
+
+    predictions_dataframe = pl.DataFrame(
+        {
+            "quantile_10": predictions_flat[:, 0].tolist(),
+            "quantile_50": predictions_flat[:, 1].tolist(),
+            "quantile_90": predictions_flat[:, 2].tolist(),
+        }
+    )
+
+    actuals_dataframe = pl.DataFrame({"daily_return": targets_flat.tolist()})
+
+    crps = compute_crps(predictions_dataframe, actuals_dataframe)
+    directional_accuracy = compute_directional_accuracy(
+        predictions_dataframe, actuals_dataframe
+    )
+    quantile_coverage = compute_quantile_coverage(
+        predictions_dataframe, actuals_dataframe
+    )
+
+    logger.info(
+        "Evaluation complete",
+        crps=crps,
+        directional_accuracy=directional_accuracy,
+        quantile_coverage=quantile_coverage,
+        total_steps=total_steps,
+    )
+
+    return {
+        "crps": crps,
+        "directional_accuracy": directional_accuracy,
+        "quantile_coverage": quantile_coverage,
+    }

--- a/models/tide/src/tide/tasks.py
+++ b/models/tide/src/tide/tasks.py
@@ -1,4 +1,5 @@
 import io
+import json
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -282,3 +283,103 @@ def prepare_training_data(  # noqa: PLR0913
     )
 
     return uri, stage_counts
+
+
+def fetch_prior_evaluations(
+    s3_client: "S3Client",
+    bucket_name: str,
+    artifact_prefix: str,
+    run_count: int,
+) -> list[dict[str, float]]:
+    """List evaluation JSON files under artifact_prefix and return the N most recent."""
+    logger.info(
+        "Fetching prior evaluations",
+        bucket=bucket_name,
+        prefix=artifact_prefix,
+        run_count=run_count,
+    )
+
+    all_file_objects = []
+    kwargs: dict[str, str] = {"Bucket": bucket_name, "Prefix": artifact_prefix}
+    try:
+        while True:
+            page = s3_client.list_objects_v2(**kwargs)
+            all_file_objects.extend(page.get("Contents", []))
+            if not page.get("IsTruncated"):
+                break
+            kwargs["ContinuationToken"] = page["NextContinuationToken"]
+    except ClientError as error:
+        logger.exception(
+            "Failed to list prior evaluation objects",
+            bucket=bucket_name,
+            prefix=artifact_prefix,
+            error=str(error),
+        )
+        return []
+
+    evaluation_objects = [
+        file_object
+        for file_object in all_file_objects
+        if file_object["Key"].endswith("/evaluation.json")
+    ]
+
+    if not evaluation_objects:
+        logger.info(
+            "No prior evaluations found",
+            bucket=bucket_name,
+            prefix=artifact_prefix,
+        )
+        return []
+
+    evaluation_objects.sort(
+        key=lambda file_object: file_object["LastModified"], reverse=True
+    )
+    most_recent_evaluation = evaluation_objects[:run_count]
+
+    prior_evaluations = []
+    for file_object in most_recent_evaluation:
+        try:
+            get_response = s3_client.get_object(
+                Bucket=bucket_name,
+                Key=file_object["Key"],
+            )
+            evaluation_data = json.loads(get_response["Body"].read())
+            prior_evaluations.append(evaluation_data)
+        except ClientError as error:
+            logger.exception(
+                "Failed to read evaluation file",
+                key=file_object["Key"],
+                error=str(error),
+            )
+
+    logger.info(
+        "Fetched prior evaluations",
+        count=len(prior_evaluations),
+    )
+
+    return prior_evaluations
+
+
+def write_evaluation_results(
+    s3_client: "S3Client",
+    bucket_name: str,
+    results: dict[str, float],
+    run_id: str,
+) -> None:
+    """Write evaluation results as JSON to artifacts/tide/{run_id}/evaluation.json."""
+    key = f"artifacts/tide/{run_id}/evaluation.json"
+
+    logger.info(
+        "Writing evaluation results",
+        bucket=bucket_name,
+        key=key,
+    )
+
+    s3_client.put_object(
+        Bucket=bucket_name,
+        Key=key,
+        Body=json.dumps(results),
+        ContentType="application/json",
+    )
+
+    logger.info("Evaluation results written", key=key)

--- a/models/tide/src/tide/tasks.py
+++ b/models/tide/src/tide/tasks.py
@@ -299,15 +299,11 @@ def fetch_prior_evaluations(
         run_count=run_count,
     )
 
+    paginator = s3_client.get_paginator("list_objects_v2")
     all_file_objects = []
-    kwargs: dict[str, str] = {"Bucket": bucket_name, "Prefix": artifact_prefix}
     try:
-        while True:
-            page = s3_client.list_objects_v2(**kwargs)
+        for page in paginator.paginate(Bucket=bucket_name, Prefix=artifact_prefix):
             all_file_objects.extend(page.get("Contents", []))
-            if not page.get("IsTruncated"):
-                break
-            kwargs["ContinuationToken"] = page["NextContinuationToken"]
     except ClientError as error:
         logger.exception(
             "Failed to list prior evaluation objects",

--- a/models/tide/src/tide/workflow.py
+++ b/models/tide/src/tide/workflow.py
@@ -19,11 +19,14 @@ import structlog  # noqa: E402
 from prefect import flow, task  # noqa: E402
 from prefect_aws.s3 import S3Bucket  # noqa: E402
 
+from tide.evaluate import DriftResult, check_drift, evaluate  # noqa: E402
 from tide.notifications import send_training_notification  # noqa: E402
 from tide.tasks import (  # noqa: E402
     MINIMUM_CLOSE_PRICE,
     MINIMUM_VOLUME,
+    fetch_prior_evaluations,
     prepare_training_data,
+    write_evaluation_results,
 )
 from tide.tracking import end_run, log_model_artifact, start_run  # noqa: E402
 
@@ -123,11 +126,11 @@ def train_tide_model(
         training_data_key=resolved_training_data_key,
     )
 
-    response = s3_client.get_object(
+    training_data_response = s3_client.get_object(
         Bucket=artifacts_bucket,
         Key=resolved_training_data_key,
     )
-    training_data = pl.read_parquet(response["Body"].read())
+    training_data = pl.read_parquet(training_data_response["Body"].read())
     logger.info("Training data loaded", rows=training_data.height)
 
     start_run(
@@ -198,6 +201,107 @@ def train_tide_model(
     return f"s3://{artifacts_bucket}/{artifact_key}"
 
 
+@task(name="evaluate-tide-model")
+def evaluate_tide_model(
+    artifact_key: str,
+    training_data_key: str,
+    artifact_timestamp: str,
+) -> tuple[dict, DriftResult]:
+    """Download model artifact and training data, evaluate model, check for drift."""
+    from tide.data import Data  # noqa: PLC0415
+    from tide.model import Model  # noqa: PLC0415
+
+    try:
+        artifact_block = cast("S3Bucket", S3Bucket.load(ARTIFACT_BLOCK_NAME))
+    except ValueError as err:
+        message = (
+            f"Prefect S3Bucket block '{ARTIFACT_BLOCK_NAME}' not found. "
+            "Create it in Prefect Cloud or run 'prefect block register'. "
+            "Check that credentials are configured on the block."
+        )
+        raise ValueError(message) from err
+
+    s3_client = artifact_block.credentials.get_boto3_session().client("s3")
+    artifacts_bucket = artifact_block.bucket_name
+
+    resolved_training_data_key = training_data_key
+    bucket_prefix = f"s3://{artifacts_bucket}/"
+    if training_data_key.startswith(bucket_prefix):
+        resolved_training_data_key = training_data_key.removeprefix(bucket_prefix)
+
+    logger.info(
+        "Loading training data for evaluation",
+        artifacts_bucket=artifacts_bucket,
+        training_data_key=resolved_training_data_key,
+    )
+
+    training_data_response = s3_client.get_object(
+        Bucket=artifacts_bucket,
+        Key=resolved_training_data_key,
+    )
+    training_data = pl.read_parquet(training_data_response["Body"].read())
+
+    tide_data = Data()
+    tide_data.preprocess_and_set_data(training_data)
+    validation_dataset = tide_data.get_dataset("validate")
+
+    resolved_artifact_key = artifact_key
+    if artifact_key.startswith(bucket_prefix):
+        resolved_artifact_key = artifact_key.removeprefix(bucket_prefix)
+
+    logger.info(
+        "Downloading model artifact for evaluation",
+        artifacts_bucket=artifacts_bucket,
+        artifact_key=resolved_artifact_key,
+    )
+
+    artifact_response = s3_client.get_object(
+        Bucket=artifacts_bucket,
+        Key=resolved_artifact_key,
+    )
+    tar_bytes = artifact_response["Body"].read()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tar_buffer = io.BytesIO(tar_bytes)
+        with tarfile.open(fileobj=tar_buffer, mode="r:gz") as tar:
+            tar.extractall(path=tmpdir, filter="data")
+
+        tide_model = Model.load(directory_path=tmpdir)
+
+        logger.info("Running model evaluation")
+
+        evaluation_results = evaluate(tide_model, validation_dataset)
+
+    prior_evaluations = fetch_prior_evaluations(
+        s3_client=s3_client,
+        bucket_name=artifacts_bucket,
+        artifact_prefix="artifacts/tide/",
+        run_count=7,
+    )
+
+    drift_result = check_drift(
+        current_metrics=evaluation_results,
+        prior_evaluations=prior_evaluations,
+    )
+
+    write_evaluation_results(
+        s3_client=s3_client,
+        bucket_name=artifacts_bucket,
+        results=evaluation_results,
+        run_id=artifact_timestamp,
+    )
+
+    logger.info(
+        "Evaluation task complete",
+        drift_status=drift_result.status,
+        crps=evaluation_results["crps"],
+        directional_accuracy=evaluation_results["directional_accuracy"],
+        quantile_coverage=evaluation_results["quantile_coverage"],
+    )
+
+    return evaluation_results, drift_result
+
+
 @flow(  # type: ignore
     name="tide-training-pipeline",
     log_prints=True,
@@ -230,7 +334,11 @@ def training_pipeline(
         "stage_counts": stage_counts,
     }
 
-    return train_tide_model(training_key, training_summary, artifact_timestamp)
+    artifact_key = train_tide_model(training_key, training_summary, artifact_timestamp)
+
+    evaluate_tide_model(artifact_key, training_key, artifact_timestamp)
+
+    return artifact_key
 
 
 if __name__ == "__main__":

--- a/models/tide/tests/test_data.py
+++ b/models/tide/tests/test_data.py
@@ -342,3 +342,18 @@ def test_pipeline_honors_explicit_empty_stage_list(
     pipeline = Pipeline(stages=[])
     result = pipeline.run(data)
     assert result.equals(data)
+
+
+def test_apply_and_set_data_raises_on_unknown_category(
+    make_raw_data: Callable[..., pl.DataFrame],
+) -> None:
+    raw = make_raw_data(tickers=["AAPL"], days=60)
+    data = Data()
+    data.preprocess_and_set_data(raw)
+
+    inference_raw = make_raw_data(tickers=["AAPL"], days=10).with_columns(
+        pl.lit("NEW_SECTOR").alias("sector")
+    )
+
+    with pytest.raises(ValueError, match="Unknown categories for column 'sector'"):
+        data.apply_and_set_data(inference_raw)

--- a/models/tide/tests/test_data.py
+++ b/models/tide/tests/test_data.py
@@ -357,3 +357,23 @@ def test_apply_and_set_data_raises_on_unknown_category(
 
     with pytest.raises(ValueError, match="Unknown categories for column 'sector'"):
         data.apply_and_set_data(inference_raw)
+
+
+def test_apply_and_set_data_applies_mappings_and_scaler(
+    make_raw_data: Callable[..., pl.DataFrame],
+) -> None:
+    training_raw = make_raw_data(tickers=["AAPL"], days=60)
+    data = Data()
+    data.preprocess_and_set_data(training_raw)
+
+    training_ticker_encoding = data.mappings["ticker"]["AAPL"]
+    training_scaler_means = data.scaler.means.clone()
+    training_scaler_stds = data.scaler.standard_deviations.clone()
+
+    inference_raw = make_raw_data(tickers=["AAPL"], days=10)
+    data.apply_and_set_data(inference_raw)
+
+    assert data.mappings["ticker"]["AAPL"] == training_ticker_encoding
+    assert data.scaler.means.equals(training_scaler_means)
+    assert data.scaler.standard_deviations.equals(training_scaler_stds)
+    assert not data.data.is_empty()

--- a/models/tide/tests/test_evaluate.py
+++ b/models/tide/tests/test_evaluate.py
@@ -1,0 +1,223 @@
+import polars as pl
+import pytest
+from tide.evaluate import (
+    DriftResult,
+    check_drift,
+    compute_crps,
+    compute_directional_accuracy,
+    compute_quantile_coverage,
+)
+
+_FLOAT_TOLERANCE = 1e-6
+
+
+def _make_predictions(
+    quantile_10: list[float],
+    quantile_50: list[float],
+    quantile_90: list[float],
+) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "quantile_10": quantile_10,
+            "quantile_50": quantile_50,
+            "quantile_90": quantile_90,
+        }
+    )
+
+
+def _make_actuals(daily_return: list[float]) -> pl.DataFrame:
+    return pl.DataFrame({"daily_return": daily_return})
+
+
+def test_compute_crps_returns_float() -> None:
+    predictions = _make_predictions(
+        quantile_10=[-0.01, -0.02],
+        quantile_50=[0.01, 0.02],
+        quantile_90=[0.03, 0.04],
+    )
+    actuals = _make_actuals([0.015, 0.025])
+
+    result = compute_crps(predictions, actuals)
+
+    assert isinstance(result, float)
+
+
+def test_compute_crps_perfect_predictions_returns_zero() -> None:
+    # When quantile_50 equals actual and quantile_10/90 bracket it tightly,
+    # the pinball loss approaches zero
+    value = 0.05
+    predictions = _make_predictions(
+        quantile_10=[value],
+        quantile_50=[value],
+        quantile_90=[value],
+    )
+    actuals = _make_actuals([value])
+
+    result = compute_crps(predictions, actuals)
+
+    assert abs(result) < _FLOAT_TOLERANCE
+
+
+def test_compute_crps_positive_for_imperfect_predictions() -> None:
+    predictions = _make_predictions(
+        quantile_10=[-0.10],
+        quantile_50=[0.10],
+        quantile_90=[0.20],
+    )
+    actuals = _make_actuals([-0.05])
+
+    result = compute_crps(predictions, actuals)
+
+    assert result > 0.0
+
+
+def test_compute_directional_accuracy_all_matching_signs() -> None:
+    predictions = _make_predictions(
+        quantile_10=[0.01, 0.02, -0.03],
+        quantile_50=[0.05, 0.06, -0.01],
+        quantile_90=[0.10, 0.11, 0.01],
+    )
+    actuals = _make_actuals([0.03, 0.07, -0.02])
+
+    result = compute_directional_accuracy(predictions, actuals)
+
+    assert result == pytest.approx(1.0)
+
+
+def test_compute_directional_accuracy_all_mismatched_signs() -> None:
+    predictions = _make_predictions(
+        quantile_10=[0.01, 0.02],
+        quantile_50=[0.05, 0.06],
+        quantile_90=[0.10, 0.11],
+    )
+    actuals = _make_actuals([-0.03, -0.07])
+
+    result = compute_directional_accuracy(predictions, actuals)
+
+    assert result == pytest.approx(0.0)
+
+
+def test_compute_directional_accuracy_returns_float_between_zero_and_one() -> None:
+    predictions = _make_predictions(
+        quantile_10=[-0.01, 0.01],
+        quantile_50=[-0.05, 0.05],
+        quantile_90=[0.01, 0.10],
+    )
+    actuals = _make_actuals([-0.03, -0.02])
+
+    result = compute_directional_accuracy(predictions, actuals)
+
+    assert 0.0 <= result <= 1.0
+
+
+def test_compute_quantile_coverage_all_within_bounds() -> None:
+    predictions = _make_predictions(
+        quantile_10=[-0.10, -0.10],
+        quantile_50=[0.0, 0.0],
+        quantile_90=[0.10, 0.10],
+    )
+    actuals = _make_actuals([0.05, -0.05])
+
+    result = compute_quantile_coverage(predictions, actuals)
+
+    assert result == pytest.approx(1.0)
+
+
+def test_compute_quantile_coverage_none_within_bounds() -> None:
+    predictions = _make_predictions(
+        quantile_10=[0.01, 0.01],
+        quantile_50=[0.05, 0.05],
+        quantile_90=[0.10, 0.10],
+    )
+    actuals = _make_actuals([-0.05, -0.10])
+
+    result = compute_quantile_coverage(predictions, actuals)
+
+    assert result == pytest.approx(0.0)
+
+
+def test_compute_quantile_coverage_returns_float_between_zero_and_one() -> None:
+    predictions = _make_predictions(
+        quantile_10=[-0.05, 0.01],
+        quantile_50=[0.0, 0.05],
+        quantile_90=[0.05, 0.10],
+    )
+    actuals = _make_actuals([0.03, -0.02])
+
+    result = compute_quantile_coverage(predictions, actuals)
+
+    assert 0.0 <= result <= 1.0
+
+
+def test_check_drift_returns_insufficient_history_when_below_minimum_runs() -> None:
+    current_metrics = {"crps": 0.05}
+    prior_evaluations = [{"crps": 0.04}, {"crps": 0.045}]
+
+    result = check_drift(
+        current_metrics=current_metrics,
+        prior_evaluations=prior_evaluations,
+        minimum_runs=3,
+    )
+
+    assert result.status == "insufficient_history"
+    assert result.current_crps == pytest.approx(0.05)
+    assert result.baseline_crps is None
+
+
+def test_check_drift_returns_insufficient_history_when_no_prior_evaluations() -> None:
+    current_metrics = {"crps": 0.05}
+
+    result = check_drift(
+        current_metrics=current_metrics,
+        prior_evaluations=[],
+        minimum_runs=3,
+    )
+
+    assert result.status == "insufficient_history"
+    assert isinstance(result, DriftResult)
+
+
+def test_check_drift_returns_drift_detected_when_crps_exceeds_threshold() -> None:
+    baseline = 0.04
+    current_metrics = {"crps": baseline * 1.25}  # 25% degradation, above 20% threshold
+    prior_evaluations = [{"crps": baseline}, {"crps": baseline}, {"crps": baseline}]
+
+    result = check_drift(
+        current_metrics=current_metrics,
+        prior_evaluations=prior_evaluations,
+        minimum_runs=3,
+        degradation_threshold=0.20,
+    )
+
+    assert result.status == "drift_detected"
+    assert result.current_crps == pytest.approx(baseline * 1.25)
+    assert result.baseline_crps == pytest.approx(baseline)
+
+
+def test_check_drift_returns_no_drift_when_crps_within_threshold() -> None:
+    baseline = 0.04
+    current_metrics = {"crps": baseline * 1.10}  # 10% degradation, below 20% threshold
+    prior_evaluations = [{"crps": baseline}, {"crps": baseline}, {"crps": baseline}]
+
+    result = check_drift(
+        current_metrics=current_metrics,
+        prior_evaluations=prior_evaluations,
+        minimum_runs=3,
+        degradation_threshold=0.20,
+    )
+
+    assert result.status == "no_drift"
+    assert result.baseline_crps == pytest.approx(baseline)
+
+
+def test_check_drift_baseline_crps_is_mean_of_prior_evaluations() -> None:
+    prior_evaluations = [{"crps": 0.02}, {"crps": 0.04}, {"crps": 0.06}]
+    current_metrics = {"crps": 0.04}
+
+    result = check_drift(
+        current_metrics=current_metrics,
+        prior_evaluations=prior_evaluations,
+        minimum_runs=3,
+    )
+
+    assert result.baseline_crps == pytest.approx(0.04)

--- a/models/tide/tests/test_workflow.py
+++ b/models/tide/tests/test_workflow.py
@@ -188,6 +188,7 @@ def test_prepare_data_raises_on_missing_blocks(
         )
 
 
+@patch("tide.workflow.evaluate_tide_model")
 @patch("tide.workflow.train_tide_model", return_value="s3://bucket/model")
 @patch("tide.workflow.prepare_data", return_value=("training/data.parquet", {}))
 @patch("tide.workflow.get_training_date_range")
@@ -195,6 +196,7 @@ def test_training_pipeline_threads_data_key(
     mock_date_range: MagicMock,
     mock_prepare: MagicMock,
     mock_train: MagicMock,
+    mock_evaluate: MagicMock,
 ) -> None:
     start_date = datetime(2024, 1, 1, tzinfo=UTC)
     end_date = datetime(2024, 1, 31, tzinfo=UTC)
@@ -207,6 +209,9 @@ def test_training_pipeline_threads_data_key(
     mock_date_range.assert_called_once_with(LOOKBACK_DAYS)
     mock_prepare.assert_called_once_with(start_date, end_date, ANY)
     mock_train.assert_called_once_with("training/data.parquet", ANY, ANY)
+    mock_evaluate.assert_called_once_with(
+        "s3://bucket/model", "training/data.parquet", ANY
+    )
     assert result == "s3://bucket/model"
 
 

--- a/tools/src/tools/download_model_artifacts.py
+++ b/tools/src/tools/download_model_artifacts.py
@@ -1,31 +1,23 @@
 import os
 import sys
 import tarfile
+from typing import TYPE_CHECKING
 
 import boto3
 import structlog
 
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+
 logger = structlog.get_logger()
 
 
-def download_model_artifacts(  # noqa: C901, PLR0915
+def _resolve_artifact_run_id(
+    s3_client: "S3Client",
     application_name: str,
     artifacts_bucket: str,
     github_actions_check: bool,  # noqa: FBT001
-) -> None:
-    logger.info("Downloading model artifact", application_name=application_name)
-
-    try:
-        s3_client = boto3.client("s3")
-
-    except Exception as e:
-        logger.exception(
-            "Error creating S3 client",
-            error=f"{e}",
-            application_name=application_name,
-        )
-        raise RuntimeError from e
-
+) -> str:
     try:
         file_objects = s3_client.list_objects_v2(
             Bucket=artifacts_bucket,
@@ -40,7 +32,6 @@ def download_model_artifacts(  # noqa: C901, PLR0915
 
     for file_object in file_objects.get("Contents", []):
         file_object_name = file_object["Key"]
-
         file_object_name_parts = file_object_name.split("/")
 
         if len(file_object_name_parts) < 3:  # noqa: PLR2004
@@ -68,23 +59,55 @@ def download_model_artifacts(  # noqa: C901, PLR0915
             "GitHub Actions detected, selecting latest artifact",
             selected_option=selected_option,
         )
+        return selected_option
 
+    if not options:
+        logger.error("No artifacts found", application_name=application_name)
+        raise RuntimeError
+
+    logger.info("Available artifacts", options=options)
+    selected_option = input("Select an artifact to download: ")
+
+    if selected_option not in options:
+        logger.error(
+            "Invalid selection",
+            selected_option=selected_option,
+            valid_options=options,
+        )
+        raise RuntimeError
+
+    return selected_option
+
+
+def download_model_artifacts(
+    application_name: str,
+    artifacts_bucket: str,
+    github_actions_check: bool,  # noqa: FBT001
+    artifact_run_id: str | None = None,
+) -> None:
+    logger.info("Downloading model artifact", application_name=application_name)
+
+    try:
+        s3_client = boto3.client("s3")
+
+    except Exception as e:
+        logger.exception(
+            "Error creating S3 client",
+            error=f"{e}",
+            application_name=application_name,
+        )
+        raise RuntimeError from e
+
+    if artifact_run_id is not None:
+        logger.info(
+            "Using provided artifact run ID, skipping listing",
+            artifact_run_id=artifact_run_id,
+        )
+        selected_option = artifact_run_id
     else:
-        if not options:
-            logger.error("No artifacts found", application_name=application_name)
-            raise RuntimeError
-
-        logger.info("Available artifacts", options=options)
-
-        selected_option = input("Select an artifact to download: ")
-
-        if selected_option not in options:
-            logger.error(
-                "Invalid selection",
-                selected_option=selected_option,
-                valid_options=options,
-            )
-            raise RuntimeError
+        selected_option = _resolve_artifact_run_id(
+            s3_client, application_name, artifacts_bucket, github_actions_check
+        )
 
     logger.info("Selected artifact", selected_option=selected_option)
 
@@ -127,6 +150,7 @@ if __name__ == "__main__":
     application_name = os.getenv("APPLICATION_NAME", "")
     artifacts_bucket = os.getenv("AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME", "")
     github_actions_check = os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
+    artifact_run_id = os.getenv("FUND_ARTIFACT_RUN_ID") or None
 
     environment_variables = {
         "APPLICATION_NAME": application_name,
@@ -148,6 +172,7 @@ if __name__ == "__main__":
             application_name=application_name,
             artifacts_bucket=artifacts_bucket,
             github_actions_check=github_actions_check,
+            artifact_run_id=artifact_run_id,
         )
     except Exception as e:
         logger.exception("Failed to download model artifacts", error=f"{e}")


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated post-training evaluation with drift detection and metric reporting.

* **Enhancements**
  * Inference now applies stored scaling and categorical encodings and fails on unknown categories.
  * CLI gained an option to target a specific model run; utilities added for S3-backed evaluation fetch/write.

* **Behavior**
  * Predictions are restricted to tickers seen during training; requests with no remaining tickers return an error.

* **Logging**
  * Warning when input tickers are dropped; evaluation results and drift status are logged.

* **Tests**
  * Added tests for filtering, case-normalization, warning emission, evaluation metrics, and workflow integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->