### PR TITLE
Enable local training pipeline via devenv

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -285,6 +285,47 @@ in {
 
   # --- Local dev commands ---
 
+  # Register Prefect S3Bucket blocks on the local server
+  scripts.register-blocks.exec = ''
+    echo "Waiting for orchestrator..."
+    while ! curl -sf http://localhost:4200/api/health > /dev/null 2>&1; do
+      sleep 2
+    done
+
+    export PREFECT_API_URL="http://localhost:4200/api"
+
+    echo "Reading bucket names from Pulumi stack outputs..."
+    unset AWS_ENDPOINT_URL AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+    DATA_BUCKET=$(cd "$DEVENV_ROOT/infrastructure" && pulumi stack output --stack production aws_s3_data_bucket_name 2>/dev/null)
+    ARTIFACTS_BUCKET=$(cd "$DEVENV_ROOT/infrastructure" && pulumi stack output --stack production aws_s3_model_artifacts_bucket_name 2>/dev/null)
+
+    if [ -z "$DATA_BUCKET" ] || [ -z "$ARTIFACTS_BUCKET" ]; then
+      echo "Could not read bucket names from Pulumi. Using defaults."
+      DATA_BUCKET="fund-data-404221e2"
+      ARTIFACTS_BUCKET="fund-model-artifacts-404221e2"
+    fi
+
+    echo "  data bucket:      $DATA_BUCKET"
+    echo "  artifacts bucket:  $ARTIFACTS_BUCKET"
+
+    echo "Registering S3Bucket blocks on local Prefect server..."
+    uv run --package tide python -c "
+import sys
+from prefect_aws.s3 import S3Bucket
+from prefect_aws.credentials import AwsCredentials
+
+data_bucket = sys.argv[1]
+artifacts_bucket = sys.argv[2]
+
+creds = AwsCredentials()
+creds.save('aws-credentials', overwrite=True)
+
+S3Bucket(bucket_name=data_bucket, credentials=creds).save('data-bucket', overwrite=True)
+S3Bucket(bucket_name=artifacts_bucket, credentials=creds).save('artifact-bucket', overwrite=True)
+print('Blocks registered: data-bucket, artifact-bucket')
+" "$DATA_BUCKET" "$ARTIFACTS_BUCKET"
+  '';
+
   # Create work pool and register training deployment locally
   scripts.initialize-local-trainer.exec = ''
     echo "Waiting for orchestrator..."
@@ -292,12 +333,20 @@ in {
       sleep 2
     done
 
+    register-blocks
+
     echo "Creating fund-models-local work pool..."
     uv run --package tools prefect work-pool create "fund-models-local" --type process 2>/dev/null \
       || echo "  already exists"
 
     echo "Registering local training deployment..."
     uv run prefect --no-prompt deploy --name tide-trainer-local
+
+    echo "Setting pull steps to local project root..."
+    DEPLOYMENT_ID=$(curl -sf http://localhost:4200/api/deployments/name/tide-training-pipeline/tide-trainer-local | jq -r '.id')
+    curl -sf -X PATCH "http://localhost:4200/api/deployments/$DEPLOYMENT_ID" \
+      -H 'Content-Type: application/json' \
+      -d "{\"pull_steps\": [{\"prefect.deployments.steps.set_working_directory\": {\"directory\": \"$DEVENV_ROOT\"}}]}"
 
     echo ""
     echo "Done. Visit http://localhost:4200 to see the orchestrator dashboard."
@@ -353,11 +402,20 @@ in {
         sleep 2
       done
 
-      # Create work pool and register deployment on first startup
-      PREFECT_API_URL="http://localhost:4200/api" \
-        uv run --package tools prefect work-pool create "fund-models-local" --type process 2>/dev/null || true
-      PREFECT_API_URL="http://localhost:4200/api" \
-        uv run --package tide python -m tide.deploy 2>/dev/null || true
+      # Register S3 blocks, create work pool, and register deployment on first startup
+      export PREFECT_API_URL="http://localhost:4200/api"
+      register-blocks || true
+
+      uv run --package tools prefect work-pool create "fund-models-local" --type process 2>/dev/null || true
+
+      uv run prefect --no-prompt deploy --name tide-trainer-local 2>/dev/null || true
+      DEPLOYMENT_ID=$(curl -sf http://localhost:4200/api/deployments/name/tide-training-pipeline/tide-trainer-local | jq -r '.id') || true
+      if [ -n "$DEPLOYMENT_ID" ] && [ "$DEPLOYMENT_ID" != "null" ]; then
+        PROJECT_ROOT="''${DEVENV_ROOT:-$(pwd)}"
+        curl -sf -X PATCH "http://localhost:4200/api/deployments/$DEPLOYMENT_ID" \
+          -H 'Content-Type: application/json' \
+          -d "{\"pull_steps\": [{\"prefect.deployments.steps.set_working_directory\": {\"directory\": \"$PROJECT_ROOT\"}}]}" || true
+      fi
 
       cd tools
       exec uv run prefect worker start --pool fund-models-local --name worker-1
@@ -442,6 +500,7 @@ in {
     echo "    initialize-remote-trainer  Create work pool + register deployment (prod)"
     echo ""
     echo "  Local:"
+    echo "    register-blocks            Register S3 blocks on local Prefect server"
     echo "    initialize-local-trainer   Create work pool + register deployment (local)"
     echo "    cleanup-services  Kill stale local processes"
   '';

--- a/models/tide/src/tide/tasks.py
+++ b/models/tide/src/tide/tasks.py
@@ -253,6 +253,8 @@ def prepare_training_data(  # noqa: PLR0913
 
     filtered_bars = filter_equity_bars(equity_bars)
 
+    filtered_bars = filtered_bars.unique(subset=["ticker", "timestamp"], keep="last")
+
     equity_bars_schema.validate(filtered_bars)
 
     filtered_rows = filtered_bars.height

--- a/models/tide/tests/test_tasks.py
+++ b/models/tide/tests/test_tasks.py
@@ -379,3 +379,47 @@ def test_prepare_training_data_returns_stage_counts() -> None:
     assert stage_counts["filtered_tickers"] == 1
     assert stage_counts["consolidated_rows"] == 1
     assert stage_counts["consolidated_tickers"] == 1
+
+
+def test_prepare_training_data_deduplicates_ticker_timestamp() -> None:
+    duplicate_bars = pl.DataFrame(
+        {
+            "ticker": ["AAPL", "AAPL"],
+            "timestamp": [
+                int(_TARGET_DATE.timestamp()) * 1000,
+                int(_TARGET_DATE.timestamp()) * 1000,
+            ],
+            "open_price": [148.0, 149.0],
+            "high_price": [152.0, 153.0],
+            "low_price": [147.0, 148.0],
+            "close_price": [150.0, 151.0],
+            "volume": [1_000_000, 2_000_000],
+            "volume_weighted_average_price": [151.0, 152.0],
+            "transactions": [5_000, 6_000],
+        }
+    )
+    parquet_bytes = _to_parquet_bytes(duplicate_bars)
+    csv_bytes = _to_csv_bytes(_SAMPLE_CATEGORIES)
+
+    mock_body_bars = MagicMock()
+    mock_body_bars.read.return_value = parquet_bytes
+    mock_body_categories = MagicMock()
+    mock_body_categories.read.return_value = csv_bytes
+
+    mock_s3_client = MagicMock()
+    mock_s3_client.get_object.side_effect = [
+        {"Body": mock_body_bars},
+        {"Body": mock_body_categories},
+    ]
+
+    with patch("tide.tasks.boto3.client", return_value=mock_s3_client):
+        uri, stage_counts = prepare_training_data(
+            data_bucket_name="test-data-bucket",
+            model_artifacts_bucket_name="test-artifacts-bucket",
+            start_date=_TARGET_DATE,
+            end_date=_TARGET_DATE,
+        )
+
+    assert uri.startswith("s3://test-artifacts-bucket/")
+    assert stage_counts["filtered_rows"] == 1
+    assert stage_counts["filtered_tickers"] == 1

--- a/prefect.yaml
+++ b/prefect.yaml
@@ -1,9 +1,4 @@
 ---
-pull:
-  - prefect.deployments.steps.git_clone:
-      repository: https://github.com/oscmcompany/fund.git
-      branch: master
-
 deployments:
   - name: tide-trainer-local
     entrypoint: models/tide/src/tide/workflow.py:training_pipeline


### PR DESCRIPTION
## Summary

- Add `register-blocks` devenv script that reads S3 bucket names from Pulumi stack outputs and registers Prefect S3Bucket blocks on the local server
- Wire block registration and deployment setup into `training-worker-1` so `devenv up` auto-configures everything needed for local training
- Patch local deployment pull steps to use the project root instead of cloning from GitHub, resolving the issue where local code changes were not picked up
- Deduplicate equity bars by `(ticker, timestamp)` before pandera schema validation to handle overlapping daily parquet files in S3
- Add test covering deduplication behavior

Run pipeline by

```sh
devenv up
devenv tasks run models:tide:train:local
```

## Test plan

- [x] `pytest models/tide/tests/test_tasks.py` -- 15/15 passing
- [x] `devenv up` starts orchestrator, registers blocks, creates work pool, deploys and patches local deployment
- [x] `devenv tasks run models:tide:train:local` runs full training pipeline against live S3 data
- [x] Verified model artifact, run metadata, and evaluation JSON landed in S3

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AWS S3 bucket blocks now explicitly registered during local development initialization.

* **Bug Fixes**
  * Training data pipeline removes duplicate equity bar rows with identical ticker and timestamp values.

* **Tests**
  * Added unit test verifying equity bar row deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->