### PR TITLE
redeploy trigger

### DIFF
--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -3,6 +3,7 @@ from compute import acm_certificate_arn, alb, cluster, service_discovery_namespa
 from config import account_id
 from iam import github_actions_infrastructure_role, github_actions_oidc_provider
 from networking import ecs_security_group, private_subnet_1, private_subnet_2, vpc
+from redeployment import redeployment_lambda
 from storage import (
     data_bucket,
     data_manager_image_uri,
@@ -15,7 +16,6 @@ from storage import (
     tide_runner_image_uri,
     tide_runner_repository,
 )
-from redeployment import redeployment_lambda  # noqa: F401
 from training import models_cluster, tide_trainer_task_definition
 
 protocol = "https://" if acm_certificate_arn else "http://"

--- a/infrastructure/__main__.py
+++ b/infrastructure/__main__.py
@@ -15,6 +15,7 @@ from storage import (
     tide_runner_image_uri,
     tide_runner_repository,
 )
+from redeployment import redeployment_lambda  # noqa: F401
 from training import models_cluster, tide_trainer_task_definition
 
 protocol = "https://" if acm_certificate_arn else "http://"
@@ -81,5 +82,6 @@ pulumi.export(
     "aws_iam_github_actions_oidc_provider_arn",
     github_actions_oidc_provider.arn,
 )
+pulumi.export("aws_lambda_redeployment_arn", redeployment_lambda.arn)
 pulumi.export("fund_base_url", fund_base_url)
 pulumi.export("readme", pulumi.Output.format(readme_content, fund_base_url))

--- a/infrastructure/iam.py
+++ b/infrastructure/iam.py
@@ -448,7 +448,7 @@ github_actions_trainer_policy = aws.iam.Policy(
 github_actions_redeployment_policy = aws.iam.Policy(
     "github_actions_redeployment_policy",
     name="fund-github-actions-redeployment-policy",
-    description="Redeployment infrastructure permissions for GitHub Actions deployments.",
+    description="Redeployment infrastructure permissions for GitHub Actions.",
     policy=json.dumps(
         {
             "Version": "2012-10-17",
@@ -468,9 +468,10 @@ github_actions_redeployment_policy = aws.iam.Policy(
                     "Sid": "ManageLambdaFunctions",
                     "Effect": "Allow",
                     "Action": "lambda:*",
-                    "Resource": (
-                        f"arn:aws:lambda:{region}:{account_id}:function:fund-*"
-                    ),
+                    "Resource": [
+                        f"arn:aws:lambda:{region}:{account_id}:function:fund-redeploy-ensemble-manager",
+                        f"arn:aws:lambda:{region}:{account_id}:function:fund-redeploy-ensemble-manager:*",
+                    ],
                 },
                 {
                     "Sid": "ManageEventBridgeRules",
@@ -488,9 +489,7 @@ github_actions_redeployment_policy = aws.iam.Policy(
                         "events:TagResource",
                         "events:UntagResource",
                     ],
-                    "Resource": (
-                        f"arn:aws:events:{region}:{account_id}:rule/fund-*"
-                    ),
+                    "Resource": (f"arn:aws:events:{region}:{account_id}:rule/fund-*"),
                 },
                 {
                     "Sid": "ManageLambdaLogGroups",
@@ -525,8 +524,7 @@ github_actions_redeployment_policy = aws.iam.Policy(
                         "iam:UpdateAssumeRolePolicy",
                     ],
                     "Resource": (
-                        f"arn:aws:iam::{account_id}:role"
-                        "/fund-redeployment-lambda-role"
+                        f"arn:aws:iam::{account_id}:role/fund-redeployment-lambda-role"
                     ),
                     "Condition": {
                         "StringLikeIfExists": {
@@ -542,8 +540,7 @@ github_actions_redeployment_policy = aws.iam.Policy(
                         "iam:PutRolePolicy",
                     ],
                     "Resource": (
-                        f"arn:aws:iam::{account_id}:role"
-                        "/fund-redeployment-lambda-role"
+                        f"arn:aws:iam::{account_id}:role/fund-redeployment-lambda-role"
                     ),
                     "Condition": {
                         "StringEquals": {

--- a/infrastructure/iam.py
+++ b/infrastructure/iam.py
@@ -445,6 +445,120 @@ github_actions_trainer_policy = aws.iam.Policy(
     tags=tags,
 )
 
+github_actions_redeployment_policy = aws.iam.Policy(
+    "github_actions_redeployment_policy",
+    name="fund-github-actions-redeployment-policy",
+    description="Redeployment infrastructure permissions for GitHub Actions deployments.",
+    policy=json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "ReadLambdaAndEventBridgeMetadata",
+                    "Effect": "Allow",
+                    "Action": [
+                        "lambda:Get*",
+                        "lambda:List*",
+                        "events:Describe*",
+                        "events:List*",
+                    ],
+                    "Resource": "*",
+                },
+                {
+                    "Sid": "ManageLambdaFunctions",
+                    "Effect": "Allow",
+                    "Action": "lambda:*",
+                    "Resource": (
+                        f"arn:aws:lambda:{region}:{account_id}:function:fund-*"
+                    ),
+                },
+                {
+                    "Sid": "ManageEventBridgeRules",
+                    "Effect": "Allow",
+                    "Action": [
+                        "events:DeleteRule",
+                        "events:DescribeRule",
+                        "events:DisableRule",
+                        "events:EnableRule",
+                        "events:ListTagsForResource",
+                        "events:ListTargetsByRule",
+                        "events:PutRule",
+                        "events:PutTargets",
+                        "events:RemoveTargets",
+                        "events:TagResource",
+                        "events:UntagResource",
+                    ],
+                    "Resource": (
+                        f"arn:aws:events:{region}:{account_id}:rule/fund-*"
+                    ),
+                },
+                {
+                    "Sid": "ManageLambdaLogGroups",
+                    "Effect": "Allow",
+                    "Action": "logs:*",
+                    "Resource": [
+                        f"arn:aws:logs:{region}:{account_id}:log-group:/aws/lambda/fund-*",
+                        f"arn:aws:logs:{region}:{account_id}:log-group:/aws/lambda/fund-*:*",
+                    ],
+                },
+                {
+                    "Sid": "CreateRedeploymentRole",
+                    "Effect": "Allow",
+                    "Action": "iam:CreateRole",
+                    "Resource": "*",
+                    "Condition": {
+                        "StringEquals": {
+                            "iam:RoleName": "fund-redeployment-lambda-role",
+                        }
+                    },
+                },
+                {
+                    "Sid": "ManageRedeploymentRole",
+                    "Effect": "Allow",
+                    "Action": [
+                        "iam:AttachRolePolicy",
+                        "iam:DeleteRole",
+                        "iam:DetachRolePolicy",
+                        "iam:PassRole",
+                        "iam:TagRole",
+                        "iam:UntagRole",
+                        "iam:UpdateAssumeRolePolicy",
+                    ],
+                    "Resource": (
+                        f"arn:aws:iam::{account_id}:role"
+                        "/fund-redeployment-lambda-role"
+                    ),
+                    "Condition": {
+                        "StringLikeIfExists": {
+                            "iam:PassedToService": "lambda.amazonaws.com",
+                        },
+                    },
+                },
+                {
+                    "Sid": "ManageRedeploymentInlinePolicy",
+                    "Effect": "Allow",
+                    "Action": [
+                        "iam:DeleteRolePolicy",
+                        "iam:PutRolePolicy",
+                    ],
+                    "Resource": (
+                        f"arn:aws:iam::{account_id}:role"
+                        "/fund-redeployment-lambda-role"
+                    ),
+                    "Condition": {
+                        "StringEquals": {
+                            "iam:PolicyName": "fund-redeployment-lambda-policy",
+                        }
+                    },
+                },
+            ],
+        },
+        sort_keys=True,
+    ),
+    opts=pulumi.ResourceOptions(retain_on_delete=True),
+    tags=tags,
+)
+
 github_actions_infrastructure_role = aws.iam.Role(
     "github_actions_infrastructure_role",
     name=github_actions_role_name,
@@ -478,6 +592,7 @@ github_actions_infrastructure_role = aws.iam.Role(
     ),
     managed_policy_arns=[
         github_actions_infrastructure_policy.arn,
+        github_actions_redeployment_policy.arn,
         github_actions_trainer_policy.arn,
     ],
     opts=pulumi.ResourceOptions(retain_on_delete=True),

--- a/infrastructure/redeployment.py
+++ b/infrastructure/redeployment.py
@@ -58,10 +58,10 @@ aws.iam.RolePolicy(
                             "logs:CreateLogStream",
                             "logs:PutLogEvents",
                         ],
-                        "Resource": (
-                            f"arn:aws:logs:{region}:{account_id}"
-                            ":log-group:/aws/lambda/fund-redeploy-ensemble-manager*"
-                        ),
+                        "Resource": [
+                            f"arn:aws:logs:{region}:{account_id}:log-group:/aws/lambda/fund-redeploy-ensemble-manager",
+                            f"arn:aws:logs:{region}:{account_id}:log-group:/aws/lambda/fund-redeploy-ensemble-manager:log-stream:*",
+                        ],
                     },
                 ],
             },
@@ -83,6 +83,7 @@ aws.cloudwatch.LogGroup(
 _handler_code = textwrap.dedent("""\
     import json
     import os
+    from typing import Any
 
     import boto3
 
@@ -93,7 +94,7 @@ _handler_code = textwrap.dedent("""\
     REQUIRED_PREFIX = "artifacts/tide/"
 
 
-    def handler(event, context):
+    def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
         detail = event.get("detail", {})
         key = detail.get("object", {}).get("key", "")
 
@@ -143,7 +144,9 @@ model_artifact_uploaded_rule = aws.cloudwatch.EventRule(
                 "detail-type": ["Object Created"],
                 "detail": {
                     "bucket": {"name": [bucket_name]},
-                    "object": {"key": [{"suffix": "model.tar.gz"}]},
+                    "object": {
+                        "key": [{"prefix": "artifacts/tide/", "suffix": "model.tar.gz"}]
+                    },
                 },
             },
             sort_keys=True,

--- a/infrastructure/redeployment.py
+++ b/infrastructure/redeployment.py
@@ -1,0 +1,169 @@
+import json
+import textwrap
+
+import pulumi
+import pulumi_aws as aws
+from compute import cluster, ensemble_manager_service
+from config import account_id, region, tags
+from storage import model_artifacts_bucket
+
+# Enable EventBridge notifications on the model artifacts bucket so S3
+# publishes "Object Created" events to the default event bus.
+aws.s3.BucketNotification(
+    "model_artifacts_eventbridge_notification",
+    bucket=model_artifacts_bucket.id,
+    eventbridge=True,
+)
+
+# IAM role for the redeployment Lambda function.
+redeployment_lambda_role = aws.iam.Role(
+    "redeployment_lambda_role",
+    name="fund-redeployment-lambda-role",
+    assume_role_policy=json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Effect": "Allow",
+                    "Principal": {"Service": "lambda.amazonaws.com"},
+                }
+            ],
+        },
+        sort_keys=True,
+    ),
+    tags=tags,
+)
+
+# Inline policy: allow ecs:UpdateService on the ensemble-manager service and
+# CloudWatch Logs write access for the Lambda log group.
+aws.iam.RolePolicy(
+    "redeployment_lambda_policy",
+    name="fund-redeployment-lambda-policy",
+    role=redeployment_lambda_role.id,
+    policy=ensemble_manager_service.id.apply(
+        lambda service_arn: json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "ecs:UpdateService",
+                        "Resource": service_arn,
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "logs:CreateLogGroup",
+                            "logs:CreateLogStream",
+                            "logs:PutLogEvents",
+                        ],
+                        "Resource": (
+                            f"arn:aws:logs:{region}:{account_id}"
+                            ":log-group:/aws/lambda/fund-redeploy-ensemble-manager*"
+                        ),
+                    },
+                ],
+            },
+            sort_keys=True,
+        )
+    ),
+)
+
+# CloudWatch log group for the Lambda function.
+aws.cloudwatch.LogGroup(
+    "redeployment_lambda_logs",
+    name="/aws/lambda/fund-redeploy-ensemble-manager",
+    retention_in_days=7,
+    tags=tags,
+)
+
+# Inline Lambda handler that validates the S3 key prefix and forces a new
+# deployment on the ensemble-manager ECS service.
+_handler_code = textwrap.dedent("""\
+    import json
+    import os
+
+    import boto3
+
+    ecs = boto3.client("ecs")
+
+    CLUSTER = os.environ["ECS_CLUSTER_NAME"]
+    SERVICE = os.environ["ECS_SERVICE_NAME"]
+    REQUIRED_PREFIX = "artifacts/tide/"
+
+
+    def handler(event, context):
+        detail = event.get("detail", {})
+        key = detail.get("object", {}).get("key", "")
+
+        if not key.startswith(REQUIRED_PREFIX):
+            print(f"Skipping key outside required prefix: {key}")
+            return {"statusCode": 200, "body": "skipped"}
+
+        print(f"New model artifact detected: {key}")
+        response = ecs.update_service(
+            cluster=CLUSTER,
+            service=SERVICE,
+            forceNewDeployment=True,
+        )
+        status = response["service"]["status"]
+        print(f"Forced new deployment, service status: {status}")
+        return {"statusCode": 200, "body": json.dumps({"status": status})}
+""")
+
+redeployment_lambda = aws.lambda_.Function(
+    "redeployment_lambda",
+    name="fund-redeploy-ensemble-manager",
+    runtime="python3.12",
+    handler="index.handler",
+    memory_size=128,
+    timeout=30,
+    role=redeployment_lambda_role.arn,
+    code=pulumi.AssetArchive({"index.py": pulumi.StringAsset(_handler_code)}),
+    environment=aws.lambda_.FunctionEnvironmentArgs(
+        variables={
+            "ECS_CLUSTER_NAME": cluster.name,
+            "ECS_SERVICE_NAME": ensemble_manager_service.name,
+        },
+    ),
+    tags=tags,
+)
+
+# EventBridge rule: match S3 "Object Created" events for model.tar.gz files
+# in the model artifacts bucket.
+model_artifact_uploaded_rule = aws.cloudwatch.EventRule(
+    "model_artifact_uploaded_rule",
+    name="fund-model-artifact-uploaded",
+    description="Triggers when a new model artifact is uploaded to S3",
+    event_pattern=model_artifacts_bucket.bucket.apply(
+        lambda bucket_name: json.dumps(
+            {
+                "source": ["aws.s3"],
+                "detail-type": ["Object Created"],
+                "detail": {
+                    "bucket": {"name": [bucket_name]},
+                    "object": {"key": [{"suffix": "model.tar.gz"}]},
+                },
+            },
+            sort_keys=True,
+        )
+    ),
+    tags=tags,
+)
+
+# EventBridge target: invoke the redeployment Lambda when the rule matches.
+aws.cloudwatch.EventTarget(
+    "model_artifact_uploaded_target",
+    rule=model_artifact_uploaded_rule.name,
+    arn=redeployment_lambda.arn,
+)
+
+# Allow EventBridge to invoke the Lambda function.
+aws.lambda_.Permission(
+    "redeployment_lambda_eventbridge_permission",
+    action="lambda:InvokeFunction",
+    function=redeployment_lambda.name,
+    principal="events.amazonaws.com",
+    source_arn=model_artifact_uploaded_rule.arn,
+)

--- a/notes.md
+++ b/notes.md
@@ -1,7 +1,0 @@
-## cleanups
-fix prefect, needs to run nightly
-
-## data fetch
-is it working appropriately?
-
-## 

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,7 @@
+## cleanups
+fix prefect, needs to run nightly
+
+## data fetch
+is it working appropriately?
+
+## 


### PR DESCRIPTION
This pull request introduces infrastructure to automate redeployment of the `ensemble-manager` ECS service when a new model artifact is uploaded to S3. The main changes include creating a new Lambda function triggered by S3 events via EventBridge, defining the necessary IAM roles and policies, and exporting the Lambda ARN for use in other parts of the stack.

**Redeployment automation infrastructure:**

* Added `infrastructure/redeployment.py` to define a Lambda function (`fund-redeploy-ensemble-manager`) that listens for S3 "Object Created" events for new model artifacts and triggers a force redeployment of the `ensemble-manager` ECS service. This includes S3 bucket notifications, EventBridge rule/target, Lambda code, and permissions.
* Imported the redeployment Lambda in `infrastructure/__main__.py` and exported its ARN as `aws_lambda_redeployment_arn` for downstream use. [[1]](diffhunk://#diff-77101562d6a4ace19bd6cca445edb26347fdb6760d861e91e5f95b7675370261R18) [[2]](diffhunk://#diff-77101562d6a4ace19bd6cca445edb26347fdb6760d861e91e5f95b7675370261R85)

**IAM roles and permissions:**

* Created a new IAM policy (`github_actions_redeployment_policy`) granting GitHub Actions permissions to manage redeployment-related Lambda functions, EventBridge rules, and associated log groups/roles.
* Attached the new redeployment policy to the `github_actions_infrastructure_role` so GitHub Actions workflows can manage the redeployment infrastructure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure to enable automated service redeployment triggered when model artifacts are uploaded.
  * Established event-driven automation pipeline connecting artifact uploads to automatic deployment workflows.
  * Enhanced AWS permissions and infrastructure configuration to support continuous deployment of model service updates without requiring manual intervention.
  * Added automated monitoring and logging for deployment operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->