### PR TITLE
Add fixes/tests for service schedules

### DIFF
--- a/applications/data_manager/src/equity_bars.rs
+++ b/applications/data_manager/src/equity_bars.rs
@@ -155,7 +155,11 @@ pub async fn fetch_and_store(
     let text_content = response
         .error_for_status()
         .map_err(|err| {
-            warn!("API request failed with status code: {:?}", err.status());
+            warn!(
+                "API request failed with status code {:?}: {}",
+                err.status(),
+                err.without_url()
+            );
             "API request failed".to_string()
         })?
         .text()

--- a/applications/data_manager/src/equity_bars.rs
+++ b/applications/data_manager/src/equity_bars.rs
@@ -155,10 +155,7 @@ pub async fn fetch_and_store(
     let text_content = response
         .error_for_status()
         .map_err(|err| {
-            warn!(
-                "API request failed with error status: {}",
-                err.without_url()
-            );
+            warn!("API request failed with status code: {:?}", err.status());
             "API request failed".to_string()
         })?
         .text()

--- a/applications/data_manager/src/scheduler.rs
+++ b/applications/data_manager/src/scheduler.rs
@@ -1,17 +1,24 @@
 use crate::equity_bars::fetch_and_store;
 use crate::state::State;
-use chrono::{Datelike, NaiveTime, TimeZone, Utc, Weekday};
+use chrono::{DateTime, Datelike, NaiveDate, NaiveTime, TimeZone, Utc, Weekday};
 use chrono_tz::US::Eastern;
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing::{error, info};
 
-const SYNC_HOUR: u32 = 18;
+const SYNC_HOUR: u32 = 1;
 const SYNC_MINUTE: u32 = 0;
 
-fn duration_until_next_sync() -> Duration {
-    let now_utc = Utc::now();
-    let now_eastern = now_utc.with_timezone(&Eastern);
+fn prior_trading_day(date: NaiveDate) -> NaiveDate {
+    let mut prior = date.pred_opt().unwrap();
+    while matches!(prior.weekday(), Weekday::Sat | Weekday::Sun) {
+        prior = prior.pred_opt().unwrap();
+    }
+    prior
+}
+
+fn duration_until_next_sync(now: DateTime<Utc>) -> Duration {
+    let now_eastern = now.with_timezone(&Eastern);
     let sync_time = NaiveTime::from_hms_opt(SYNC_HOUR, SYNC_MINUTE, 0).unwrap();
 
     let mut target_date = now_eastern.date_naive();
@@ -36,9 +43,13 @@ fn duration_until_next_sync() -> Duration {
             .unwrap();
     }
 
-    (target_eastern.with_timezone(&Utc) - now_utc)
+    (target_eastern.with_timezone(&Utc) - now)
         .to_std()
         .unwrap_or(Duration::ZERO)
+}
+
+fn sync_date_for(now: DateTime<Utc>) -> NaiveDate {
+    prior_trading_day(now.with_timezone(&Eastern).date_naive())
 }
 
 pub fn spawn_sync_scheduler(state: State) {
@@ -47,7 +58,7 @@ pub fn spawn_sync_scheduler(state: State) {
 
 async fn sync_loop(state: State) {
     loop {
-        let wait_duration = duration_until_next_sync();
+        let wait_duration = duration_until_next_sync(Utc::now());
         info!(
             "Waiting for next equity bar sync, seconds_until_sync: {}",
             wait_duration.as_secs()
@@ -61,17 +72,27 @@ async fn sync_loop(state: State) {
             continue;
         }
 
+        let sync_date = sync_date_for(now_utc);
+        let sync_noon_eastern = Eastern
+            .from_local_datetime(&sync_date.and_hms_opt(12, 0, 0).unwrap())
+            .earliest()
+            .unwrap();
+        let sync_utc = sync_noon_eastern.with_timezone(&Utc);
+
         info!(
             "Starting scheduled equity bar sync for {}",
-            now_eastern.format("%Y-%m-%d")
+            sync_date.format("%Y-%m-%d")
         );
 
-        match fetch_and_store(&state, &now_utc).await {
+        match fetch_and_store(&state, &sync_utc).await {
             Ok(Some(s3_key)) => {
                 info!("Scheduled equity bar sync completed, s3_key: {}", s3_key);
             }
             Ok(None) => {
-                info!("No equity bar data available for today");
+                info!(
+                    "No equity bar data available for sync date {}",
+                    sync_date.format("%Y-%m-%d")
+                );
             }
             Err(err) => {
                 error!("Scheduled equity bar sync failed: {}", err);
@@ -82,11 +103,14 @@ async fn sync_loop(state: State) {
 
 #[cfg(test)]
 mod tests {
-    use super::duration_until_next_sync;
+    use super::{duration_until_next_sync, prior_trading_day, sync_date_for};
+    use chrono::{NaiveDate, TimeZone, Utc};
+    use chrono_tz::US::Eastern;
+    use std::time::Duration;
 
     #[test]
     fn test_duration_until_next_sync_is_positive() {
-        let duration = duration_until_next_sync();
+        let duration = duration_until_next_sync(Utc::now());
         assert!(
             duration.as_secs() > 0,
             "Expected positive wait time, got {:?}",
@@ -96,12 +120,119 @@ mod tests {
 
     #[test]
     fn test_duration_until_next_sync_is_within_one_week() {
-        let duration = duration_until_next_sync();
+        let duration = duration_until_next_sync(Utc::now());
         let one_week = std::time::Duration::from_secs(7 * 24 * 60 * 60);
         assert!(
             duration <= one_week,
             "Expected wait time within one week, got {:?}",
             duration
         );
+    }
+
+    #[test]
+    fn test_prior_trading_day_wednesday_returns_tuesday() {
+        let wednesday = NaiveDate::from_ymd_opt(2026, 4, 29).unwrap();
+        let prior = prior_trading_day(wednesday);
+        assert_eq!(prior, NaiveDate::from_ymd_opt(2026, 4, 28).unwrap());
+    }
+
+    #[test]
+    fn test_prior_trading_day_monday_returns_friday() {
+        let monday = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+        let prior = prior_trading_day(monday);
+        assert_eq!(prior, NaiveDate::from_ymd_opt(2026, 4, 24).unwrap());
+    }
+
+    #[test]
+    fn test_prior_trading_day_tuesday_returns_monday() {
+        let tuesday = NaiveDate::from_ymd_opt(2026, 4, 28).unwrap();
+        let prior = prior_trading_day(tuesday);
+        assert_eq!(prior, NaiveDate::from_ymd_opt(2026, 4, 27).unwrap());
+    }
+
+    // --- duration_until_next_sync with injected now ---
+
+    #[test]
+    fn test_duration_until_next_sync_fires_within_one_minute_just_before_1am_et() {
+        // Monday 2026-04-27 at 00:59 ET — should fire in ≤ 60 seconds
+        let now = Eastern
+            .with_ymd_and_hms(2026, 4, 27, 0, 59, 0)
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = duration_until_next_sync(now);
+        assert!(
+            duration.as_secs() <= 60,
+            "Expected ≤ 60s, got {:?}",
+            duration
+        );
+    }
+
+    #[test]
+    fn test_duration_until_next_sync_after_1am_waits_until_next_weekday() {
+        // Monday 2026-04-27 at 02:00 ET — next fire is Tuesday 2026-04-28 at 01:00 ET (~23h)
+        let now = Eastern
+            .with_ymd_and_hms(2026, 4, 27, 2, 0, 0)
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = duration_until_next_sync(now);
+        let twenty_two_hours = Duration::from_secs(22 * 3600);
+        let twenty_four_hours = Duration::from_secs(24 * 3600);
+        assert!(
+            duration > twenty_two_hours && duration < twenty_four_hours,
+            "Expected ~23h, got {:?}",
+            duration
+        );
+    }
+
+    #[test]
+    fn test_duration_until_next_sync_from_friday_skips_to_monday() {
+        // Friday 2026-05-01 at 02:00 ET — next fire is Monday 2026-05-04 at 01:00 ET (~71h)
+        let now = Eastern
+            .with_ymd_and_hms(2026, 5, 1, 2, 0, 0)
+            .unwrap()
+            .with_timezone(&Utc);
+        let duration = duration_until_next_sync(now);
+        let seventy_hours = Duration::from_secs(70 * 3600);
+        let seventy_two_hours = Duration::from_secs(72 * 3600);
+        assert!(
+            duration > seventy_hours && duration < seventy_two_hours,
+            "Expected ~71h, got {:?}",
+            duration
+        );
+    }
+
+    // --- sync_date_for with injected now ---
+
+    #[test]
+    fn test_sync_date_for_tuesday_fire_is_monday() {
+        // Tuesday 2026-04-28 at 01:00 ET — should sync Monday 2026-04-27
+        let now = Eastern
+            .with_ymd_and_hms(2026, 4, 28, 1, 0, 0)
+            .unwrap()
+            .with_timezone(&Utc);
+        let sync_date = sync_date_for(now);
+        assert_eq!(sync_date, NaiveDate::from_ymd_opt(2026, 4, 27).unwrap());
+    }
+
+    #[test]
+    fn test_sync_date_for_monday_fire_is_friday() {
+        // Monday 2026-04-27 at 01:00 ET — should sync Friday 2026-04-24
+        let now = Eastern
+            .with_ymd_and_hms(2026, 4, 27, 1, 0, 0)
+            .unwrap()
+            .with_timezone(&Utc);
+        let sync_date = sync_date_for(now);
+        assert_eq!(sync_date, NaiveDate::from_ymd_opt(2026, 4, 24).unwrap());
+    }
+
+    #[test]
+    fn test_sync_date_for_wednesday_fire_is_tuesday() {
+        // Wednesday 2026-04-29 at 01:00 ET — should sync Tuesday 2026-04-28
+        let now = Eastern
+            .with_ymd_and_hms(2026, 4, 29, 1, 0, 0)
+            .unwrap()
+            .with_timezone(&Utc);
+        let sync_date = sync_date_for(now);
+        assert_eq!(sync_date, NaiveDate::from_ymd_opt(2026, 4, 28).unwrap());
     }
 }

--- a/applications/portfolio_manager/src/portfolio_manager/server.py
+++ b/applications/portfolio_manager/src/portfolio_manager/server.py
@@ -17,7 +17,9 @@ from .metrics import (
 from .rebalance import DATA_MANAGER_BASE_URL, run_rebalance
 from .scheduler import spawn_rebalance_scheduler
 
-logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
+logging.basicConfig(
+    level=logging.INFO, stream=sys.stdout, format="%(message)s", force=True
+)
 
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),

--- a/applications/portfolio_manager/src/portfolio_manager/server.py
+++ b/applications/portfolio_manager/src/portfolio_manager/server.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import sys
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -15,6 +16,8 @@ from .metrics import (
 )
 from .rebalance import DATA_MANAGER_BASE_URL, run_rebalance
 from .scheduler import spawn_rebalance_scheduler
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(message)s")
 
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),

--- a/applications/portfolio_manager/tests/test_metrics.py
+++ b/applications/portfolio_manager/tests/test_metrics.py
@@ -1,0 +1,30 @@
+import time
+
+from fastapi import Response
+from portfolio_manager.metrics import get_metrics, observe_duration, start_timer
+
+
+def test_get_metrics_returns_response() -> None:
+    result = get_metrics()
+
+    assert isinstance(result, Response)
+    assert result.media_type == "text/plain; version=0.0.4; charset=utf-8"
+    assert result.body is not None
+
+
+def test_start_timer_returns_float() -> None:
+    result = start_timer()
+
+    assert isinstance(result, float)
+    assert result > 0
+
+
+def test_observe_duration_accepts_start_timer_value() -> None:
+    start = start_timer()
+    time.sleep(0.01)
+
+    observe_duration(start)
+
+
+def test_observe_duration_accepts_zero_start() -> None:
+    observe_duration(0.0)

--- a/applications/portfolio_manager/tests/test_scheduler.py
+++ b/applications/portfolio_manager/tests/test_scheduler.py
@@ -5,6 +5,7 @@ from zoneinfo import ZoneInfo
 
 from portfolio_manager.scheduler import (
     _already_rebalanced_today,
+    _rebalance_loop,
     _seconds_until_next_rebalance,
 )
 
@@ -212,3 +213,113 @@ def test_already_rebalanced_today_returns_false_when_timestamp_field_is_missing(
         result = asyncio.run(_already_rebalanced_today("http://data-manager:8080"))
 
     assert result is False
+
+
+# --- _rebalance_loop ---
+
+
+def _run_loop(
+    mock_alpaca: MagicMock,
+    mock_sleep_side_effect: list,
+    frozen_now: datetime,
+    *,
+    already_rebalanced: bool = False,
+    market_open: bool = True,
+) -> AsyncMock:
+    """Run one pass of the rebalance loop and return the run_rebalance mock."""
+    mock_alpaca.is_market_open.return_value = market_open
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_run_rebalance = AsyncMock(return_value=mock_response)
+
+    async def run() -> None:
+        lock = asyncio.Lock()
+        await _rebalance_loop(mock_alpaca, "http://data-manager:8080", lock)
+
+    with (
+        patch("portfolio_manager.scheduler.datetime") as mock_dt,
+        patch(
+            "portfolio_manager.scheduler._already_rebalanced_today",
+            AsyncMock(return_value=already_rebalanced),
+        ),
+        patch("portfolio_manager.scheduler.run_rebalance", mock_run_rebalance),
+        patch("asyncio.sleep", AsyncMock(side_effect=mock_sleep_side_effect)),
+    ):
+        mock_dt.now.return_value = frozen_now
+        mock_dt.fromtimestamp.side_effect = datetime.fromtimestamp
+        asyncio.run(run())
+
+    return mock_run_rebalance
+
+
+def test_rebalance_loop_fires_immediately_on_catch_up() -> None:
+    # Tuesday 10:05 AM ET — past the 10:00 trigger, not yet rebalanced today.
+    # Catch-up fires without sleeping; first sleep after the rebalance stops the loop.
+    frozen_now = _make_eastern_datetime(weekday_offset=1, hour=10, minute=5).astimezone(
+        UTC
+    )
+    mock_alpaca = MagicMock()
+
+    mock_run_rebalance = _run_loop(
+        mock_alpaca=mock_alpaca,
+        frozen_now=frozen_now,
+        mock_sleep_side_effect=[asyncio.CancelledError()],
+        already_rebalanced=False,
+        market_open=True,
+    )
+
+    mock_run_rebalance.assert_called_once()
+
+
+def test_rebalance_loop_fires_after_sleeping_when_started_before_window() -> None:
+    # Monday 09:00 AM ET — before 10:00, so the loop sleeps first, then rebalances.
+    # First sleep resolves normally; second sleep stops the loop.
+    frozen_now = _make_eastern_datetime(weekday_offset=0, hour=9).astimezone(UTC)
+    mock_alpaca = MagicMock()
+
+    mock_run_rebalance = _run_loop(
+        mock_alpaca=mock_alpaca,
+        frozen_now=frozen_now,
+        mock_sleep_side_effect=[None, asyncio.CancelledError()],
+        already_rebalanced=False,
+        market_open=True,
+    )
+
+    mock_run_rebalance.assert_called_once()
+
+
+def test_rebalance_loop_skips_when_market_is_closed() -> None:
+    # Tuesday 10:05 AM ET — catch-up fires, but market is closed → no rebalance.
+    frozen_now = _make_eastern_datetime(weekday_offset=1, hour=10, minute=5).astimezone(
+        UTC
+    )
+    mock_alpaca = MagicMock()
+
+    mock_run_rebalance = _run_loop(
+        mock_alpaca=mock_alpaca,
+        frozen_now=frozen_now,
+        mock_sleep_side_effect=[asyncio.CancelledError()],
+        already_rebalanced=False,
+        market_open=False,
+    )
+
+    mock_run_rebalance.assert_not_called()
+
+
+def test_rebalance_loop_skips_when_already_rebalanced_today() -> None:
+    # Tuesday 10:05 AM ET — catch-up check finds today's rebalance already done.
+    frozen_now = _make_eastern_datetime(weekday_offset=1, hour=10, minute=5).astimezone(
+        UTC
+    )
+    mock_alpaca = MagicMock()
+
+    mock_run_rebalance = _run_loop(
+        mock_alpaca=mock_alpaca,
+        frozen_now=frozen_now,
+        mock_sleep_side_effect=[asyncio.CancelledError()],
+        already_rebalanced=True,
+        market_open=True,
+    )
+
+    mock_run_rebalance.assert_not_called()

--- a/applications/portfolio_manager/tests/test_scheduler.py
+++ b/applications/portfolio_manager/tests/test_scheduler.py
@@ -220,7 +220,7 @@ def test_already_rebalanced_today_returns_false_when_timestamp_field_is_missing(
 
 def _run_loop(
     mock_alpaca: MagicMock,
-    mock_sleep_side_effect: list,
+    mock_sleep_side_effect: list[BaseException | None],
     frozen_now: datetime,
     *,
     already_rebalanced: bool = False,
@@ -319,6 +319,182 @@ def test_rebalance_loop_skips_when_already_rebalanced_today() -> None:
         frozen_now=frozen_now,
         mock_sleep_side_effect=[asyncio.CancelledError()],
         already_rebalanced=True,
+        market_open=True,
+    )
+
+    mock_run_rebalance.assert_not_called()
+
+
+def test_rebalance_loop_skips_on_weekend_in_loop() -> None:
+    # Saturday 09:00 AM ET — catch_up=False (weekend), loop sleeps, in-loop weekend
+    # check skips, second sleep cancels.
+    frozen_now = _make_eastern_datetime(weekday_offset=5, hour=9).astimezone(UTC)
+    mock_alpaca = MagicMock()
+
+    mock_run_rebalance = _run_loop(
+        mock_alpaca=mock_alpaca,
+        frozen_now=frozen_now,
+        mock_sleep_side_effect=[None, asyncio.CancelledError()],
+        already_rebalanced=False,
+        market_open=True,
+    )
+
+    mock_run_rebalance.assert_not_called()
+
+
+def test_rebalance_loop_skips_when_already_rebalanced_in_loop() -> None:
+    # Monday 09:00 AM ET — before the 10:00 window so catch_up=False; after
+    # sleeping, the in-loop already-rebalanced check returns True → skip.
+    frozen_now = _make_eastern_datetime(weekday_offset=0, hour=9).astimezone(UTC)
+    mock_alpaca = MagicMock()
+
+    mock_run_rebalance = _run_loop(
+        mock_alpaca=mock_alpaca,
+        frozen_now=frozen_now,
+        mock_sleep_side_effect=[None, asyncio.CancelledError()],
+        already_rebalanced=True,
+        market_open=True,
+    )
+
+    mock_run_rebalance.assert_not_called()
+
+
+def test_rebalance_loop_skips_when_lock_is_held() -> None:
+    # Tuesday 10:05 AM ET — catch-up fires but the rebalance lock is already held.
+    frozen_now = _make_eastern_datetime(weekday_offset=1, hour=10, minute=5).astimezone(
+        UTC
+    )
+    mock_alpaca = MagicMock()
+    mock_alpaca.is_market_open.return_value = True
+    mock_run_rebalance = AsyncMock()
+
+    async def run() -> None:
+        lock = asyncio.Lock()
+        await lock.acquire()
+        await _rebalance_loop(mock_alpaca, "http://data-manager:8080", lock)
+
+    with (
+        patch("portfolio_manager.scheduler.datetime") as mock_dt,
+        patch(
+            "portfolio_manager.scheduler._already_rebalanced_today",
+            AsyncMock(return_value=False),
+        ),
+        patch("portfolio_manager.scheduler.run_rebalance", mock_run_rebalance),
+        patch("asyncio.sleep", AsyncMock(side_effect=[asyncio.CancelledError()])),
+    ):
+        mock_dt.now.return_value = frozen_now
+        mock_dt.fromtimestamp.side_effect = datetime.fromtimestamp
+        asyncio.run(run())
+
+    mock_run_rebalance.assert_not_called()
+
+
+def test_rebalance_loop_handles_market_open_exception() -> None:
+    # Tuesday 10:05 AM ET — catch-up fires; is_market_open raises; sentry notified.
+    frozen_now = _make_eastern_datetime(weekday_offset=1, hour=10, minute=5).astimezone(
+        UTC
+    )
+    mock_alpaca = MagicMock()
+    mock_alpaca.is_market_open.side_effect = Exception("market check failed")
+    mock_run_rebalance = AsyncMock()
+
+    async def run() -> None:
+        lock = asyncio.Lock()
+        await _rebalance_loop(mock_alpaca, "http://data-manager:8080", lock)
+
+    with (
+        patch("portfolio_manager.scheduler.datetime") as mock_dt,
+        patch(
+            "portfolio_manager.scheduler._already_rebalanced_today",
+            AsyncMock(return_value=False),
+        ),
+        patch("portfolio_manager.scheduler.run_rebalance", mock_run_rebalance),
+        patch("asyncio.sleep", AsyncMock(side_effect=[asyncio.CancelledError()])),
+        patch("portfolio_manager.scheduler.sentry_sdk") as mock_sentry,
+    ):
+        mock_dt.now.return_value = frozen_now
+        mock_dt.fromtimestamp.side_effect = datetime.fromtimestamp
+        asyncio.run(run())
+
+    mock_run_rebalance.assert_not_called()
+    mock_sentry.capture_exception.assert_called_once()
+
+
+def test_rebalance_loop_handles_run_rebalance_exception() -> None:
+    # Tuesday 10:05 AM ET — catch-up fires; run_rebalance raises; sentry notified.
+    frozen_now = _make_eastern_datetime(weekday_offset=1, hour=10, minute=5).astimezone(
+        UTC
+    )
+    mock_alpaca = MagicMock()
+    mock_alpaca.is_market_open.return_value = True
+    mock_run_rebalance = AsyncMock(side_effect=Exception("rebalance failed"))
+
+    async def run() -> None:
+        lock = asyncio.Lock()
+        await _rebalance_loop(mock_alpaca, "http://data-manager:8080", lock)
+
+    with (
+        patch("portfolio_manager.scheduler.datetime") as mock_dt,
+        patch(
+            "portfolio_manager.scheduler._already_rebalanced_today",
+            AsyncMock(return_value=False),
+        ),
+        patch("portfolio_manager.scheduler.run_rebalance", mock_run_rebalance),
+        patch("asyncio.sleep", AsyncMock(side_effect=[asyncio.CancelledError()])),
+        patch("portfolio_manager.scheduler.sentry_sdk") as mock_sentry,
+    ):
+        mock_dt.now.return_value = frozen_now
+        mock_dt.fromtimestamp.side_effect = datetime.fromtimestamp
+        asyncio.run(run())
+
+    mock_run_rebalance.assert_called_once()
+    mock_sentry.capture_exception.assert_called_once()
+
+
+def test_rebalance_loop_logs_warning_on_non_200_response() -> None:
+    # Tuesday 10:05 AM ET — catch-up fires; run_rebalance returns non-200.
+    frozen_now = _make_eastern_datetime(weekday_offset=1, hour=10, minute=5).astimezone(
+        UTC
+    )
+    mock_alpaca = MagicMock()
+    mock_alpaca.is_market_open.return_value = True
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    mock_run_rebalance = AsyncMock(return_value=mock_response)
+
+    async def run() -> None:
+        lock = asyncio.Lock()
+        await _rebalance_loop(mock_alpaca, "http://data-manager:8080", lock)
+
+    with (
+        patch("portfolio_manager.scheduler.datetime") as mock_dt,
+        patch(
+            "portfolio_manager.scheduler._already_rebalanced_today",
+            AsyncMock(return_value=False),
+        ),
+        patch("portfolio_manager.scheduler.run_rebalance", mock_run_rebalance),
+        patch("asyncio.sleep", AsyncMock(side_effect=[asyncio.CancelledError()])),
+        patch("portfolio_manager.scheduler.logger") as mock_logger,
+    ):
+        mock_dt.now.return_value = frozen_now
+        mock_dt.fromtimestamp.side_effect = datetime.fromtimestamp
+        asyncio.run(run())
+
+    mock_run_rebalance.assert_called_once()
+    mock_logger.warning.assert_called_once()
+
+
+def test_rebalance_loop_retries_after_unexpected_error() -> None:
+    # Monday 09:00 AM ET — before window so catch_up=False; first sleep raises an
+    # unexpected error caught by the outer except, loop retries; second sleep cancels.
+    frozen_now = _make_eastern_datetime(weekday_offset=0, hour=9).astimezone(UTC)
+    mock_alpaca = MagicMock()
+
+    mock_run_rebalance = _run_loop(
+        mock_alpaca=mock_alpaca,
+        frozen_now=frozen_now,
+        mock_sleep_side_effect=[RuntimeError("unexpected"), asyncio.CancelledError()],
+        already_rebalanced=False,
         market_open=True,
     )
 

--- a/applications/portfolio_manager/tests/test_scheduler.py
+++ b/applications/portfolio_manager/tests/test_scheduler.py
@@ -489,13 +489,31 @@ def test_rebalance_loop_retries_after_unexpected_error() -> None:
     # unexpected error caught by the outer except, loop retries; second sleep cancels.
     frozen_now = _make_eastern_datetime(weekday_offset=0, hour=9).astimezone(UTC)
     mock_alpaca = MagicMock()
+    mock_alpaca.is_market_open.return_value = True
+    mock_run_rebalance = AsyncMock()
 
-    mock_run_rebalance = _run_loop(
-        mock_alpaca=mock_alpaca,
-        frozen_now=frozen_now,
-        mock_sleep_side_effect=[RuntimeError("unexpected"), asyncio.CancelledError()],
-        already_rebalanced=False,
-        market_open=True,
-    )
+    async def run() -> None:
+        lock = asyncio.Lock()
+        await _rebalance_loop(mock_alpaca, "http://data-manager:8080", lock)
+
+    with (
+        patch("portfolio_manager.scheduler.datetime") as mock_dt,
+        patch(
+            "portfolio_manager.scheduler._already_rebalanced_today",
+            AsyncMock(return_value=False),
+        ),
+        patch("portfolio_manager.scheduler.run_rebalance", mock_run_rebalance),
+        patch(
+            "asyncio.sleep",
+            AsyncMock(
+                side_effect=[RuntimeError("unexpected"), asyncio.CancelledError()]
+            ),
+        ),
+        patch("portfolio_manager.scheduler.sentry_sdk") as mock_sentry,
+    ):
+        mock_dt.now.return_value = frozen_now
+        mock_dt.fromtimestamp.side_effect = datetime.fromtimestamp
+        asyncio.run(run())
 
     mock_run_rebalance.assert_not_called()
+    mock_sentry.capture_exception.assert_called_once()

--- a/applications/portfolio_manager/tests/test_server_app.py
+++ b/applications/portfolio_manager/tests/test_server_app.py
@@ -63,20 +63,25 @@ def test_lifespan_initializes_client_and_scheduler() -> None:
     async def run() -> None:
         # Use an already-done future: cancel() is a no-op on done futures,
         # and await returns None without raising CancelledError.
-        future: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         future.set_result(None)
 
         with (
             patch.object(server_module, "ALPACA_API_KEY_ID", "test-key"),
             patch.object(server_module, "ALPACA_API_SECRET", "test-secret"),
-            patch("portfolio_manager.server.AlpacaClient", return_value=mock_alpaca),
+            patch(
+                "portfolio_manager.server.AlpacaClient", return_value=mock_alpaca
+            ) as mock_alpaca_client,
             patch(
                 "portfolio_manager.server.spawn_rebalance_scheduler",
                 AsyncMock(return_value=future),
-            ),
+            ) as mock_spawn_scheduler,
         ):
             async with _lifespan(mock_app):
                 pass
+
+        mock_alpaca_client.assert_called_once()
+        mock_spawn_scheduler.assert_awaited_once()
 
     asyncio.run(run())
 
@@ -105,8 +110,6 @@ def test_create_portfolio_calls_run_rebalance() -> None:
     application.state.alpaca_client = mock_alpaca
 
     async def run() -> Response:
-        # asyncio.wait_for(lock.acquire(), timeout=0) raises TimeoutError even for a
-        # free lock in Python 3.12 because the task hasn't run yet when timeout fires.
         # Patch wait_for to simulate a successful lock acquisition so we can verify
         # that run_rebalance is called and the lock is released in the finally block.
         with (

--- a/applications/portfolio_manager/tests/test_server_app.py
+++ b/applications/portfolio_manager/tests/test_server_app.py
@@ -1,0 +1,126 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import portfolio_manager.server as server_module
+import pytest
+from fastapi import Response, status
+from portfolio_manager.server import (
+    _lifespan,
+    application,
+    create_portfolio,
+    health_check,
+    metrics_endpoint,
+)
+
+
+def test_health_check_returns_200() -> None:
+    response = health_check()
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_metrics_endpoint_returns_response() -> None:
+    response = metrics_endpoint()
+
+    assert isinstance(response, Response)
+    assert response.status_code == status.HTTP_200_OK
+
+
+def test_lifespan_raises_when_api_key_missing() -> None:
+    mock_app = MagicMock()
+
+    async def run() -> None:
+        async with _lifespan(mock_app):
+            pass
+
+    with (
+        patch.object(server_module, "ALPACA_API_KEY_ID", ""),
+        patch.object(server_module, "ALPACA_API_SECRET", "secret"),
+        pytest.raises(ValueError, match="ALPACA_API_KEY_ID and ALPACA_API_SECRET"),
+    ):
+        asyncio.run(run())
+
+
+def test_lifespan_raises_when_api_secret_missing() -> None:
+    mock_app = MagicMock()
+
+    async def run() -> None:
+        async with _lifespan(mock_app):
+            pass
+
+    with (
+        patch.object(server_module, "ALPACA_API_KEY_ID", "key"),
+        patch.object(server_module, "ALPACA_API_SECRET", ""),
+        pytest.raises(ValueError, match="ALPACA_API_KEY_ID and ALPACA_API_SECRET"),
+    ):
+        asyncio.run(run())
+
+
+def test_lifespan_initializes_client_and_scheduler() -> None:
+    mock_app = MagicMock()
+    mock_alpaca = MagicMock()
+
+    async def run() -> None:
+        # Use an already-done future: cancel() is a no-op on done futures,
+        # and await returns None without raising CancelledError.
+        future: asyncio.Future[None] = asyncio.get_event_loop().create_future()
+        future.set_result(None)
+
+        with (
+            patch.object(server_module, "ALPACA_API_KEY_ID", "test-key"),
+            patch.object(server_module, "ALPACA_API_SECRET", "test-secret"),
+            patch("portfolio_manager.server.AlpacaClient", return_value=mock_alpaca),
+            patch(
+                "portfolio_manager.server.spawn_rebalance_scheduler",
+                AsyncMock(return_value=future),
+            ),
+        ):
+            async with _lifespan(mock_app):
+                pass
+
+    asyncio.run(run())
+
+
+def test_create_portfolio_returns_conflict_when_lock_held() -> None:
+    async def run() -> Response:
+        with patch(
+            "portfolio_manager.server.asyncio.wait_for",
+            AsyncMock(side_effect=TimeoutError),
+        ):
+            return await create_portfolio()
+
+    response = asyncio.run(run())
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+
+
+def test_create_portfolio_calls_run_rebalance() -> None:
+    mock_alpaca = MagicMock()
+    mock_response = MagicMock(spec=Response)
+    mock_response.status_code = status.HTTP_200_OK
+    mock_run = AsyncMock(return_value=mock_response)
+    mock_lock = MagicMock()
+    mock_lock.release = MagicMock()
+
+    application.state.alpaca_client = mock_alpaca
+
+    async def run() -> Response:
+        # asyncio.wait_for(lock.acquire(), timeout=0) raises TimeoutError even for a
+        # free lock in Python 3.12 because the task hasn't run yet when timeout fires.
+        # Patch wait_for to simulate a successful lock acquisition so we can verify
+        # that run_rebalance is called and the lock is released in the finally block.
+        with (
+            patch(
+                "portfolio_manager.server.asyncio.wait_for",
+                AsyncMock(return_value=True),
+            ),
+            patch("portfolio_manager.server._rebalance_lock", mock_lock),
+            patch("portfolio_manager.server.run_rebalance", mock_run),
+        ):
+            return await create_portfolio()
+
+    response = asyncio.run(run())
+
+    assert response.status_code == status.HTTP_200_OK
+    mock_run.assert_called_once_with(mock_alpaca)
+    mock_lock.release.assert_called_once()

--- a/tools/src/tools/sync_equity_bars_data.py
+++ b/tools/src/tools/sync_equity_bars_data.py
@@ -2,9 +2,12 @@ import json
 import sys
 import time
 from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import requests
 import structlog
+
+_EASTERN = ZoneInfo("America/New_York")
 
 logger = structlog.get_logger()
 
@@ -48,7 +51,8 @@ def validate_and_parse_dates(date_range_json: str) -> tuple[datetime, datetime]:
 
 def sync_equity_bars_for_date(base_url: str, date: datetime) -> tuple[int, str]:
     url = f"{base_url}/equity-bars"
-    date_string = date.strftime("%Y-%m-%dT16:00:00Z")
+    eastern_noon = datetime(date.year, date.month, date.day, 12, 0, 0, tzinfo=_EASTERN)
+    date_string = eastern_noon.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     response = requests.post(
         url,

--- a/tools/src/tools/sync_equity_bars_data.py
+++ b/tools/src/tools/sync_equity_bars_data.py
@@ -48,7 +48,7 @@ def validate_and_parse_dates(date_range_json: str) -> tuple[datetime, datetime]:
 
 def sync_equity_bars_for_date(base_url: str, date: datetime) -> tuple[int, str]:
     url = f"{base_url}/equity-bars"
-    date_string = date.strftime("%Y-%m-%dT00:00:00Z")
+    date_string = date.strftime("%Y-%m-%dT16:00:00Z")
 
     response = requests.post(
         url,

--- a/tools/src/tools/sync_equity_bars_data.py
+++ b/tools/src/tools/sync_equity_bars_data.py
@@ -32,8 +32,9 @@ def validate_and_parse_dates(date_range_json: str) -> tuple[datetime, datetime]:
     except ValueError as e:
         raise RuntimeError from e
 
-    current_date = datetime.now(tz=UTC).replace(
-        hour=0, minute=0, second=0, microsecond=0
+    today_eastern = datetime.now(tz=_EASTERN).date()
+    current_date = datetime(
+        today_eastern.year, today_eastern.month, today_eastern.day, tzinfo=UTC
     )
     maximum_lookback_days = 365 * 2  # two year limit
 

--- a/tools/tests/test_sync_equity_bars_data.py
+++ b/tools/tests/test_sync_equity_bars_data.py
@@ -62,7 +62,7 @@ def test_sync_equity_bars_for_date_returns_status_and_body() -> None:
     mock_post.assert_called_once()
     call_kwargs = mock_post.call_args
     assert call_kwargs.args[0] == "http://localhost:8080/equity-bars"
-    assert call_kwargs.kwargs["json"]["date"] == "2025-06-01T00:00:00Z"
+    assert call_kwargs.kwargs["json"]["date"] == "2025-06-01T16:00:00Z"
 
 
 def test_sync_equity_bars_data_single_date_makes_one_request() -> None:

--- a/tools/tests/test_sync_equity_bars_data.py
+++ b/tools/tests/test_sync_equity_bars_data.py
@@ -62,7 +62,28 @@ def test_sync_equity_bars_for_date_returns_status_and_body() -> None:
     mock_post.assert_called_once()
     call_kwargs = mock_post.call_args
     assert call_kwargs.args[0] == "http://localhost:8080/equity-bars"
+    # June = EDT (UTC-4), so noon Eastern = 16:00 UTC
     assert call_kwargs.kwargs["json"]["date"] == "2025-06-01T16:00:00Z"
+
+
+def test_sync_equity_bars_for_date_uses_correct_utc_offset_in_standard_time() -> None:
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = '{"synced": true}'
+
+    target_date = datetime(2025, 1, 15, tzinfo=UTC)
+
+    with patch(
+        "tools.sync_equity_bars_data.requests.post", return_value=mock_response
+    ) as mock_post:
+        sync_equity_bars_for_date(
+            base_url="http://localhost:8080",
+            date=target_date,
+        )
+
+    call_kwargs = mock_post.call_args
+    # January = EST (UTC-5), so noon Eastern = 17:00 UTC
+    assert call_kwargs.kwargs["json"]["date"] == "2025-01-15T17:00:00Z"
 
 
 def test_sync_equity_bars_data_single_date_makes_one_request() -> None:

--- a/tools/tests/test_sync_equity_bars_data.py
+++ b/tools/tests/test_sync_equity_bars_data.py
@@ -32,19 +32,20 @@ def test_validate_and_parse_dates_returns_datetime_tuple() -> None:
 def test_validate_and_parse_dates_clamps_to_current_day() -> None:
     eastern = ZoneInfo("America/New_York")
     today_eastern = datetime.now(tz=eastern).date()
+    tomorrow_eastern = today_eastern + timedelta(days=1)
     date_range_json = json.dumps(
         {
             "start_date": today_eastern.strftime("%Y-%m-%d"),
-            "end_date": today_eastern.strftime("%Y-%m-%d"),
+            "end_date": tomorrow_eastern.strftime("%Y-%m-%d"),
         }
     )
 
     _, end_date = validate_and_parse_dates(date_range_json)
 
-    current_day_utc = datetime(
+    expected_current_date = datetime(
         today_eastern.year, today_eastern.month, today_eastern.day, tzinfo=UTC
     )
-    assert end_date <= current_day_utc
+    assert end_date == expected_current_date
 
 
 def test_sync_equity_bars_for_date_returns_status_and_body() -> None:

--- a/tools/tests/test_sync_equity_bars_data.py
+++ b/tools/tests/test_sync_equity_bars_data.py
@@ -1,6 +1,7 @@
 import json
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
 
 from tools.sync_equity_bars_data import (
     sync_equity_bars_data,
@@ -29,17 +30,21 @@ def test_validate_and_parse_dates_returns_datetime_tuple() -> None:
 
 
 def test_validate_and_parse_dates_clamps_to_current_day() -> None:
-    now = datetime.now(tz=UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    eastern = ZoneInfo("America/New_York")
+    today_eastern = datetime.now(tz=eastern).date()
     date_range_json = json.dumps(
         {
-            "start_date": now.strftime("%Y-%m-%d"),
-            "end_date": now.strftime("%Y-%m-%d"),
+            "start_date": today_eastern.strftime("%Y-%m-%d"),
+            "end_date": today_eastern.strftime("%Y-%m-%d"),
         }
     )
 
     _, end_date = validate_and_parse_dates(date_range_json)
 
-    assert end_date <= now
+    current_day_utc = datetime(
+        today_eastern.year, today_eastern.month, today_eastern.day, tzinfo=UTC
+    )
+    assert end_date <= current_day_utc
 
 
 def test_sync_equity_bars_for_date_returns_status_and_body() -> None:


### PR DESCRIPTION
# Overview

## Changes

- update data manager trigger logic
- update portfolio manager trigger logic
- obfuscate Massive API key in log output
- expand test suite for various services
- update "sync equity bar" date logic

<!-- 
Provide bullet point details.
Include "- fixes <#issue_number>" to link to an outstanding issue.
Apply relevant labels currently available on the repository.
-->

## Context

<!-- 
Provide additional information as needed.
-->

This should fix the incorrectly firing or schedule errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error logs to include HTTP status information.

* **New Features**
  * Scheduler now runs on Eastern-time windows, schedules fetches aligned to Eastern/noon, and skips weekends.
  * Server logging configured for consistent stdout output.

* **Tests**
  * Expanded scheduler tests for many control-flow cases and failure handling.
  * Added server and metrics tests.
  * Updated sync-equity-bars tests to validate Eastern-time/date payloads across DST.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->