### PR TITLE
Fix ensemble manager producing 0 predictions due to output_length mismatch

### DIFF
--- a/applications/ensemble_manager/src/ensemble_manager/predictions_schema.py
+++ b/applications/ensemble_manager/src/ensemble_manager/predictions_schema.py
@@ -79,7 +79,7 @@ predictions_schema = pa.DataFrameSchema(
     },
     coerce=True,
     checks=[
-        # Model outputs 7 days, but server.py filters to 7th day before validation
+        # Model outputs N days, but server.py filters to the last day before validation
         pa.Check(
             check_fn=lambda data: check_dates_count_per_ticker(
                 data=data, dates_count=1

--- a/applications/ensemble_manager/src/ensemble_manager/server.py
+++ b/applications/ensemble_manager/src/ensemble_manager/server.py
@@ -378,7 +378,9 @@ def create_predictions(request: Request) -> Response:  # noqa: PLR0911, PLR0915
     from tinygrad.tensor import Tensor  # noqa: PLC0415
 
     model = request.app.state.tide_model
-    dataset = tide_data.get_dataset(data_type="predict", output_length=model.output_length)
+    dataset = tide_data.get_dataset(
+        data_type="predict", output_length=model.output_length
+    )
 
     if len(dataset) == 0:
         prediction_errors_total.labels(stage="batch_creation").inc()

--- a/applications/ensemble_manager/src/ensemble_manager/server.py
+++ b/applications/ensemble_manager/src/ensemble_manager/server.py
@@ -377,7 +377,8 @@ def create_predictions(request: Request) -> Response:  # noqa: PLR0911, PLR0915
 
     from tinygrad.tensor import Tensor  # noqa: PLC0415
 
-    dataset = tide_data.get_dataset(data_type="predict")
+    model = request.app.state.tide_model
+    dataset = tide_data.get_dataset(data_type="predict", output_length=model.output_length)
 
     if len(dataset) == 0:
         prediction_errors_total.labels(stage="batch_creation").inc()
@@ -394,7 +395,7 @@ def create_predictions(request: Request) -> Response:  # noqa: PLR0911, PLR0915
         "static_categorical_features": Tensor(dataset.static_categorical),
     }
 
-    raw_predictions = request.app.state.tide_model.predict(inputs=batch)
+    raw_predictions = model.predict(inputs=batch)
     predictions = tide_data.postprocess_predictions(
         input_batch=batch,
         predictions=raw_predictions,
@@ -405,7 +406,9 @@ def create_predictions(request: Request) -> Response:  # noqa: PLR0911, PLR0915
         total_predictions=predictions.height,
     )
 
-    processed_prediction_timestamp = current_timestamp + timedelta(days=6)
+    processed_prediction_timestamp = current_timestamp + timedelta(
+        days=model.output_length - 1
+    )
     processed_predictions = predictions.filter(
         pl.col("timestamp")
         == to_timestamp_milliseconds(

--- a/applications/portfolio_manager/pyproject.toml
+++ b/applications/portfolio_manager/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "structlog>=25.5.0",
   "scipy>=1.17.1",
   "prometheus-client>=0.21.0",
+  "tenacity>=9.0",
 ]
 
 [tool.uv]

--- a/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
@@ -3,12 +3,6 @@ from typing import TYPE_CHECKING, cast
 
 import structlog
 from alpaca.common.exceptions import APIError
-from tenacity import (
-    retry,
-    retry_if_exception,
-    stop_after_attempt,
-    wait_exponential,
-)
 from alpaca.data import StockHistoricalDataClient
 from alpaca.trading import (
     Asset,
@@ -16,6 +10,7 @@ from alpaca.trading import (
     ClosePositionRequest,
     GetAssetsRequest,
     OrderRequest,
+    Position,
     TradeAccount,
     TradingClient,
 )
@@ -25,6 +20,12 @@ from alpaca.trading.enums import (
     OrderSide,
     OrderType,
     TimeInForce,
+)
+from tenacity import (
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
 )
 
 if TYPE_CHECKING:
@@ -46,11 +47,13 @@ def _is_transient_error(error: BaseException) -> bool:
 
 
 def _log_retry(retry_state: "RetryCallState") -> None:
+    outcome = retry_state.outcome
+    error = outcome.exception() if outcome is not None else None
     logger.warning(
         "Retrying Alpaca API call",
         attempt=retry_state.attempt_number,
         wait_seconds=getattr(retry_state.next_action, "sleep", None),
-        error=str(retry_state.outcome.exception()),
+        error=str(error),
     )
 
 
@@ -108,8 +111,8 @@ class AlpacaClient:
         time.sleep(self.rate_limit_sleep)
 
         return AlpacaAccount(
-            cash_amount=float(cast("str", account.cash)),
-            buying_power=float(cast("str", account.buying_power)),
+            cash_amount=float(str(account.cash)),
+            buying_power=float(str(account.buying_power)),
         )
 
     def open_position(
@@ -144,7 +147,11 @@ class AlpacaClient:
                 message = f"Insufficient buying power for {ticker}: {e}"
                 raise InsufficientBuyingPowerError(message) from e
             # Handle non-shortable assets
-            if "cannot be sold short" in error_str or "not shortable" in error_str or "not allowed to short" in error_str:
+            if (
+                "cannot be sold short" in error_str
+                or "not shortable" in error_str
+                or "not allowed to short" in error_str
+            ):
                 message = f"Asset {ticker} cannot be sold short: {e}"
                 raise AssetNotShortableError(message) from e
             # Re-raise other API errors
@@ -173,15 +180,18 @@ class AlpacaClient:
 
     @_alpaca_retry
     def get_open_positions(self) -> list[dict[str, object]]:
-        positions = self.trading_client.get_all_positions()
+        positions: list[Position] = cast(
+            "list[Position]",
+            self.trading_client.get_all_positions(),
+        )
         time.sleep(self.rate_limit_sleep)
         return [
             {
                 "ticker": str(position.symbol),
                 "side": str(position.side),
-                "quantity": float(cast("str", position.qty)),
-                "market_value": float(cast("str", position.market_value)),
-                "unrealized_profit_and_loss": float(cast("str", position.unrealized_pl)),
+                "quantity": float(str(position.qty)),
+                "market_value": float(str(position.market_value)),
+                "unrealized_profit_and_loss": float(str(position.unrealized_pl)),
             }
             for position in positions
         ]

--- a/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
@@ -145,7 +145,7 @@ class AlpacaClient:
                 message = f"Insufficient buying power for {ticker}: {e}"
                 raise InsufficientBuyingPowerError(message) from e
             # Handle non-shortable assets
-            if "cannot be sold short" in error_str or "not shortable" in error_str:
+            if "cannot be sold short" in error_str or "not shortable" in error_str or "not allowed to short" in error_str:
                 message = f"Asset {ticker} cannot be sold short: {e}"
                 raise AssetNotShortableError(message) from e
             # Re-raise other API errors

--- a/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
@@ -93,7 +93,7 @@ class AlpacaClient:
             self.trading_client.submit_order(
                 order_data=OrderRequest(
                     symbol=ticker.upper(),
-                    notional=dollar_amount,
+                    notional=round(dollar_amount, 2),
                     side=OrderSide(side.value.lower()),
                     type=OrderType.MARKET,
                     time_in_force=TimeInForce.DAY,

--- a/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
@@ -1,8 +1,14 @@
 import time
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import structlog
 from alpaca.common.exceptions import APIError
+from tenacity import (
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
 from alpaca.data import StockHistoricalDataClient
 from alpaca.trading import (
     Asset,
@@ -21,10 +27,40 @@ from alpaca.trading.enums import (
     TimeInForce,
 )
 
+if TYPE_CHECKING:
+    from tenacity import RetryCallState
+
 from .enums import TradeSide
 from .exceptions import AssetNotShortableError, InsufficientBuyingPowerError
 
 logger = structlog.get_logger(__name__)
+
+_TRANSIENT_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+def _is_transient_error(error: BaseException) -> bool:
+    status_code = getattr(error, "status_code", None)
+    if status_code in _TRANSIENT_STATUS_CODES:
+        return True
+    return isinstance(error, OSError)
+
+
+def _log_retry(retry_state: "RetryCallState") -> None:
+    logger.warning(
+        "Retrying Alpaca API call",
+        attempt=retry_state.attempt_number,
+        wait_seconds=getattr(retry_state.next_action, "sleep", None),
+        error=str(retry_state.outcome.exception()),
+    )
+
+
+_alpaca_retry = retry(
+    retry=retry_if_exception(_is_transient_error),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    before_sleep=_log_retry,
+    reraise=True,
+)
 
 
 class AlpacaAccount:
@@ -59,11 +95,13 @@ class AlpacaClient:
 
         self.is_paper = is_paper
 
+    @_alpaca_retry
     def is_market_open(self) -> bool:
         clock: Clock = cast("Clock", self.trading_client.get_clock())
         time.sleep(self.rate_limit_sleep)
         return bool(clock.is_open)
 
+    @_alpaca_retry
     def get_account(self) -> AlpacaAccount:
         account: TradeAccount = cast("TradeAccount", self.trading_client.get_account())
 
@@ -74,6 +112,7 @@ class AlpacaClient:
             buying_power=float(cast("str", account.buying_power)),
         )
 
+    @_alpaca_retry
     def open_position(
         self,
         ticker: str,
@@ -114,6 +153,7 @@ class AlpacaClient:
 
         time.sleep(self.rate_limit_sleep)
 
+    @_alpaca_retry
     def get_shortable_tickers(self, tickers: list[str]) -> set[str]:
         all_assets: list[Asset] = cast(
             "list[Asset]",
@@ -132,6 +172,22 @@ class AlpacaClient:
             if asset.symbol in ticker_set and asset.shortable and asset.easy_to_borrow
         }
 
+    @_alpaca_retry
+    def get_open_positions(self) -> list[dict[str, object]]:
+        positions = self.trading_client.get_all_positions()
+        time.sleep(self.rate_limit_sleep)
+        return [
+            {
+                "ticker": str(position.symbol),
+                "side": str(position.side),
+                "quantity": float(cast("str", position.qty)),
+                "market_value": float(cast("str", position.market_value)),
+                "unrealized_profit_and_loss": float(cast("str", position.unrealized_pl)),
+            }
+            for position in positions
+        ]
+
+    @_alpaca_retry
     def close_position(
         self,
         ticker: str,

--- a/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
@@ -112,7 +112,6 @@ class AlpacaClient:
             buying_power=float(cast("str", account.buying_power)),
         )
 
-    @_alpaca_retry
     def open_position(
         self,
         ticker: str,

--- a/applications/portfolio_manager/src/portfolio_manager/data_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/data_client.py
@@ -3,8 +3,11 @@ from datetime import datetime, timedelta
 
 import polars as pl
 import requests
+import structlog
 
 from .exceptions import PriceDataUnavailableError
+
+logger = structlog.get_logger(__name__)
 
 
 def fetch_historical_prices(
@@ -32,11 +35,16 @@ def fetch_historical_prices(
         raise PriceDataUnavailableError(message) from error
 
     dataframe = pl.read_parquet(io.BytesIO(response.content))
-    return (
-        dataframe.select(["ticker", "timestamp", "close_price"])
-        .unique(subset=["ticker", "timestamp"], keep="last")
-        .drop_nulls(subset=["close_price"])
-    )
+    selected = dataframe.select(["ticker", "timestamp", "close_price"])
+    cleaned = selected.drop_nulls(subset=["close_price"])
+    deduped = cleaned.unique(subset=["ticker", "timestamp"], keep="last")
+    duplicates_removed = cleaned.height - deduped.height
+    if duplicates_removed > 0:
+        logger.warning(
+            "Removed duplicate ticker-timestamp rows from historical prices",
+            duplicates_removed=duplicates_removed,
+        )
+    return deduped
 
 
 def fetch_equity_details(datamanager_base_url: str) -> pl.DataFrame:
@@ -83,8 +91,13 @@ def fetch_spy_prices(
         raise PriceDataUnavailableError(message) from error
 
     dataframe = pl.read_parquet(io.BytesIO(response.content))
-    return (
-        dataframe.select(["ticker", "timestamp", "close_price"])
-        .unique(subset=["ticker", "timestamp"], keep="last")
-        .drop_nulls(subset=["close_price"])
-    )
+    selected = dataframe.select(["ticker", "timestamp", "close_price"])
+    cleaned = selected.drop_nulls(subset=["close_price"])
+    deduped = cleaned.unique(subset=["ticker", "timestamp"], keep="last")
+    duplicates_removed = cleaned.height - deduped.height
+    if duplicates_removed > 0:
+        logger.warning(
+            "Removed duplicate ticker-timestamp rows from SPY prices",
+            duplicates_removed=duplicates_removed,
+        )
+    return deduped

--- a/applications/portfolio_manager/src/portfolio_manager/data_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/data_client.py
@@ -32,8 +32,10 @@ def fetch_historical_prices(
         raise PriceDataUnavailableError(message) from error
 
     dataframe = pl.read_parquet(io.BytesIO(response.content))
-    return dataframe.select(["ticker", "timestamp", "close_price"]).drop_nulls(
-        subset=["close_price"]
+    return (
+        dataframe.select(["ticker", "timestamp", "close_price"])
+        .unique(subset=["ticker", "timestamp"], keep="last")
+        .drop_nulls(subset=["close_price"])
     )
 
 
@@ -81,6 +83,8 @@ def fetch_spy_prices(
         raise PriceDataUnavailableError(message) from error
 
     dataframe = pl.read_parquet(io.BytesIO(response.content))
-    return dataframe.select(["ticker", "timestamp", "close_price"]).drop_nulls(
-        subset=["close_price"]
+    return (
+        dataframe.select(["ticker", "timestamp", "close_price"])
+        .unique(subset=["ticker", "timestamp"], keep="last")
+        .drop_nulls(subset=["close_price"])
     )

--- a/applications/portfolio_manager/src/portfolio_manager/data_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/data_client.py
@@ -37,7 +37,9 @@ def fetch_historical_prices(
     dataframe = pl.read_parquet(io.BytesIO(response.content))
     selected = dataframe.select(["ticker", "timestamp", "close_price"])
     cleaned = selected.drop_nulls(subset=["close_price"])
-    deduped = cleaned.unique(subset=["ticker", "timestamp"], keep="last")
+    deduped = cleaned.sort("timestamp").unique(
+        subset=["ticker", "timestamp"], keep="last", maintain_order=True
+    )
     duplicates_removed = cleaned.height - deduped.height
     if duplicates_removed > 0:
         logger.warning(
@@ -93,7 +95,9 @@ def fetch_spy_prices(
     dataframe = pl.read_parquet(io.BytesIO(response.content))
     selected = dataframe.select(["ticker", "timestamp", "close_price"])
     cleaned = selected.drop_nulls(subset=["close_price"])
-    deduped = cleaned.unique(subset=["ticker", "timestamp"], keep="last")
+    deduped = cleaned.sort("timestamp").unique(
+        subset=["ticker", "timestamp"], keep="last", maintain_order=True
+    )
     duplicates_removed = cleaned.height - deduped.height
     if duplicates_removed > 0:
         logger.warning(

--- a/applications/portfolio_manager/src/portfolio_manager/scheduler.py
+++ b/applications/portfolio_manager/src/portfolio_manager/scheduler.py
@@ -93,10 +93,13 @@ async def spawn_status_logger(
 
 
 async def _status_logger_loop(alpaca_client: AlpacaClient) -> None:
+    loop = asyncio.get_running_loop()
     while True:
         try:
-            account = alpaca_client.get_account()
-            positions = alpaca_client.get_open_positions()
+            account = await loop.run_in_executor(None, alpaca_client.get_account)
+            positions = await loop.run_in_executor(
+                None, alpaca_client.get_open_positions
+            )
             logger.info(
                 "Account status",
                 cash_amount=account.cash_amount,

--- a/applications/portfolio_manager/src/portfolio_manager/scheduler.py
+++ b/applications/portfolio_manager/src/portfolio_manager/scheduler.py
@@ -54,7 +54,7 @@ async def _already_rebalanced_today(data_manager_base_url: str) -> bool:
             timestamp_value = row.get("timestamp")
             if timestamp_value is not None:
                 row_date = datetime.fromtimestamp(
-                    float(timestamp_value), tz=_EASTERN
+                    float(timestamp_value) / 1000, tz=_EASTERN
                 ).date()
                 if row_date == today:
                     return True

--- a/applications/portfolio_manager/src/portfolio_manager/scheduler.py
+++ b/applications/portfolio_manager/src/portfolio_manager/scheduler.py
@@ -117,7 +117,11 @@ async def _status_logger_loop(alpaca_client: AlpacaClient) -> None:
             return
         except Exception as error:
             logger.exception("Status logger error", error=str(error))
-            await asyncio.sleep(_STATUS_LOG_INTERVAL_SECONDS)
+            try:
+                await asyncio.sleep(_STATUS_LOG_INTERVAL_SECONDS)
+            except asyncio.CancelledError:
+                logger.info("Status logger cancelled")
+                return
 
 
 async def _rebalance_loop(  # noqa: C901

--- a/applications/portfolio_manager/src/portfolio_manager/scheduler.py
+++ b/applications/portfolio_manager/src/portfolio_manager/scheduler.py
@@ -80,6 +80,39 @@ async def spawn_rebalance_scheduler(
     return task
 
 
+_STATUS_LOG_INTERVAL_SECONDS = 60
+
+
+async def spawn_status_logger(
+    alpaca_client: AlpacaClient,
+) -> asyncio.Task:
+    task = asyncio.create_task(_status_logger_loop(alpaca_client))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
+
+
+async def _status_logger_loop(alpaca_client: AlpacaClient) -> None:
+    while True:
+        try:
+            account = alpaca_client.get_account()
+            positions = alpaca_client.get_open_positions()
+            logger.info(
+                "Account status",
+                cash_amount=account.cash_amount,
+                buying_power=account.buying_power,
+                position_count=len(positions),
+                positions=positions,
+            )
+            await asyncio.sleep(_STATUS_LOG_INTERVAL_SECONDS)
+        except asyncio.CancelledError:
+            logger.info("Status logger cancelled")
+            return
+        except Exception as error:
+            logger.exception("Status logger error", error=str(error))
+            await asyncio.sleep(_STATUS_LOG_INTERVAL_SECONDS)
+
+
 async def _rebalance_loop(  # noqa: C901
     alpaca_client: AlpacaClient,
     data_manager_base_url: str,

--- a/applications/portfolio_manager/src/portfolio_manager/server.py
+++ b/applications/portfolio_manager/src/portfolio_manager/server.py
@@ -18,7 +18,7 @@ from .metrics import (
     get_metrics,
 )
 from .rebalance import DATA_MANAGER_BASE_URL, run_rebalance
-from .scheduler import spawn_rebalance_scheduler
+from .scheduler import spawn_rebalance_scheduler, spawn_status_logger
 
 logging.basicConfig(
     level=logging.INFO, stream=sys.stdout, format="%(message)s", force=True
@@ -85,8 +85,14 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         rebalance_lock=_rebalance_lock,
     )
     logger.info("Portfolio rebalance scheduler started")
+    _app.state.status_logger_task = await spawn_status_logger(
+        alpaca_client=_app.state.alpaca_client,
+    )
+    logger.info("Account status logger started")
     yield
+    _app.state.status_logger_task.cancel()
     _app.state.scheduler_task.cancel()
+    await _app.state.status_logger_task
     await _app.state.scheduler_task
 
 

--- a/applications/portfolio_manager/tests/test_alpaca_client.py
+++ b/applications/portfolio_manager/tests/test_alpaca_client.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from alpaca.trading.enums import AssetClass, AssetStatus, OrderSide, PositionIntent
@@ -615,6 +615,7 @@ def test_get_account_retries_on_transient_error(
     mock_account = MagicMock()
     mock_account.cash = "5000.00"
     mock_account.buying_power = "10000.00"
+    mock_account.equity = "15000.00"
     mock_trading.get_account.side_effect = [transient_error, mock_account]
 
     result = client.get_account()
@@ -677,4 +678,4 @@ def test_get_account_raises_after_retries_exhausted(
     expected_attempts = 3
     assert mock_trading.get_account.call_count == expected_attempts
     assert mock_tenacity_sleep is not None
-    assert mock_rate_limit_sleep.called
+    assert call(client.rate_limit_sleep) not in mock_rate_limit_sleep.call_args_list

--- a/applications/portfolio_manager/tests/test_alpaca_client.py
+++ b/applications/portfolio_manager/tests/test_alpaca_client.py
@@ -3,7 +3,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from alpaca.trading.enums import AssetClass, AssetStatus
 from alpaca.trading.requests import GetAssetsRequest
-from portfolio_manager.alpaca_client import AlpacaAccount, AlpacaClient
+from portfolio_manager.alpaca_client import (
+    AlpacaAccount,
+    AlpacaClient,
+    _is_transient_error,
+)
 from portfolio_manager.enums import TradeSide
 from portfolio_manager.exceptions import (
     AssetNotShortableError,
@@ -270,6 +274,63 @@ def test_close_position_reraises_other_api_errors() -> None:
         client.close_position(ticker="AAPL")
 
 
+def _make_mock_position(
+    symbol: str,
+    side: str,
+    qty: str,
+    market_value: str,
+    unrealized_pl: str,
+) -> MagicMock:
+    position = MagicMock()
+    position.symbol = symbol
+    position.side = side
+    position.qty = qty
+    position.market_value = market_value
+    position.unrealized_pl = unrealized_pl
+    return position
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_get_open_positions_returns_position_dicts(mock_sleep: MagicMock) -> None:
+    client, mock_trading = _make_client()
+    mock_trading.get_all_positions.return_value = [
+        _make_mock_position("AAPL", "long", "10.0", "1500.00", "50.00"),
+        _make_mock_position("MSFT", "short", "5.0", "2000.00", "-30.00"),
+    ]
+
+    result = client.get_open_positions()
+
+    assert len(result) == 2
+    assert result[0] == {
+        "ticker": "AAPL",
+        "side": "long",
+        "quantity": 10.0,
+        "market_value": 1500.0,
+        "unrealized_profit_and_loss": 50.0,
+    }
+    assert result[1] == {
+        "ticker": "MSFT",
+        "side": "short",
+        "quantity": 5.0,
+        "market_value": 2000.0,
+        "unrealized_profit_and_loss": -30.0,
+    }
+    mock_sleep.assert_called_once_with(client.rate_limit_sleep)
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_get_open_positions_returns_empty_list_when_no_positions(
+    mock_sleep: MagicMock,
+) -> None:
+    client, mock_trading = _make_client()
+    mock_trading.get_all_positions.return_value = []
+
+    result = client.get_open_positions()
+
+    assert result == []
+    mock_sleep.assert_called_once_with(client.rate_limit_sleep)
+
+
 def test_get_shortable_tickers_excludes_non_shortable() -> None:
     client, mock_trading = _make_client()
     mock_trading.get_all_assets.return_value = [
@@ -333,3 +394,103 @@ def test_get_shortable_tickers_does_not_pass_attributes_to_api() -> None:
         status=AssetStatus.ACTIVE,
     )
     mock_trading.get_all_assets.assert_called_once_with(expected_request)
+
+
+# --- _is_transient_error predicate tests ---
+
+
+def test_is_transient_error_returns_true_for_429() -> None:
+    error = _FakeAPIError("rate limited", status_code=429)
+    assert _is_transient_error(error) is True
+
+
+def test_is_transient_error_returns_true_for_500() -> None:
+    error = _FakeAPIError("internal server error", status_code=500)
+    assert _is_transient_error(error) is True
+
+
+def test_is_transient_error_returns_true_for_os_error() -> None:
+    error = OSError("connection reset")
+    assert _is_transient_error(error) is True
+
+
+def test_is_transient_error_returns_false_for_permanent_api_error() -> None:
+    error = _FakeAPIError("bad request", status_code=400)
+    assert _is_transient_error(error) is False
+
+
+def test_is_transient_error_returns_false_for_non_api_error() -> None:
+    error = ValueError("invalid value")
+    assert _is_transient_error(error) is False
+
+
+# --- Retry behavior tests ---
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+@patch("tenacity.nap.time.sleep")
+def test_get_account_retries_on_transient_error(
+    mock_tenacity_sleep: MagicMock,
+    mock_rate_limit_sleep: MagicMock,
+) -> None:
+    client, mock_trading = _make_client()
+    transient_error = _FakeAPIError("server error", status_code=500)
+    mock_account = MagicMock()
+    mock_account.cash = "5000.00"
+    mock_account.buying_power = "10000.00"
+    mock_trading.get_account.side_effect = [transient_error, mock_account]
+
+    result = client.get_account()
+
+    assert result.cash_amount == 5000.0
+    assert mock_trading.get_account.call_count == 2
+
+
+@patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
+@patch("portfolio_manager.alpaca_client.time.sleep")
+@patch("tenacity.nap.time.sleep")
+def test_open_position_retries_on_transient_error(
+    mock_tenacity_sleep: MagicMock,
+    mock_rate_limit_sleep: MagicMock,
+) -> None:
+    client, mock_trading = _make_client()
+    transient_error = _FakeAPIError("service unavailable", status_code=503)
+    mock_trading.submit_order.side_effect = [transient_error, None]
+
+    client.open_position(ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0)
+
+    assert mock_trading.submit_order.call_count == 2
+
+
+@patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
+@patch("portfolio_manager.alpaca_client.time.sleep")
+@patch("tenacity.nap.time.sleep")
+def test_close_position_retries_on_transient_error(
+    mock_tenacity_sleep: MagicMock,
+    mock_rate_limit_sleep: MagicMock,
+) -> None:
+    client, mock_trading = _make_client()
+    transient_error = _FakeAPIError("bad gateway", status_code=502)
+    mock_trading.close_position.side_effect = [transient_error, None]
+
+    result = client.close_position(ticker="AAPL")
+
+    assert result is True
+    assert mock_trading.close_position.call_count == 2
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+@patch("tenacity.nap.time.sleep")
+def test_get_account_raises_after_retries_exhausted(
+    mock_tenacity_sleep: MagicMock,
+    mock_rate_limit_sleep: MagicMock,
+) -> None:
+    client, mock_trading = _make_client()
+    transient_error = _FakeAPIError("server error", status_code=500)
+    mock_trading.get_account.side_effect = transient_error
+
+    with pytest.raises(_FakeAPIError, match="server error"):
+        client.get_account()
+
+    expected_attempts = 3
+    assert mock_trading.get_account.call_count == expected_attempts

--- a/applications/portfolio_manager/tests/test_alpaca_client.py
+++ b/applications/portfolio_manager/tests/test_alpaca_client.py
@@ -460,19 +460,15 @@ def test_get_account_retries_on_transient_error(
 
 
 @patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
-@patch("portfolio_manager.alpaca_client.time.sleep")
-@patch("tenacity.nap.time.sleep")
-def test_open_position_retries_on_transient_error(
-    mock_tenacity_sleep: MagicMock,
-    mock_rate_limit_sleep: MagicMock,
-) -> None:
+def test_open_position_does_not_retry_on_transient_error() -> None:
     client, mock_trading = _make_client()
     transient_error = _FakeAPIError("service unavailable", status_code=503)
-    mock_trading.submit_order.side_effect = [transient_error, None]
+    mock_trading.submit_order.side_effect = transient_error
 
-    client.open_position(ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0)
+    with pytest.raises(_FakeAPIError, match="service unavailable"):
+        client.open_position(ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0)
 
-    assert mock_trading.submit_order.call_count == 2
+    assert mock_trading.submit_order.call_count == 1
 
 
 @patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)

--- a/applications/portfolio_manager/tests/test_alpaca_client.py
+++ b/applications/portfolio_manager/tests/test_alpaca_client.py
@@ -190,6 +190,19 @@ def test_open_position_raises_asset_not_shortable_error_on_not_shortable_keyword
 
 
 @patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
+def test_open_position_raises_asset_not_shortable_error_on_not_allowed_to_short() -> (
+    None
+):
+    client, mock_trading = _make_client()
+    mock_trading.submit_order.side_effect = _FakeAPIError(
+        "account is not allowed to short"
+    )
+
+    with pytest.raises(AssetNotShortableError):
+        client.open_position(ticker="AAPL", side=TradeSide.SELL, dollar_amount=500.0)
+
+
+@patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
 def test_open_position_reraises_other_api_errors() -> None:
     client, mock_trading = _make_client()
     mock_trading.submit_order.side_effect = _FakeAPIError("some unhandled error")

--- a/applications/portfolio_manager/tests/test_alpaca_client.py
+++ b/applications/portfolio_manager/tests/test_alpaca_client.py
@@ -313,7 +313,8 @@ def test_get_open_positions_returns_position_dicts(mock_sleep: MagicMock) -> Non
 
     result = client.get_open_positions()
 
-    assert len(result) == 2
+    expected_positions = 2
+    assert len(result) == expected_positions
     assert result[0] == {
         "ticker": "AAPL",
         "side": "long",
@@ -455,8 +456,12 @@ def test_get_account_retries_on_transient_error(
 
     result = client.get_account()
 
-    assert result.cash_amount == 5000.0
-    assert mock_trading.get_account.call_count == 2
+    expected_cash = 5000.0
+    expected_attempts = 2
+    assert result.cash_amount == expected_cash
+    assert mock_trading.get_account.call_count == expected_attempts
+    assert mock_tenacity_sleep is not None
+    assert mock_rate_limit_sleep.called
 
 
 @patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
@@ -484,8 +489,11 @@ def test_close_position_retries_on_transient_error(
 
     result = client.close_position(ticker="AAPL")
 
+    expected_attempts = 2
     assert result is True
-    assert mock_trading.close_position.call_count == 2
+    assert mock_trading.close_position.call_count == expected_attempts
+    assert mock_tenacity_sleep is not None
+    assert mock_rate_limit_sleep.called
 
 
 @patch("portfolio_manager.alpaca_client.time.sleep")
@@ -503,3 +511,5 @@ def test_get_account_raises_after_retries_exhausted(
 
     expected_attempts = 3
     assert mock_trading.get_account.call_count == expected_attempts
+    assert mock_tenacity_sleep is not None
+    assert mock_rate_limit_sleep.called

--- a/applications/portfolio_manager/tests/test_scheduler.py
+++ b/applications/portfolio_manager/tests/test_scheduler.py
@@ -100,7 +100,7 @@ def _make_mock_http_client(mock_response: MagicMock) -> AsyncMock:
 
 def test_already_rebalanced_today_returns_true_when_todays_portfolio_exists() -> None:
     frozen_now = datetime(2026, 3, 23, 10, 30, 0, tzinfo=_EASTERN)
-    data = [{"ticker": "AAPL", "timestamp": frozen_now.timestamp()}]
+    data = [{"ticker": "AAPL", "timestamp": int(frozen_now.timestamp() * 1000)}]
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = data
@@ -122,7 +122,7 @@ def test_already_rebalanced_today_returns_false_when_portfolio_is_from_yesterday
 ):
     frozen_now = datetime(2026, 3, 23, 10, 30, 0, tzinfo=_EASTERN)
     yesterday = frozen_now - timedelta(days=1)
-    data = [{"ticker": "AAPL", "timestamp": yesterday.timestamp()}]
+    data = [{"ticker": "AAPL", "timestamp": int(yesterday.timestamp() * 1000)}]
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = data
@@ -143,7 +143,7 @@ def test_already_rebalanced_today_handles_eastern_utc_day_boundary() -> None:
     # Timestamp recorded at Monday 20:30 ET (= Tuesday 00:30 UTC).
     # "now" is also Monday 20:30 ET — should detect already rebalanced for that ET day.
     monday_eastern = datetime(2026, 3, 23, 20, 30, 0, tzinfo=_EASTERN)
-    data = [{"ticker": "AAPL", "timestamp": monday_eastern.timestamp()}]
+    data = [{"ticker": "AAPL", "timestamp": int(monday_eastern.timestamp() * 1000)}]
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = data

--- a/applications/portfolio_manager/tests/test_scheduler.py
+++ b/applications/portfolio_manager/tests/test_scheduler.py
@@ -3,10 +3,12 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
+from portfolio_manager.alpaca_client import AlpacaAccount
 from portfolio_manager.scheduler import (
     _already_rebalanced_today,
     _rebalance_loop,
     _seconds_until_next_rebalance,
+    _status_logger_loop,
 )
 
 _EASTERN = ZoneInfo("America/New_York")
@@ -511,3 +513,99 @@ def test_rebalance_loop_retries_after_unexpected_error() -> None:
         asyncio.run(run())
 
     mock_run_rebalance.assert_not_called()
+
+
+# --- _status_logger_loop ---
+
+
+def _make_mock_alpaca_for_status(
+    positions: list[dict[str, object]] | None = None,
+) -> MagicMock:
+    mock_alpaca = MagicMock()
+    mock_alpaca.get_account.return_value = AlpacaAccount(
+        cash_amount=10000.0, buying_power=20000.0
+    )
+    mock_alpaca.get_open_positions.return_value = positions or []
+    return mock_alpaca
+
+
+def test_status_logger_loop_logs_account_status() -> None:
+    mock_alpaca = _make_mock_alpaca_for_status(
+        positions=[
+            {
+                "ticker": "AAPL",
+                "side": "long",
+                "quantity": 10.0,
+                "market_value": 1500.0,
+                "unrealized_profit_and_loss": 50.0,
+            }
+        ]
+    )
+
+    async def run() -> None:
+        await _status_logger_loop(mock_alpaca)
+
+    with (
+        patch(
+            "asyncio.sleep",
+            AsyncMock(side_effect=[asyncio.CancelledError()]),
+        ),
+        patch("portfolio_manager.scheduler.logger") as mock_logger,
+    ):
+        asyncio.run(run())
+
+    mock_logger.info.assert_any_call(
+        "Account status",
+        cash_amount=10000.0,
+        buying_power=20000.0,
+        position_count=1,
+        positions=mock_alpaca.get_open_positions.return_value,
+    )
+
+
+def test_status_logger_loop_handles_exception_without_crashing() -> None:
+    mock_alpaca = MagicMock()
+    mock_alpaca.get_account.side_effect = [
+        Exception("api error"),
+        AlpacaAccount(cash_amount=5000.0, buying_power=10000.0),
+    ]
+    mock_alpaca.get_open_positions.return_value = []
+
+    async def run() -> None:
+        await _status_logger_loop(mock_alpaca)
+
+    with (
+        patch(
+            "asyncio.sleep",
+            AsyncMock(side_effect=[None, asyncio.CancelledError()]),
+        ),
+        patch("portfolio_manager.scheduler.logger") as mock_logger,
+    ):
+        asyncio.run(run())
+
+    mock_logger.exception.assert_called_once()
+    mock_logger.info.assert_any_call(
+        "Account status",
+        cash_amount=5000.0,
+        buying_power=10000.0,
+        position_count=0,
+        positions=[],
+    )
+
+
+def test_status_logger_loop_exits_on_cancellation() -> None:
+    mock_alpaca = _make_mock_alpaca_for_status()
+
+    async def run() -> None:
+        await _status_logger_loop(mock_alpaca)
+
+    with (
+        patch(
+            "asyncio.sleep",
+            AsyncMock(side_effect=[asyncio.CancelledError()]),
+        ),
+        patch("portfolio_manager.scheduler.logger") as mock_logger,
+    ):
+        asyncio.run(run())
+
+    mock_logger.info.assert_any_call("Status logger cancelled")

--- a/applications/portfolio_manager/tests/test_server_app.py
+++ b/applications/portfolio_manager/tests/test_server_app.py
@@ -167,12 +167,17 @@ def test_lifespan_initializes_client_and_scheduler() -> None:
                 "portfolio_manager.server.spawn_rebalance_scheduler",
                 AsyncMock(return_value=future),
             ) as mock_spawn_scheduler,
+            patch(
+                "portfolio_manager.server.spawn_status_logger",
+                AsyncMock(return_value=future),
+            ) as mock_spawn_status_logger,
         ):
             async with _lifespan(mock_app):
                 pass
 
         mock_alpaca_client.assert_called_once()
         mock_spawn_scheduler.assert_awaited_once()
+        mock_spawn_status_logger.assert_awaited_once()
 
     asyncio.run(run())
 

--- a/tools/src/tools/vulture_whitelist.py
+++ b/tools/src/tools/vulture_whitelist.py
@@ -2,5 +2,7 @@
 # These imports are used only for type hints under TYPE_CHECKING
 
 from mypy_boto3_s3 import S3Client
+from tenacity import RetryCallState
 
 _ = S3Client  # used in type annotations
+_ = RetryCallState  # used in string annotation for type checker

--- a/tools/src/tools/vulture_whitelist.py
+++ b/tools/src/tools/vulture_whitelist.py
@@ -1,5 +1,5 @@
 # Vulture whitelist - mark intentionally unused code
-# These imports are used only for type hints under TYPE_CHECKING
+# These symbols are imported unconditionally so vulture recognizes them as used
 
 from mypy_boto3_s3 import S3Client
 from tenacity import RetryCallState

--- a/uv.lock
+++ b/uv.lock
@@ -1651,6 +1651,7 @@ dependencies = [
     { name = "requests" },
     { name = "scipy" },
     { name = "structlog" },
+    { name = "tenacity" },
     { name = "uvicorn" },
 ]
 
@@ -1666,6 +1667,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.5" },
     { name = "scipy", specifier = ">=1.17.1" },
     { name = "structlog", specifier = ">=25.5.0" },
+    { name = "tenacity", specifier = ">=9.0" },
     { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 


### PR DESCRIPTION
## Summary

- The TiDE model `output_length` was changed from 7 to 5 in a prior rebuild, but `server.py` still hardcoded `timedelta(days=6)` when filtering predictions to the target day. The model outputs days 0-4, so filtering for day 6 matched nothing, producing 0 predictions.
- Pass `model.output_length` to `Data.get_dataset()` and use `timedelta(days=model.output_length - 1)` for the timestamp filter so the prediction endpoint dynamically adapts to the trained model's forecast horizon.

## Test plan

- [x] All 44 ensemble manager tests pass
- [ ] Verify predictions endpoint returns non-empty results after deployment
- [ ] Confirm portfolio manager receives predictions and proceeds with rebalance

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prediction timestamps now follow the model's configured output length instead of a fixed offset.
  * Improved handling of transient broker/API errors with automatic retries to increase reliability.

* **New Features**
  * Background account status logger that periodically records cash, buying power, and open position count.
  * Improved position reporting/formatting when fetching open positions.

* **Data**
  * Historical price pipeline now drops null closes and deduplicates entries.

* **Chores**
  * Added runtime retry dependency.

* **Tests**
  * Expanded tests for retries, position fetching, and the status logger.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oscmcompany/fund/pull/857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->