### PR TITLE
Update risk management for short selling constraints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  statuses: write
 
 jobs:
   ci:
@@ -41,26 +40,3 @@ jobs:
           restore-keys: uv-
       - name: Run all CI checks
         run: devenv --secretspec-provider env --secretspec-profile development tasks run --mode before checks:ci
-      - name: Upload Rust coverage to Coveralls
-        if: hashFiles('.coverage_output/rust.xml') != ''
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: rust
-          file: .coverage_output/rust.xml
-          parallel: true
-      - name: Upload Python coverage to Coveralls
-        if: hashFiles('.coverage_output/python.xml') != ''
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: python
-          file: .coverage_output/python.xml
-          parallel: true
-      - name: Finalize coverage upload
-        if: hashFiles('.coverage_output/rust.xml') != '' || hashFiles('.coverage_output/python.xml') != ''
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
-          carryforward: rust,python

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-.env
 .ruff_cache/
 .pytest_cache/
 .venv/
@@ -19,5 +18,4 @@ data/
 **/*.json
 .claude/tasks/
 .scratchpad/
-
 .devenv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,9 +125,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607e64bb911ee4f90483e044fe78f175989148c2892e659a2cd25429e782ec54"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e754319ed8a85d817fe7adf183227e0b5308b82790a737b426c1124626b48118"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -157,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841321891f247aa86c6112c80d83d89cb36e0addd020fa2425085b8eb6c3f579"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -167,7 +167,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f955dfb73fae000425f49c8226d2044dab60fb7ad4af1e24f961756354d996c9"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
 dependencies = [
  "bytes",
  "half",
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca5e686972523798f76bef355145bc1ae25a84c731e650268d31ab763c701663"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3b5846209775b6dc8056d77ff9a032b27043383dd5488abd0b663e265b9373"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa70d9d6b1356f1fb9f1f651b84a725b7e0abb93f188cf7d31f14abfa2f2e6f"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faec88a945338192beffbbd4be0def70135422930caa244ac3cec0cd213b26b4"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -248,18 +248,18 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18aa020f6bc8e5201dcd2d4b7f98c68f8a410ef37128263243e6ff2a47a67d4f"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
  "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657ab5132e9c8ca3b24eb15a823d0ced38017fe3930ff50167466b02e2d592c"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.2.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6de2efbbd1a9f9780ceb8d1ff5d20421b35863b361e3386b4f571f1fc69fcb8"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -465,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.131.0"
+version = "1.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1b8c5282bf859170836045296b3cd710b7573aceb909498366bb508a41058e"
+checksum = "5575840a3a6b11f6011463ebe359320dfe5b67babb5e9b06fed6ddf809a9ab40"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1086,6 +1086,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1837,13 +1846,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -2186,9 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2313,9 +2321,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -2626,7 +2634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2636,16 +2644,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "itertools"
@@ -2723,9 +2721,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2840,18 +2838,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "plain",
- "redox_syscall 0.7.5",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3143,9 +3129,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -3174,9 +3160,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -3306,12 +3292,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "planus"
@@ -4189,15 +4169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4424,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -4821,11 +4792,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4840,9 +4812,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5293,10 +5265,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5433,9 +5405,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -5577,21 +5549,21 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -5884,9 +5856,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5898,9 +5870,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5908,9 +5880,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5918,9 +5890,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5931,9 +5903,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -5987,9 +5959,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6291,9 +6263,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -6474,9 +6446,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 > The open source capital management company
 
-<!-- markdownlint-disable-next-line MD013 -->
-[![Code checks](https://github.com/oscmcompany/fund/actions/workflows/ci.yaml/badge.svg)](https://github.com/oscmcompany/fund/actions/workflows/ci.yaml) [![Test coverage](https://coveralls.io/repos/github/oscmcompany/fund/badge.svg?branch=master)](https://coveralls.io/github/oscmcompany/fund?branch=master)
-
 ## About
 
 The **fund** repository holds the resources for the Open Source Capital Management platform.

--- a/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
@@ -18,6 +18,7 @@ from alpaca.trading.enums import (
     AssetStatus,
     OrderSide,
     OrderType,
+    PositionIntent,
     TimeInForce,
 )
 
@@ -115,6 +116,7 @@ class AlpacaClient:
                 side=OrderSide.SELL,
                 type=OrderType.MARKET,
                 time_in_force=TimeInForce.DAY,
+                position_intent=PositionIntent.SELL_TO_OPEN,
             )
         else:
             # Long buys use notional so Alpaca handles fractional shares automatically.
@@ -124,6 +126,7 @@ class AlpacaClient:
                 side=OrderSide.BUY,
                 type=OrderType.MARKET,
                 time_in_force=TimeInForce.DAY,
+                position_intent=PositionIntent.BUY_TO_OPEN,
             )
 
         try:

--- a/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
@@ -92,6 +92,13 @@ class AlpacaClient:
             )
             raise ValueError(message)
 
+        if entry_price <= 0:
+            message = (
+                f"Cannot open position for {ticker}: "
+                f"entry_price must be positive, got {entry_price}"
+            )
+            raise ValueError(message)
+
         if side == TradeSide.SELL:
             # Alpaca does not support fractional short sells; whole shares only.
             # Use the pre-computed quantity when available to avoid recomputation.

--- a/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
@@ -32,9 +32,11 @@ class AlpacaAccount:
         self,
         cash_amount: float,
         buying_power: float,
+        equity: float,
     ) -> None:
         self.cash_amount = cash_amount
         self.buying_power = buying_power
+        self.equity = equity
 
 
 class AlpacaClient:
@@ -72,6 +74,7 @@ class AlpacaClient:
         return AlpacaAccount(
             cash_amount=float(cast("str", account.cash)),
             buying_power=float(cast("str", account.buying_power)),
+            equity=float(cast("str", account.equity)),
         )
 
     def open_position(
@@ -79,9 +82,9 @@ class AlpacaClient:
         ticker: str,
         side: TradeSide,
         dollar_amount: float,
+        entry_price: float,
+        quantity: int | None = None,
     ) -> None:
-        # Use notional (dollar amount) for order submission
-        # This allows Alpaca to handle fractional shares automatically
         if dollar_amount <= 0:
             message = (
                 f"Cannot open position for {ticker}: "
@@ -89,27 +92,47 @@ class AlpacaClient:
             )
             raise ValueError(message)
 
-        try:
-            self.trading_client.submit_order(
-                order_data=OrderRequest(
-                    symbol=ticker.upper(),
-                    notional=dollar_amount,
-                    side=OrderSide(side.value.lower()),
-                    type=OrderType.MARKET,
-                    time_in_force=TimeInForce.DAY,
-                ),
+        if side == TradeSide.SELL:
+            # Alpaca does not support fractional short sells; whole shares only.
+            # Use the pre-computed quantity when available to avoid recomputation.
+            qty = quantity if quantity is not None else int(dollar_amount / entry_price)
+            if qty == 0:
+                message = (
+                    f"Cannot short {ticker}: dollar_amount {dollar_amount} "
+                    f"is less than one share at entry_price {entry_price}"
+                )
+                raise ValueError(message)
+            order_request = OrderRequest(
+                symbol=ticker.upper(),
+                qty=qty,
+                side=OrderSide.SELL,
+                type=OrderType.MARKET,
+                time_in_force=TimeInForce.DAY,
             )
+        else:
+            # Long buys use notional so Alpaca handles fractional shares automatically.
+            order_request = OrderRequest(
+                symbol=ticker.upper(),
+                notional=round(dollar_amount, 2),
+                side=OrderSide.BUY,
+                type=OrderType.MARKET,
+                time_in_force=TimeInForce.DAY,
+            )
+
+        try:
+            self.trading_client.submit_order(order_data=order_request)
         except APIError as e:
             error_str = str(e).lower()
-            # Handle insufficient buying power
             if "insufficient buying power" in error_str or "buying_power" in error_str:
                 message = f"Insufficient buying power for {ticker}: {e}"
                 raise InsufficientBuyingPowerError(message) from e
-            # Handle non-shortable assets
-            if "cannot be sold short" in error_str or "not shortable" in error_str:
+            if (
+                "cannot be sold short" in error_str
+                or "not shortable" in error_str
+                or "not allowed to short" in error_str
+            ):
                 message = f"Asset {ticker} cannot be sold short: {e}"
                 raise AssetNotShortableError(message) from e
-            # Re-raise other API errors
             raise
 
         time.sleep(self.rate_limit_sleep)
@@ -131,6 +154,25 @@ class AlpacaClient:
             for asset in all_assets
             if asset.symbol in ticker_set and asset.shortable and asset.easy_to_borrow
         }
+
+    def get_open_positions(self) -> list[dict[str, object]]:
+        positions = cast(
+            "list[object]",
+            self.trading_client.get_all_positions(),
+        )
+        time.sleep(self.rate_limit_sleep)
+        return [
+            {
+                "ticker": str(getattr(position, "symbol", "")),
+                "side": str(getattr(position, "side", "")),
+                "quantity": float(str(getattr(position, "qty", "0"))),
+                "market_value": float(str(getattr(position, "market_value", "0"))),
+                "unrealized_profit_and_loss": float(
+                    str(getattr(position, "unrealized_pl", "0"))
+                ),
+            }
+            for position in positions
+        ]
 
     def close_position(
         self,

--- a/applications/portfolio_manager/src/portfolio_manager/configuration.py
+++ b/applications/portfolio_manager/src/portfolio_manager/configuration.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Configuration:
+    # When True, positions are held overnight and overnight margin rules apply.
+    # Set to False for intraday strategies where positions are closed before
+    # market close and no overnight maintenance margin needs to be reserved.
+    hold_overnight: bool = True
+    # Minimum account equity required by Alpaca (FINRA rule) to execute short sells.
+    minimum_short_equity: float = 2000.0
+    # Multiplier Alpaca applies to the ask price when reserving buying power for
+    # short market orders (ask * buffer * qty charged against buying power).
+    short_buying_power_buffer: float = 1.03
+    # Maintenance margin rate for stocks priced at or above low_price_threshold.
+    # Applied only when hold_overnight=True.
+    overnight_margin_rate_standard: float = 0.30
+    # Maintenance margin rate for stocks priced below low_price_threshold.
+    # Applied only when hold_overnight=True.
+    overnight_margin_rate_low_price: float = 1.00
+    # Price boundary separating standard and low-price overnight margin rates.
+    low_price_threshold: float = 5.00

--- a/applications/portfolio_manager/src/portfolio_manager/portfolio_schema.py
+++ b/applications/portfolio_manager/src/portfolio_manager/portfolio_schema.py
@@ -197,6 +197,19 @@ portfolio_schema = pa.DataFrameSchema(
             required=False,
             nullable=True,
         ),
+        # quantity is non-null only for SHORT legs (whole-share count for Alpaca SELL).
+        "quantity": pa.Column(
+            dtype=pl.Int64,
+            required=False,
+            nullable=True,
+        ),
+        # notional is non-null only for LONG legs (dollar amount for Alpaca BUY).
+        "notional": pa.Column(
+            dtype=float,
+            checks=[pa.Check.greater_than(0)],
+            required=False,
+            nullable=True,
+        ),
     },
     unique=["ticker"],
     coerce=True,
@@ -205,10 +218,9 @@ portfolio_schema = pa.DataFrameSchema(
             check_fn=check_position_side_counts,
             error="Each side must have expected position counts",
         ),
-        pa.Check(
-            check_fn=check_position_side_sums,
-            error="Position side sums must be approximately equal",
-        ),
+        # check_position_side_sums is intentionally omitted: short legs are
+        # constrained to whole shares, so their actual dollar amounts may differ
+        # from the long notional amounts by up to one share price per pair.
         pa.Check(
             check_fn=check_open_positions_have_entry_price,
             error="entry_price must be present and > 0 for OPEN_POSITION rows",

--- a/applications/portfolio_manager/src/portfolio_manager/rebalance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/rebalance.py
@@ -292,11 +292,14 @@ async def run_rebalance(  # noqa: PLR0911, PLR0912, PLR0915, C901
     )
     try:
         account = alpaca_client.get_account()
-    except Exception as e:  # noqa: BLE001
-        logger.warning(
-            "Failed to refresh account after closing positions, using prior snapshot",
+    except Exception as e:
+        logger.exception(
+            "Failed to refresh account after closing positions, aborting open phase",
             error=str(e),
         )
+        metrics.rebalance_errors_total.labels(stage="account_refresh").inc()
+        metrics.observe_duration(start)
+        return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
     open_results, opened_count = execute_open_positions(
         alpaca_client,
         open_positions,
@@ -308,8 +311,12 @@ async def run_rebalance(  # noqa: PLR0911, PLR0912, PLR0915, C901
     metrics.positions_opened_count.set(opened_count)
     metrics.positions_closed_count.set(closed_count)
 
+    opened_tickers = {r["ticker"] for r in open_results if r["status"] == "succeeded"}
+    successful_open_rows = optimal_portfolio.filter(
+        pl.col("ticker").is_in(opened_tickers)
+    )
     held_rows = prior_portfolio.filter(pl.col("ticker").is_in(held_tickers))
-    final_portfolio = pl.concat([optimal_portfolio, held_rows])
+    final_portfolio = pl.concat([successful_open_rows, held_rows])
     save_succeeded = await save_portfolio(final_portfolio, current_timestamp)
 
     all_results = close_results + open_results

--- a/applications/portfolio_manager/src/portfolio_manager/rebalance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/rebalance.py
@@ -312,8 +312,20 @@ async def run_rebalance(  # noqa: PLR0911, PLR0912, PLR0915, C901
     metrics.positions_closed_count.set(closed_count)
 
     opened_tickers = {r["ticker"] for r in open_results if r["status"] == "success"}
+    # Only persist pairs where all legs opened successfully to avoid unbalanced exposure
+    successful_pair_ids = set(
+        optimal_portfolio.filter(pl.col("ticker").is_in(opened_tickers))
+        .group_by("pair_id")
+        .agg(pl.len().alias("opened_legs"))
+        .join(
+            optimal_portfolio.group_by("pair_id").agg(pl.len().alias("total_legs")),
+            on="pair_id",
+        )
+        .filter(pl.col("opened_legs") == pl.col("total_legs"))["pair_id"]
+        .to_list()
+    )
     successful_open_rows = optimal_portfolio.filter(
-        pl.col("ticker").is_in(opened_tickers)
+        pl.col("pair_id").is_in(successful_pair_ids)
     )
     held_rows = prior_portfolio.filter(pl.col("ticker").is_in(held_tickers))
     final_portfolio = pl.concat([successful_open_rows, held_rows])

--- a/applications/portfolio_manager/src/portfolio_manager/rebalance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/rebalance.py
@@ -240,6 +240,8 @@ async def run_rebalance(  # noqa: PLR0911, PLR0912, PLR0915, C901
             entry_prices=entry_prices_map,
             exposure_scale=exposure_scale,
             short_buying_power_buffer=configuration.short_buying_power_buffer,
+            hold_overnight=configuration.hold_overnight,
+            overnight_margin_rate_standard=configuration.overnight_margin_rate_standard,
         )
         logger.info("Created optimal portfolio", count=len(optimal_portfolio))
     except InsufficientPairsError as e:
@@ -350,6 +352,8 @@ def get_optimal_portfolio(  # noqa: PLR0913
     entry_prices: dict[str, float],
     exposure_scale: float,
     short_buying_power_buffer: float,
+    hold_overnight: bool,  # noqa: FBT001
+    overnight_margin_rate_standard: float,
 ) -> pl.DataFrame:
     optimal_portfolio = size_pairs_with_volatility_parity(
         candidate_pairs=candidate_pairs,
@@ -359,6 +363,8 @@ def get_optimal_portfolio(  # noqa: PLR0913
         entry_prices=entry_prices,
         exposure_scale=exposure_scale,
         short_buying_power_buffer=short_buying_power_buffer,
+        hold_overnight=hold_overnight,
+        overnight_margin_rate_standard=overnight_margin_rate_standard,
     )
 
     return portfolio_schema.validate(optimal_portfolio)

--- a/applications/portfolio_manager/src/portfolio_manager/rebalance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/rebalance.py
@@ -290,6 +290,13 @@ async def run_rebalance(  # noqa: PLR0911, PLR0912, PLR0915, C901
     close_results, closed_count = execute_close_positions(
         alpaca_client, close_positions
     )
+    try:
+        account = alpaca_client.get_account()
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Failed to refresh account after closing positions, using prior snapshot",
+            error=str(e),
+        )
     open_results, opened_count = execute_open_positions(
         alpaca_client,
         open_positions,

--- a/applications/portfolio_manager/src/portfolio_manager/rebalance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/rebalance.py
@@ -221,9 +221,12 @@ async def run_rebalance(  # noqa: PLR0911, PLR0912, PLR0915, C901
     entry_prices_map: dict[str, float] = {
         row["ticker"]: row["entry_price"]
         for row in (
-            historical_prices.sort("timestamp", descending=True)
-            .group_by("ticker")
-            .agg(pl.col("close_price").first().alias("entry_price"))
+            historical_prices.group_by("ticker").agg(
+                pl.col("close_price")
+                .sort_by("timestamp", descending=True)
+                .first()
+                .alias("entry_price")
+            )
         ).iter_rows(named=True)
         if row["entry_price"] is not None and row["entry_price"] > 0
     }

--- a/applications/portfolio_manager/src/portfolio_manager/rebalance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/rebalance.py
@@ -311,7 +311,7 @@ async def run_rebalance(  # noqa: PLR0911, PLR0912, PLR0915, C901
     metrics.positions_opened_count.set(opened_count)
     metrics.positions_closed_count.set(closed_count)
 
-    opened_tickers = {r["ticker"] for r in open_results if r["status"] == "succeeded"}
+    opened_tickers = {r["ticker"] for r in open_results if r["status"] == "success"}
     successful_open_rows = optimal_portfolio.filter(
         pl.col("ticker").is_in(opened_tickers)
     )

--- a/applications/portfolio_manager/src/portfolio_manager/rebalance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/rebalance.py
@@ -242,6 +242,7 @@ async def run_rebalance(  # noqa: PLR0911, PLR0912, PLR0915, C901
             short_buying_power_buffer=configuration.short_buying_power_buffer,
             hold_overnight=configuration.hold_overnight,
             overnight_margin_rate_standard=configuration.overnight_margin_rate_standard,
+            overnight_margin_rate_low_price=configuration.overnight_margin_rate_low_price,
         )
         logger.info("Created optimal portfolio", count=len(optimal_portfolio))
     except InsufficientPairsError as e:
@@ -354,6 +355,7 @@ def get_optimal_portfolio(  # noqa: PLR0913
     short_buying_power_buffer: float,
     hold_overnight: bool,  # noqa: FBT001
     overnight_margin_rate_standard: float,
+    overnight_margin_rate_low_price: float,
 ) -> pl.DataFrame:
     optimal_portfolio = size_pairs_with_volatility_parity(
         candidate_pairs=candidate_pairs,
@@ -365,6 +367,7 @@ def get_optimal_portfolio(  # noqa: PLR0913
         short_buying_power_buffer=short_buying_power_buffer,
         hold_overnight=hold_overnight,
         overnight_margin_rate_standard=overnight_margin_rate_standard,
+        overnight_margin_rate_low_price=overnight_margin_rate_low_price,
     )
 
     return portfolio_schema.validate(optimal_portfolio)

--- a/applications/portfolio_manager/src/portfolio_manager/rebalance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/rebalance.py
@@ -9,6 +9,7 @@ from fastapi import Response, status
 from . import metrics
 from .alpaca_client import AlpacaAccount, AlpacaClient
 from .beta import compute_market_betas
+from .configuration import Configuration
 from .consolidation import consolidate_predictions
 from .data_client import fetch_equity_details, fetch_historical_prices, fetch_spy_prices
 from .exceptions import InsufficientPairsError
@@ -62,7 +63,12 @@ def _prune_pairs_with_invalid_entry_price(portfolio: pl.DataFrame) -> pl.DataFra
     return portfolio.filter(~pl.col("pair_id").is_in(invalid_pair_ids))
 
 
-async def run_rebalance(alpaca_client: AlpacaClient) -> Response:  # noqa: PLR0911, PLR0912, PLR0915, C901
+async def run_rebalance(  # noqa: PLR0911, PLR0912, PLR0915, C901
+    alpaca_client: AlpacaClient,
+    configuration: Configuration | None = None,
+) -> Response:
+    if configuration is None:
+        configuration = Configuration()
     metrics.rebalance_requests_total.inc()
     start = metrics.start_timer()
     current_timestamp = datetime.now(tz=UTC)
@@ -74,6 +80,7 @@ async def run_rebalance(alpaca_client: AlpacaClient) -> Response:  # noqa: PLR09
             "Retrieved account",
             cash_amount=account.cash_amount,
             buying_power=account.buying_power,
+            equity=account.equity,
         )
         metrics.account_cash.set(float(account.cash_amount))
         metrics.account_buying_power.set(float(account.buying_power))
@@ -209,13 +216,27 @@ async def run_rebalance(alpaca_client: AlpacaClient) -> Response:  # noqa: PLR09
         metrics.observe_duration(start)
         return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
+    # Build entry prices before portfolio sizing so risk management can enforce
+    # the whole-share constraint on short legs.
+    entry_prices_map: dict[str, float] = {
+        row["ticker"]: row["entry_price"]
+        for row in (
+            historical_prices.sort("timestamp", descending=True)
+            .group_by("ticker")
+            .agg(pl.col("close_price").first().alias("entry_price"))
+        ).iter_rows(named=True)
+        if row["entry_price"] is not None and row["entry_price"] > 0
+    }
+
     try:
         optimal_portfolio = get_optimal_portfolio(
             candidate_pairs=candidate_pairs,
             maximum_capital=float(account.cash_amount),
             current_timestamp=current_timestamp,
             market_betas=market_betas,
+            entry_prices=entry_prices_map,
             exposure_scale=exposure_scale,
+            short_buying_power_buffer=configuration.short_buying_power_buffer,
         )
         logger.info("Created optimal portfolio", count=len(optimal_portfolio))
     except InsufficientPairsError as e:
@@ -236,13 +257,8 @@ async def run_rebalance(alpaca_client: AlpacaClient) -> Response:  # noqa: PLR09
         metrics.observe_duration(start)
         return Response(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    latest_prices = (
-        historical_prices.sort("timestamp", descending=True)
-        .group_by("ticker")
-        .agg(pl.col("close_price").first().alias("entry_price"))
-    )
-    optimal_portfolio = optimal_portfolio.join(latest_prices, on="ticker", how="left")
-
+    # entry_price is embedded in optimal_portfolio by size_pairs_with_volatility_parity;
+    # prune any pairs that still have missing or invalid entry prices as a safety guard.
     optimal_portfolio = _prune_pairs_with_invalid_entry_price(optimal_portfolio)
 
     try:
@@ -269,7 +285,11 @@ async def run_rebalance(alpaca_client: AlpacaClient) -> Response:  # noqa: PLR09
         alpaca_client, close_positions
     )
     open_results, opened_count = execute_open_positions(
-        alpaca_client, open_positions, account.buying_power
+        alpaca_client,
+        open_positions,
+        account.buying_power,
+        account.equity,
+        configuration,
     )
 
     metrics.positions_opened_count.set(opened_count)
@@ -319,19 +339,23 @@ async def get_raw_predictions() -> pl.DataFrame:
         return pl.DataFrame(response.json()["data"])
 
 
-def get_optimal_portfolio(
+def get_optimal_portfolio(  # noqa: PLR0913
     candidate_pairs: pl.DataFrame,
     maximum_capital: float,
     current_timestamp: datetime,
     market_betas: pl.DataFrame,
+    entry_prices: dict[str, float],
     exposure_scale: float,
+    short_buying_power_buffer: float,
 ) -> pl.DataFrame:
     optimal_portfolio = size_pairs_with_volatility_parity(
         candidate_pairs=candidate_pairs,
         maximum_capital=maximum_capital,
         current_timestamp=current_timestamp,
         market_betas=market_betas,
+        entry_prices=entry_prices,
         exposure_scale=exposure_scale,
+        short_buying_power_buffer=short_buying_power_buffer,
     )
 
     return portfolio_schema.validate(optimal_portfolio)

--- a/applications/portfolio_manager/src/portfolio_manager/risk_management.py
+++ b/applications/portfolio_manager/src/portfolio_manager/risk_management.py
@@ -207,6 +207,13 @@ def size_pairs_with_volatility_parity(  # noqa: PLR0913
         )
         pairs = pairs.filter(pl.col("_short_qty") > 0)
 
+    if 0 < pairs.height < REQUIRED_PAIRS:
+        message = (
+            f"Only {pairs.height} viable pairs remain after zero-quantity filter, "
+            f"need at least {REQUIRED_PAIRS}."
+        )
+        raise InsufficientPairsError(message)
+
     if pairs.height == 0:
         message = "No viable pairs remain after whole-share short constraint."
         raise InsufficientPairsError(message)

--- a/applications/portfolio_manager/src/portfolio_manager/risk_management.py
+++ b/applications/portfolio_manager/src/portfolio_manager/risk_management.py
@@ -73,6 +73,7 @@ def size_pairs_with_volatility_parity(  # noqa: PLR0913
     short_buying_power_buffer: float = 1.03,
     hold_overnight: bool = True,  # noqa: FBT001, FBT002
     overnight_margin_rate_standard: float = 0.30,
+    overnight_margin_rate_low_price: float = 1.00,
 ) -> pl.DataFrame:
     """Size pairs so each contributes equal risk, then optimize for beta neutrality.
 
@@ -95,7 +96,18 @@ def size_pairs_with_volatility_parity(  # noqa: PLR0913
     # discarding pairs that the optimizer might assign a higher-than-equal weight.
     # Denominator accounts for the short buying power buffer and, when holding
     # overnight, the maintenance margin so the capital budget matches execution.
-    overnight_margin_rate = overnight_margin_rate_standard if hold_overnight else 0.0
+    # When holding overnight, the more conservative (higher) of the two margin rates
+    # is used so that low-priced shorts are not oversized relative to the buying
+    # power cost that execute_open_positions will charge at execution time.
+    # REQUIRED_PAIRS (the target pair count) is used as the divisor rather than
+    # feasible_pairs.height so the bound is stable before filtering; pairs whose
+    # short price exceeds this upper bound cannot be afforded at any weight the
+    # optimizer assigns within BETA_WEIGHT_UPPER_BOUND of an equal allocation.
+    overnight_margin_rate = 0.0
+    if hold_overnight:
+        overnight_margin_rate = max(
+            overnight_margin_rate_standard, overnight_margin_rate_low_price
+        )
     capital_divisor = 1.0 + short_buying_power_buffer + overnight_margin_rate
     maximum_per_pair_dollar = (
         (maximum_capital / capital_divisor)

--- a/applications/portfolio_manager/src/portfolio_manager/risk_management.py
+++ b/applications/portfolio_manager/src/portfolio_manager/risk_management.py
@@ -115,17 +115,25 @@ def size_pairs_with_volatility_parity(  # noqa: PLR0913
         * BETA_WEIGHT_UPPER_BOUND
         / REQUIRED_PAIRS
     )
+    long_prices = [
+        entry_prices.get(ticker, 0.0)
+        for ticker in candidate_pairs["long_ticker"].to_list()
+    ]
     short_prices = [
         entry_prices.get(ticker, 0.0)
         for ticker in candidate_pairs["short_ticker"].to_list()
     ]
     feasible_pairs = (
-        candidate_pairs.with_columns(pl.Series("_short_entry_price", short_prices))
+        candidate_pairs.with_columns(
+            pl.Series("_long_entry_price", long_prices),
+            pl.Series("_short_entry_price", short_prices),
+        )
         .filter(
-            (pl.col("_short_entry_price") > 0)
+            (pl.col("_long_entry_price") > 0)
+            & (pl.col("_short_entry_price") > 0)
             & (pl.col("_short_entry_price") <= maximum_per_pair_dollar)
         )
-        .drop("_short_entry_price")
+        .drop("_long_entry_price", "_short_entry_price")
     )
 
     if feasible_pairs.height < REQUIRED_PAIRS:

--- a/applications/portfolio_manager/src/portfolio_manager/risk_management.py
+++ b/applications/portfolio_manager/src/portfolio_manager/risk_management.py
@@ -62,31 +62,65 @@ def _apply_beta_neutral_weights(
     return volatility_parity_weights
 
 
-def size_pairs_with_volatility_parity(
+def size_pairs_with_volatility_parity(  # noqa: PLR0913
     candidate_pairs: pl.DataFrame,
     maximum_capital: float,
     current_timestamp: datetime,
     market_betas: pl.DataFrame,
+    entry_prices: dict[str, float],
     exposure_scale: float = 1.0,
+    # Default mirrors Configuration.short_buying_power_buffer.
+    short_buying_power_buffer: float = 1.03,
 ) -> pl.DataFrame:
     """Size pairs so each contributes equal risk, then optimize for beta neutrality.
 
     Pairs with lower realized spread volatility receive more capital so that every
     pair contributes the same risk to the portfolio (volatility parity). A SLSQP
     optimizer then nudges the weights to drive net portfolio beta toward zero.
-    Each pair is dollar-neutral: the same dollar amount is allocated to both legs.
+    Each pair is dollar-neutral: the short leg is floored to whole shares (Alpaca
+    does not support fractional short sells), and the long notional is matched to
+    the short's whole-share-adjusted amount so each pair is exactly balanced.
+    The capital split accounts for Alpaca's short buying power reservation
+    (ask * short_buying_power_buffer * qty), so the total buying power consumed
+    equals maximum_capital.
     The exposure_scale parameter is a regime-driven multiplier (1.0x for
     mean_reversion, 0.5x for trending) applied before the final dollar amounts.
     """
-    if candidate_pairs.height < REQUIRED_PAIRS:
+    # Pre-filter: remove pairs whose short leg cannot fill at least 1 whole share
+    # at the maximum possible per-pair allocation the optimizer can assign.
+    # Upper bound uses BETA_WEIGHT_UPPER_BOUND to stay conservative without
+    # discarding pairs that the optimizer might assign a higher-than-equal weight.
+    # Denominator accounts for the short buying power buffer so the capital budget
+    # matches what is used in the optimizer below.
+    capital_divisor = 1.0 + short_buying_power_buffer
+    maximum_per_pair_dollar = (
+        (maximum_capital / capital_divisor)
+        * exposure_scale
+        * BETA_WEIGHT_UPPER_BOUND
+        / REQUIRED_PAIRS
+    )
+    short_prices = [
+        entry_prices.get(ticker, 0.0)
+        for ticker in candidate_pairs["short_ticker"].to_list()
+    ]
+    feasible_pairs = (
+        candidate_pairs.with_columns(pl.Series("_short_entry_price", short_prices))
+        .filter(
+            (pl.col("_short_entry_price") > 0)
+            & (pl.col("_short_entry_price") <= maximum_per_pair_dollar)
+        )
+        .drop("_short_entry_price")
+    )
+
+    if feasible_pairs.height < REQUIRED_PAIRS:
         message = (
-            f"Only {candidate_pairs.height} pairs available, "
-            f"need at least {REQUIRED_PAIRS}."
+            f"Only {feasible_pairs.height} pairs available after whole-share short "
+            f"constraint filter, need at least {REQUIRED_PAIRS}."
         )
         raise InsufficientPairsError(message)
 
     pairs = (
-        candidate_pairs.head(REQUIRED_PAIRS)
+        feasible_pairs.head(REQUIRED_PAIRS)
         .with_columns(
             (
                 (
@@ -116,8 +150,42 @@ def size_pairs_with_volatility_parity(
     else:
         adjusted_weights = adjusted_weights / adjusted_weights.sum()
 
-    dollar_amounts = adjusted_weights * (maximum_capital / 2.0) * exposure_scale
+    dollar_amounts = (
+        adjusted_weights * (maximum_capital / capital_divisor) * exposure_scale
+    )
     pairs = pairs.with_columns(pl.Series("dollar_amount", dollar_amounts))
+
+    # Apply whole-share constraint to short legs: floor to the nearest whole share.
+    # Long legs retain the full notional amount (fractional shares are supported).
+    short_prices_for_pairs = [
+        entry_prices.get(ticker, 0.0) for ticker in pairs["short_ticker"].to_list()
+    ]
+    pairs = (
+        pairs.with_columns(pl.Series("_short_entry_price", short_prices_for_pairs))
+        .with_columns(
+            (pl.col("dollar_amount") / pl.col("_short_entry_price"))
+            .cast(pl.Int64)
+            .alias("_short_qty")
+        )
+        .with_columns(
+            (
+                pl.col("_short_qty").cast(pl.Float64) * pl.col("_short_entry_price")
+            ).alias("_short_dollar_amount")
+        )
+    )
+
+    # Drop any pairs where the optimizer assigned too little capital for even 1 share.
+    zero_qty_count = int(pairs.filter(pl.col("_short_qty") == 0).height)
+    if zero_qty_count > 0:
+        logger.warning(
+            "Dropped pairs with zero short quantity after optimization",
+            count=zero_qty_count,
+        )
+        pairs = pairs.filter(pl.col("_short_qty") > 0)
+
+    if pairs.height == 0:
+        message = "No viable pairs remain after whole-share short constraint."
+        raise InsufficientPairsError(message)
 
     logger.info(
         "Sized pairs with volatility parity",
@@ -127,22 +195,38 @@ def size_pairs_with_volatility_parity(
     )
 
     timestamp_val = to_timestamp_milliseconds(current_timestamp)
+
+    long_entry_prices = [
+        entry_prices.get(ticker, 0.0) for ticker in pairs["long_ticker"].to_list()
+    ]
+    # Long notional is matched to the short's whole-share-adjusted dollar amount so
+    # each pair is exactly dollar-neutral. quantity is null for long legs because
+    # Alpaca BUY orders use notional (fractional shares are supported).
     long_positions = pairs.select(
         pl.col("long_ticker").alias("ticker"),
         pl.lit(timestamp_val).cast(pl.Int64).alias("timestamp"),
         pl.lit(PositionSide.LONG.value).alias("side"),
-        pl.col("dollar_amount"),
+        pl.col("_short_dollar_amount").alias("dollar_amount"),
         pl.lit(PositionAction.OPEN_POSITION.value).alias("action"),
         pl.col("pair_id"),
+    ).with_columns(
+        pl.Series("entry_price", long_entry_prices),
+        pl.lit(None).cast(pl.Int64).alias("quantity"),
+        pl.col("dollar_amount").alias("notional"),
     )
 
+    # Short legs carry the pre-computed whole-share quantity. notional is null because
+    # Alpaca SELL orders must use qty (fractional short sells are not supported).
     short_positions = pairs.select(
         pl.col("short_ticker").alias("ticker"),
         pl.lit(timestamp_val).cast(pl.Int64).alias("timestamp"),
         pl.lit(PositionSide.SHORT.value).alias("side"),
-        pl.col("dollar_amount"),
+        pl.col("_short_dollar_amount").alias("dollar_amount"),
         pl.lit(PositionAction.OPEN_POSITION.value).alias("action"),
         pl.col("pair_id"),
+        pl.col("_short_entry_price").alias("entry_price"),
+        pl.col("_short_qty").alias("quantity"),
+        pl.lit(None).cast(pl.Float64).alias("notional"),
     )
 
     return pl.concat([long_positions, short_positions]).sort(["ticker", "side"])

--- a/applications/portfolio_manager/src/portfolio_manager/risk_management.py
+++ b/applications/portfolio_manager/src/portfolio_manager/risk_management.py
@@ -69,8 +69,10 @@ def size_pairs_with_volatility_parity(  # noqa: PLR0913
     market_betas: pl.DataFrame,
     entry_prices: dict[str, float],
     exposure_scale: float = 1.0,
-    # Default mirrors Configuration.short_buying_power_buffer.
+    # Defaults mirror Configuration fields.
     short_buying_power_buffer: float = 1.03,
+    hold_overnight: bool = True,  # noqa: FBT001, FBT002
+    overnight_margin_rate_standard: float = 0.30,
 ) -> pl.DataFrame:
     """Size pairs so each contributes equal risk, then optimize for beta neutrality.
 
@@ -81,7 +83,8 @@ def size_pairs_with_volatility_parity(  # noqa: PLR0913
     does not support fractional short sells), and the long notional is matched to
     the short's whole-share-adjusted amount so each pair is exactly balanced.
     The capital split accounts for Alpaca's short buying power reservation
-    (ask * short_buying_power_buffer * qty), so the total buying power consumed
+    (ask * short_buying_power_buffer * qty) and, when hold_overnight=True, the
+    overnight maintenance margin reserve, so the total buying power consumed
     equals maximum_capital.
     The exposure_scale parameter is a regime-driven multiplier (1.0x for
     mean_reversion, 0.5x for trending) applied before the final dollar amounts.
@@ -90,9 +93,10 @@ def size_pairs_with_volatility_parity(  # noqa: PLR0913
     # at the maximum possible per-pair allocation the optimizer can assign.
     # Upper bound uses BETA_WEIGHT_UPPER_BOUND to stay conservative without
     # discarding pairs that the optimizer might assign a higher-than-equal weight.
-    # Denominator accounts for the short buying power buffer so the capital budget
-    # matches what is used in the optimizer below.
-    capital_divisor = 1.0 + short_buying_power_buffer
+    # Denominator accounts for the short buying power buffer and, when holding
+    # overnight, the maintenance margin so the capital budget matches execution.
+    overnight_margin_rate = overnight_margin_rate_standard if hold_overnight else 0.0
+    capital_divisor = 1.0 + short_buying_power_buffer + overnight_margin_rate
     maximum_per_pair_dollar = (
         (maximum_capital / capital_divisor)
         * exposure_scale

--- a/applications/portfolio_manager/src/portfolio_manager/scheduler.py
+++ b/applications/portfolio_manager/src/portfolio_manager/scheduler.py
@@ -7,6 +7,7 @@ import structlog
 from fastapi import status
 
 from .alpaca_client import AlpacaClient
+from .configuration import Configuration
 from .rebalance import run_rebalance
 
 logger = structlog.get_logger()
@@ -69,11 +70,14 @@ async def _already_rebalanced_today(data_manager_base_url: str) -> bool:
 
 async def spawn_rebalance_scheduler(
     alpaca_client: AlpacaClient,
+    configuration: Configuration,
     data_manager_base_url: str,
     rebalance_lock: asyncio.Lock,
 ) -> asyncio.Task:
     task = asyncio.create_task(
-        _rebalance_loop(alpaca_client, data_manager_base_url, rebalance_lock)
+        _rebalance_loop(
+            alpaca_client, configuration, data_manager_base_url, rebalance_lock
+        )
     )
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.discard)
@@ -82,6 +86,7 @@ async def spawn_rebalance_scheduler(
 
 async def _rebalance_loop(  # noqa: C901
     alpaca_client: AlpacaClient,
+    configuration: Configuration,
     data_manager_base_url: str,
     rebalance_lock: asyncio.Lock,
 ) -> None:
@@ -131,7 +136,7 @@ async def _rebalance_loop(  # noqa: C901
             logger.info("Starting scheduled portfolio rebalance")
             try:
                 async with rebalance_lock:
-                    response = await run_rebalance(alpaca_client)
+                    response = await run_rebalance(alpaca_client, configuration)
                 if response.status_code != status.HTTP_200_OK:
                     logger.warning(
                         "Scheduled rebalance completed with non-200 status",

--- a/applications/portfolio_manager/src/portfolio_manager/server.py
+++ b/applications/portfolio_manager/src/portfolio_manager/server.py
@@ -14,6 +14,7 @@ from alpaca.common.exceptions import APIError
 from fastapi import FastAPI, Response, status
 
 from .alpaca_client import AlpacaClient
+from .configuration import Configuration
 from .metrics import (
     get_metrics,
 )
@@ -76,11 +77,17 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         api_secret=ALPACA_API_SECRET,
         is_paper=os.getenv("ALPACA_IS_PAPER", "true").lower() == "true",
     )
+    _app.state.configuration = Configuration(
+        hold_overnight=os.getenv("FUND_HOLD_OVERNIGHT", "true").lower() == "true",
+    )
     logger.info(
-        "Portfolio manager initialized", is_paper=_app.state.alpaca_client.is_paper
+        "Portfolio manager initialized",
+        is_paper=_app.state.alpaca_client.is_paper,
+        hold_overnight=_app.state.configuration.hold_overnight,
     )
     _app.state.scheduler_task = await spawn_rebalance_scheduler(
         alpaca_client=_app.state.alpaca_client,
+        configuration=_app.state.configuration,
         data_manager_base_url=DATA_MANAGER_BASE_URL,
         rebalance_lock=_rebalance_lock,
     )
@@ -143,4 +150,7 @@ async def create_portfolio() -> Response:
     if _rebalance_lock.locked():
         return Response(status_code=status.HTTP_409_CONFLICT)
     async with _rebalance_lock:
-        return await run_rebalance(application.state.alpaca_client)
+        return await run_rebalance(
+            application.state.alpaca_client,
+            application.state.configuration,
+        )

--- a/applications/portfolio_manager/src/portfolio_manager/trade_execution.py
+++ b/applications/portfolio_manager/src/portfolio_manager/trade_execution.py
@@ -3,6 +3,7 @@ import structlog
 
 from . import metrics
 from .alpaca_client import AlpacaClient
+from .configuration import Configuration
 from .enums import PositionSide, TradeSide
 from .exceptions import AssetNotShortableError, InsufficientBuyingPowerError
 
@@ -29,6 +30,9 @@ def get_positions(
                 else TradeSide.SELL
             ),
             "dollar_amount": row["dollar_amount"],
+            "entry_price": row["entry_price"],
+            "quantity": row.get("quantity"),
+            "notional": row.get("notional"),
         }
         for row in optimal_portfolio.iter_rows(named=True)
     ]
@@ -96,10 +100,12 @@ def execute_close_positions(
     return close_results, closed_count
 
 
-def execute_open_positions(
+def execute_open_positions(  # noqa: C901, PLR0915
     alpaca_client: AlpacaClient,
     open_positions: list[dict],
     initial_buying_power: float,
+    account_equity: float,
+    configuration: Configuration,
 ) -> tuple[list[dict], int]:
     open_results = []
     opened_count = 0
@@ -107,17 +113,104 @@ def execute_open_positions(
     skipped_insufficient_buying_power = 0
     skipped_not_shortable = 0
 
-    for open_position in open_positions:
+    # Submit all long (BUY) positions before short (SELL) positions so that long
+    # legs are established first and buying power is accurately reflected when
+    # evaluating each short leg.
+    sorted_positions = sorted(
+        open_positions,
+        key=lambda position: 0 if position["side"] == TradeSide.BUY else 1,
+    )
+
+    for open_position in sorted_positions:
         ticker = open_position["ticker"]
         side = open_position["side"]
         dollar_amount = open_position["dollar_amount"]
+        entry_price = open_position["entry_price"]
 
-        if dollar_amount > remaining_buying_power:
+        if side == TradeSide.SELL:
+            # Check minimum account equity required for short selling.
+            if account_equity < configuration.minimum_short_equity:
+                logger.warning(
+                    "Skipping short position due to insufficient account equity",
+                    ticker=ticker,
+                    account_equity=account_equity,
+                    minimum_short_equity=configuration.minimum_short_equity,
+                )
+                skipped_insufficient_buying_power += 1
+                metrics.trades_submitted_total.labels(
+                    action="open", status="skipped"
+                ).inc()
+                open_results.append(
+                    {
+                        "ticker": ticker,
+                        "action": "open",
+                        "side": side,
+                        "dollar_amount": dollar_amount,
+                        "status": "skipped",
+                        "reason": "insufficient_equity_for_short",
+                    }
+                )
+                continue
+
+            pre_computed_qty = open_position.get("quantity")
+            short_qty = (
+                pre_computed_qty
+                if pre_computed_qty is not None
+                else int(dollar_amount / entry_price)
+            )
+            if short_qty == 0:
+                logger.warning(
+                    "Skipping short position with zero quantity",
+                    ticker=ticker,
+                    dollar_amount=dollar_amount,
+                    entry_price=entry_price,
+                )
+                skipped_insufficient_buying_power += 1
+                metrics.trades_submitted_total.labels(
+                    action="open", status="skipped"
+                ).inc()
+                open_results.append(
+                    {
+                        "ticker": ticker,
+                        "action": "open",
+                        "side": side,
+                        "dollar_amount": dollar_amount,
+                        "status": "skipped",
+                        "reason": "zero_short_quantity",
+                    }
+                )
+                continue
+
+            # Alpaca reserves ask * 1.03 * qty against buying power for short
+            # market orders.
+            buying_power_cost = (
+                short_qty * entry_price * configuration.short_buying_power_buffer
+            )
+
+            if configuration.hold_overnight:
+                # Overnight maintenance margin: 30% for stocks >= $5, 100% for < $5.
+                margin_rate = (
+                    configuration.overnight_margin_rate_low_price
+                    if entry_price < configuration.low_price_threshold
+                    else configuration.overnight_margin_rate_standard
+                )
+                overnight_margin_reserve = short_qty * entry_price * margin_rate
+                logger.info(
+                    "Overnight margin reserve for short position",
+                    ticker=ticker,
+                    short_qty=short_qty,
+                    overnight_margin_reserve=overnight_margin_reserve,
+                    margin_rate=margin_rate,
+                )
+        else:
+            buying_power_cost = dollar_amount
+
+        if buying_power_cost > remaining_buying_power:
             logger.warning(
                 "Skipping position due to insufficient buying power",
                 ticker=ticker,
                 side=side,
-                dollar_amount=dollar_amount,
+                buying_power_cost=buying_power_cost,
                 remaining_buying_power=remaining_buying_power,
             )
             skipped_insufficient_buying_power += 1
@@ -139,6 +232,8 @@ def execute_open_positions(
                 ticker=ticker,
                 side=side,
                 dollar_amount=dollar_amount,
+                entry_price=entry_price,
+                quantity=open_position.get("quantity"),
             )
             logger.info(
                 "Opened position",
@@ -149,7 +244,7 @@ def execute_open_positions(
             opened_count += 1
             metrics.trades_submitted_total.labels(action="open", status="success").inc()
             metrics.trade_dollar_amount_total.labels(side=side.value).inc(dollar_amount)
-            # Refresh remaining buying power from the account after a successful order
+            # Refresh remaining buying power from the account after a successful order.
             try:
                 account = alpaca_client.get_account()
                 remaining_buying_power = account.buying_power
@@ -157,9 +252,9 @@ def execute_open_positions(
                 logger.exception(
                     "Failed to refresh buying power from account, using estimate",
                     ticker=ticker,
-                    deducting=dollar_amount,
+                    deducting=buying_power_cost,
                 )
-                remaining_buying_power -= dollar_amount
+                remaining_buying_power -= buying_power_cost
             open_results.append(
                 {
                     "ticker": ticker,

--- a/applications/portfolio_manager/src/portfolio_manager/trade_execution.py
+++ b/applications/portfolio_manager/src/portfolio_manager/trade_execution.py
@@ -195,6 +195,7 @@ def execute_open_positions(  # noqa: C901, PLR0915
                     else configuration.overnight_margin_rate_standard
                 )
                 overnight_margin_reserve = short_qty * entry_price * margin_rate
+                buying_power_cost += overnight_margin_reserve
                 logger.info(
                     "Overnight margin reserve for short position",
                     ticker=ticker,

--- a/applications/portfolio_manager/src/portfolio_manager/trade_execution.py
+++ b/applications/portfolio_manager/src/portfolio_manager/trade_execution.py
@@ -24,6 +24,7 @@ def get_positions(
     open_positions = [
         {
             "ticker": row["ticker"],
+            "pair_id": row["pair_id"],
             "side": (
                 TradeSide.BUY
                 if row["side"] == PositionSide.LONG.value
@@ -100,235 +101,268 @@ def execute_close_positions(
     return close_results, closed_count
 
 
-def execute_open_positions(  # noqa: C901, PLR0915
+def _try_open_single_position(  # noqa: PLR0911
+    alpaca_client: AlpacaClient,
+    position: dict,
+    remaining_buying_power: float,
+    account_equity: float,
+    configuration: Configuration,
+) -> tuple[dict, bool, float]:
+    """Attempt to open one leg of a pair. Returns (result, succeeded, updated_buying_power)."""  # noqa: E501
+    ticker = position["ticker"]
+    side = position["side"]
+    dollar_amount = position["dollar_amount"]
+    entry_price = position["entry_price"]
+
+    base_result: dict = {
+        "ticker": ticker,
+        "action": "open",
+        "side": side,
+        "dollar_amount": dollar_amount,
+    }
+
+    if side == TradeSide.SELL:
+        if account_equity < configuration.minimum_short_equity:
+            logger.warning(
+                "Skipping short position due to insufficient account equity",
+                ticker=ticker,
+                account_equity=account_equity,
+                minimum_short_equity=configuration.minimum_short_equity,
+            )
+            metrics.trades_submitted_total.labels(action="open", status="skipped").inc()
+            return (
+                {
+                    **base_result,
+                    "status": "skipped",
+                    "reason": "insufficient_equity_for_short",
+                },
+                False,
+                remaining_buying_power,
+            )
+
+        pre_computed_qty = position.get("quantity")
+        short_qty = (
+            pre_computed_qty
+            if pre_computed_qty is not None
+            else int(dollar_amount / entry_price)
+        )
+        if short_qty == 0:
+            logger.warning(
+                "Skipping short position with zero quantity",
+                ticker=ticker,
+                dollar_amount=dollar_amount,
+                entry_price=entry_price,
+            )
+            metrics.trades_submitted_total.labels(action="open", status="skipped").inc()
+            return (
+                {**base_result, "status": "skipped", "reason": "zero_short_quantity"},
+                False,
+                remaining_buying_power,
+            )
+
+        # Alpaca reserves ask * 1.03 * qty against buying power for short market orders.
+        buying_power_cost = (
+            short_qty * entry_price * configuration.short_buying_power_buffer
+        )
+
+        if configuration.hold_overnight:
+            # Overnight maintenance margin: 30% for stocks >= $5, 100% for < $5.
+            margin_rate = (
+                configuration.overnight_margin_rate_low_price
+                if entry_price < configuration.low_price_threshold
+                else configuration.overnight_margin_rate_standard
+            )
+            overnight_margin_reserve = short_qty * entry_price * margin_rate
+            buying_power_cost += overnight_margin_reserve
+            logger.info(
+                "Overnight margin reserve for short position",
+                ticker=ticker,
+                short_qty=short_qty,
+                overnight_margin_reserve=overnight_margin_reserve,
+                margin_rate=margin_rate,
+            )
+    else:
+        buying_power_cost = dollar_amount
+
+    if buying_power_cost > remaining_buying_power:
+        logger.warning(
+            "Skipping position due to insufficient buying power",
+            ticker=ticker,
+            side=side,
+            buying_power_cost=buying_power_cost,
+            remaining_buying_power=remaining_buying_power,
+        )
+        metrics.trades_submitted_total.labels(action="open", status="skipped").inc()
+        return (
+            {**base_result, "status": "skipped", "reason": "insufficient_buying_power"},
+            False,
+            remaining_buying_power,
+        )
+
+    try:
+        alpaca_client.open_position(
+            ticker=ticker,
+            side=side,
+            dollar_amount=dollar_amount,
+            entry_price=entry_price,
+            quantity=short_qty if side == TradeSide.SELL else position.get("quantity"),
+        )
+        logger.info(
+            "Opened position", ticker=ticker, side=side, dollar_amount=dollar_amount
+        )
+        metrics.trades_submitted_total.labels(action="open", status="success").inc()
+        metrics.trade_dollar_amount_total.labels(side=side.value).inc(dollar_amount)
+        # Refresh remaining buying power from the account after a successful order.
+        try:
+            account = alpaca_client.get_account()
+            new_buying_power = account.buying_power
+        except Exception:
+            logger.exception(
+                "Failed to refresh buying power from account, using estimate",
+                ticker=ticker,
+                deducting=buying_power_cost,
+            )
+            new_buying_power = remaining_buying_power - buying_power_cost
+        return ({**base_result, "status": "success"}, True, new_buying_power)  # noqa: TRY300
+    except InsufficientBuyingPowerError as e:
+        logger.warning(
+            "Insufficient buying power for position",
+            ticker=ticker,
+            side=side,
+            dollar_amount=dollar_amount,
+            error=str(e),
+        )
+        metrics.trades_submitted_total.labels(action="open", status="skipped").inc()
+        return (
+            {**base_result, "status": "skipped", "reason": "insufficient_buying_power"},
+            False,
+            remaining_buying_power,
+        )
+    except AssetNotShortableError as e:
+        logger.warning(
+            "Asset cannot be sold short", ticker=ticker, side=side, error=str(e)
+        )
+        metrics.trades_submitted_total.labels(action="open", status="skipped").inc()
+        return (
+            {**base_result, "status": "skipped", "reason": "not_shortable"},
+            False,
+            remaining_buying_power,
+        )
+    except Exception as e:
+        logger.exception("Failed to open position", ticker=ticker, error=str(e))
+        metrics.trades_submitted_total.labels(action="open", status="failed").inc()
+        return (
+            {**base_result, "status": "failed", "error": str(e)},
+            False,
+            remaining_buying_power,
+        )
+
+
+def execute_open_positions(  # noqa: C901, PLR0912, PLR0915
     alpaca_client: AlpacaClient,
     open_positions: list[dict],
     initial_buying_power: float,
     account_equity: float,
     configuration: Configuration,
 ) -> tuple[list[dict], int]:
-    open_results = []
+    open_results: list[dict] = []
     opened_count = 0
     remaining_buying_power = initial_buying_power
+
+    # Group positions by pair_id; within each pair, execute long before short so that
+    # each pair is traded atomically and the short is skipped if the long fails,
+    # preventing one-sided directional exposure.
+    pairs: dict[str, dict[str, dict]] = {}
+    for position in open_positions:
+        pair_id = position["pair_id"]
+        pairs.setdefault(pair_id, {})
+        if position["side"] == TradeSide.BUY:
+            pairs[pair_id]["long"] = position
+        else:
+            pairs[pair_id]["short"] = position
+
+    skipped_incomplete_pairs = 0
+    skipped_long_leg_failed = 0
     skipped_insufficient_buying_power = 0
     skipped_insufficient_equity = 0
     skipped_zero_quantity = 0
     skipped_not_shortable = 0
 
-    # Submit all long (BUY) positions before short (SELL) positions so that long
-    # legs are established first and buying power is accurately reflected when
-    # evaluating each short leg.
-    sorted_positions = sorted(
-        open_positions,
-        key=lambda position: 0 if position["side"] == TradeSide.BUY else 1,
-    )
+    for pair_id, legs in pairs.items():
+        long_leg = legs.get("long")
+        short_leg = legs.get("short")
 
-    for open_position in sorted_positions:
-        ticker = open_position["ticker"]
-        side = open_position["side"]
-        dollar_amount = open_position["dollar_amount"]
-        entry_price = open_position["entry_price"]
-
-        if side == TradeSide.SELL:
-            # Check minimum account equity required for short selling.
-            if account_equity < configuration.minimum_short_equity:
-                logger.warning(
-                    "Skipping short position due to insufficient account equity",
-                    ticker=ticker,
-                    account_equity=account_equity,
-                    minimum_short_equity=configuration.minimum_short_equity,
-                )
-                skipped_insufficient_equity += 1
-                metrics.trades_submitted_total.labels(
-                    action="open", status="skipped"
-                ).inc()
-                open_results.append(
-                    {
-                        "ticker": ticker,
-                        "action": "open",
-                        "side": side,
-                        "dollar_amount": dollar_amount,
-                        "status": "skipped",
-                        "reason": "insufficient_equity_for_short",
-                    }
-                )
-                continue
-
-            pre_computed_qty = open_position.get("quantity")
-            short_qty = (
-                pre_computed_qty
-                if pre_computed_qty is not None
-                else int(dollar_amount / entry_price)
-            )
-            if short_qty == 0:
-                logger.warning(
-                    "Skipping short position with zero quantity",
-                    ticker=ticker,
-                    dollar_amount=dollar_amount,
-                    entry_price=entry_price,
-                )
-                skipped_zero_quantity += 1
-                metrics.trades_submitted_total.labels(
-                    action="open", status="skipped"
-                ).inc()
-                open_results.append(
-                    {
-                        "ticker": ticker,
-                        "action": "open",
-                        "side": side,
-                        "dollar_amount": dollar_amount,
-                        "status": "skipped",
-                        "reason": "zero_short_quantity",
-                    }
-                )
-                continue
-
-            # Alpaca reserves ask * 1.03 * qty against buying power for short
-            # market orders.
-            buying_power_cost = (
-                short_qty * entry_price * configuration.short_buying_power_buffer
-            )
-
-            if configuration.hold_overnight:
-                # Overnight maintenance margin: 30% for stocks >= $5, 100% for < $5.
-                margin_rate = (
-                    configuration.overnight_margin_rate_low_price
-                    if entry_price < configuration.low_price_threshold
-                    else configuration.overnight_margin_rate_standard
-                )
-                overnight_margin_reserve = short_qty * entry_price * margin_rate
-                buying_power_cost += overnight_margin_reserve
-                logger.info(
-                    "Overnight margin reserve for short position",
-                    ticker=ticker,
-                    short_qty=short_qty,
-                    overnight_margin_reserve=overnight_margin_reserve,
-                    margin_rate=margin_rate,
-                )
-        else:
-            buying_power_cost = dollar_amount
-
-        if buying_power_cost > remaining_buying_power:
-            logger.warning(
-                "Skipping position due to insufficient buying power",
-                ticker=ticker,
-                side=side,
-                buying_power_cost=buying_power_cost,
-                remaining_buying_power=remaining_buying_power,
-            )
-            skipped_insufficient_buying_power += 1
-            metrics.trades_submitted_total.labels(action="open", status="skipped").inc()
-            open_results.append(
-                {
-                    "ticker": ticker,
-                    "action": "open",
-                    "side": side,
-                    "dollar_amount": dollar_amount,
-                    "status": "skipped",
-                    "reason": "insufficient_buying_power",
-                }
-            )
+        if long_leg is None or short_leg is None:
+            logger.warning("Incomplete pair, skipping", pair_id=pair_id)
+            skipped_incomplete_pairs += 1
             continue
 
-        try:
-            alpaca_client.open_position(
-                ticker=ticker,
-                side=side,
-                dollar_amount=dollar_amount,
-                entry_price=entry_price,
-                quantity=open_position.get("quantity"),
-            )
-            logger.info(
-                "Opened position",
-                ticker=ticker,
-                side=side,
-                dollar_amount=dollar_amount,
-            )
+        long_result, long_succeeded, remaining_buying_power = _try_open_single_position(
+            alpaca_client,
+            long_leg,
+            remaining_buying_power,
+            account_equity,
+            configuration,
+        )
+        open_results.append(long_result)
+        if long_succeeded:
             opened_count += 1
-            metrics.trades_submitted_total.labels(action="open", status="success").inc()
-            metrics.trade_dollar_amount_total.labels(side=side.value).inc(dollar_amount)
-            # Refresh remaining buying power from the account after a successful order.
-            try:
-                account = alpaca_client.get_account()
-                remaining_buying_power = account.buying_power
-            except Exception:
-                logger.exception(
-                    "Failed to refresh buying power from account, using estimate",
-                    ticker=ticker,
-                    deducting=buying_power_cost,
-                )
-                remaining_buying_power -= buying_power_cost
-            open_results.append(
-                {
-                    "ticker": ticker,
-                    "action": "open",
-                    "side": side,
-                    "dollar_amount": dollar_amount,
-                    "status": "success",
-                }
-            )
-        except InsufficientBuyingPowerError as e:
-            logger.warning(
-                "Insufficient buying power for position",
-                ticker=ticker,
-                side=side,
-                dollar_amount=dollar_amount,
-                error=str(e),
-            )
-            skipped_insufficient_buying_power += 1
+        else:
+            reason = long_result.get("reason", "")
+            if reason == "insufficient_buying_power":
+                skipped_insufficient_buying_power += 1
+            elif reason == "insufficient_equity_for_short":
+                skipped_insufficient_equity += 1
+            elif reason == "zero_short_quantity":
+                skipped_zero_quantity += 1
+            elif reason == "not_shortable":
+                skipped_not_shortable += 1
+
+            # Skip the short leg to avoid one-sided directional exposure.
             metrics.trades_submitted_total.labels(action="open", status="skipped").inc()
             open_results.append(
                 {
-                    "ticker": ticker,
+                    "ticker": short_leg["ticker"],
                     "action": "open",
-                    "side": side,
-                    "dollar_amount": dollar_amount,
+                    "side": short_leg["side"],
+                    "dollar_amount": short_leg["dollar_amount"],
                     "status": "skipped",
-                    "reason": "insufficient_buying_power",
+                    "reason": "long_leg_failed",
                 }
             )
-        except AssetNotShortableError as e:
-            logger.warning(
-                "Asset cannot be sold short",
-                ticker=ticker,
-                side=side,
-                error=str(e),
+            skipped_long_leg_failed += 1
+            continue
+
+        short_result, short_succeeded, remaining_buying_power = (
+            _try_open_single_position(
+                alpaca_client,
+                short_leg,
+                remaining_buying_power,
+                account_equity,
+                configuration,
             )
-            skipped_not_shortable += 1
-            metrics.trades_submitted_total.labels(action="open", status="skipped").inc()
-            open_results.append(
-                {
-                    "ticker": ticker,
-                    "action": "open",
-                    "side": side,
-                    "dollar_amount": dollar_amount,
-                    "status": "skipped",
-                    "reason": "not_shortable",
-                }
-            )
-        except Exception as e:
-            logger.exception(
-                "Failed to open position",
-                ticker=ticker,
-                error=str(e),
-            )
-            metrics.trades_submitted_total.labels(action="open", status="failed").inc()
-            open_results.append(
-                {
-                    "ticker": ticker,
-                    "action": "open",
-                    "side": side,
-                    "dollar_amount": dollar_amount,
-                    "status": "failed",
-                    "error": str(e),
-                }
-            )
+        )
+        open_results.append(short_result)
+        if short_succeeded:
+            opened_count += 1
+        else:
+            reason = short_result.get("reason", "")
+            if reason == "insufficient_buying_power":
+                skipped_insufficient_buying_power += 1
+            elif reason == "insufficient_equity_for_short":
+                skipped_insufficient_equity += 1
+            elif reason == "zero_short_quantity":
+                skipped_zero_quantity += 1
+            elif reason == "not_shortable":
+                skipped_not_shortable += 1
 
     any_skipped = (
         skipped_insufficient_buying_power > 0
         or skipped_insufficient_equity > 0
         or skipped_zero_quantity > 0
         or skipped_not_shortable > 0
+        or skipped_long_leg_failed > 0
+        or skipped_incomplete_pairs > 0
     )
     if any_skipped:
         logger.info(
@@ -337,6 +371,8 @@ def execute_open_positions(  # noqa: C901, PLR0915
             skipped_insufficient_equity=skipped_insufficient_equity,
             skipped_zero_quantity=skipped_zero_quantity,
             skipped_not_shortable=skipped_not_shortable,
+            skipped_long_leg_failed=skipped_long_leg_failed,
+            skipped_incomplete_pairs=skipped_incomplete_pairs,
         )
 
     return open_results, opened_count

--- a/applications/portfolio_manager/src/portfolio_manager/trade_execution.py
+++ b/applications/portfolio_manager/src/portfolio_manager/trade_execution.py
@@ -111,6 +111,8 @@ def execute_open_positions(  # noqa: C901, PLR0915
     opened_count = 0
     remaining_buying_power = initial_buying_power
     skipped_insufficient_buying_power = 0
+    skipped_insufficient_equity = 0
+    skipped_zero_quantity = 0
     skipped_not_shortable = 0
 
     # Submit all long (BUY) positions before short (SELL) positions so that long
@@ -136,7 +138,7 @@ def execute_open_positions(  # noqa: C901, PLR0915
                     account_equity=account_equity,
                     minimum_short_equity=configuration.minimum_short_equity,
                 )
-                skipped_insufficient_buying_power += 1
+                skipped_insufficient_equity += 1
                 metrics.trades_submitted_total.labels(
                     action="open", status="skipped"
                 ).inc()
@@ -165,7 +167,7 @@ def execute_open_positions(  # noqa: C901, PLR0915
                     dollar_amount=dollar_amount,
                     entry_price=entry_price,
                 )
-                skipped_insufficient_buying_power += 1
+                skipped_zero_quantity += 1
                 metrics.trades_submitted_total.labels(
                     action="open", status="skipped"
                 ).inc()
@@ -322,10 +324,18 @@ def execute_open_positions(  # noqa: C901, PLR0915
                 }
             )
 
-    if skipped_insufficient_buying_power > 0 or skipped_not_shortable > 0:
+    any_skipped = (
+        skipped_insufficient_buying_power > 0
+        or skipped_insufficient_equity > 0
+        or skipped_zero_quantity > 0
+        or skipped_not_shortable > 0
+    )
+    if any_skipped:
         logger.info(
             "Some positions were skipped",
             skipped_insufficient_buying_power=skipped_insufficient_buying_power,
+            skipped_insufficient_equity=skipped_insufficient_equity,
+            skipped_zero_quantity=skipped_zero_quantity,
             skipped_not_shortable=skipped_not_shortable,
         )
 

--- a/applications/portfolio_manager/tests/test_alpaca_client.py
+++ b/applications/portfolio_manager/tests/test_alpaca_client.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from alpaca.trading.enums import AssetClass, AssetStatus
+from alpaca.trading.enums import AssetClass, AssetStatus, OrderSide
 from alpaca.trading.requests import GetAssetsRequest
 from portfolio_manager.alpaca_client import AlpacaAccount, AlpacaClient
 from portfolio_manager.enums import TradeSide
@@ -51,6 +51,7 @@ def _make_mock_asset(
 
 EXPECTED_CASH = 1000.0
 EXPECTED_BUYING_POWER = 2000.0
+EXPECTED_EQUITY = 3000.0
 
 
 @patch("portfolio_manager.alpaca_client.time.sleep")
@@ -85,11 +86,14 @@ def test_is_market_open_returns_false_when_market_is_closed(
 
 def test_alpaca_account_stores_values() -> None:
     account = AlpacaAccount(
-        cash_amount=EXPECTED_CASH, buying_power=EXPECTED_BUYING_POWER
+        cash_amount=EXPECTED_CASH,
+        buying_power=EXPECTED_BUYING_POWER,
+        equity=EXPECTED_EQUITY,
     )
 
     assert account.cash_amount == EXPECTED_CASH
     assert account.buying_power == EXPECTED_BUYING_POWER
+    assert account.equity == EXPECTED_EQUITY
 
 
 @patch("portfolio_manager.alpaca_client.time.sleep")
@@ -98,14 +102,17 @@ def test_get_account_returns_account(mock_sleep: MagicMock) -> None:
     mock_account = MagicMock()
     expected_cash_amount = 5000.0
     expected_account_buying_power = 10000.0
+    expected_account_equity = 15000.0
     mock_account.cash = "5000.00"
     mock_account.buying_power = "10000.00"
+    mock_account.equity = "15000.00"
     mock_trading.get_account.return_value = mock_account
 
     result = client.get_account()
 
     assert result.cash_amount == expected_cash_amount
     assert result.buying_power == expected_account_buying_power
+    assert result.equity == expected_account_equity
     mock_sleep.assert_called_once_with(client.rate_limit_sleep)
 
 
@@ -113,9 +120,33 @@ def test_get_account_returns_account(mock_sleep: MagicMock) -> None:
 def test_open_position_buy_submits_order(mock_sleep: MagicMock) -> None:
     client, mock_trading = _make_client()
 
-    client.open_position(ticker="aapl", side=TradeSide.BUY, dollar_amount=500.0)
+    client.open_position(
+        ticker="aapl", side=TradeSide.BUY, dollar_amount=500.0, entry_price=50.0
+    )
 
     mock_trading.submit_order.assert_called_once()
+    mock_sleep.assert_called_once_with(client.rate_limit_sleep)
+
+
+_EXPECTED_BUY_NOTIONAL = 500.0
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_open_position_buy_uses_notional(mock_sleep: MagicMock) -> None:
+    client, mock_trading = _make_client()
+
+    client.open_position(
+        ticker="AAPL",
+        side=TradeSide.BUY,
+        dollar_amount=_EXPECTED_BUY_NOTIONAL,
+        entry_price=50.0,
+    )
+
+    submitted = mock_trading.submit_order.call_args
+    order_request = submitted[1]["order_data"] if submitted[1] else submitted[0][0]
+    assert order_request.side == OrderSide.BUY
+    assert order_request.notional == _EXPECTED_BUY_NOTIONAL
+    assert not hasattr(order_request, "qty") or order_request.qty is None
     mock_sleep.assert_called_once_with(client.rate_limit_sleep)
 
 
@@ -123,24 +154,63 @@ def test_open_position_buy_submits_order(mock_sleep: MagicMock) -> None:
 def test_open_position_sell_submits_order(mock_sleep: MagicMock) -> None:
     client, mock_trading = _make_client()
 
-    client.open_position(ticker="aapl", side=TradeSide.SELL, dollar_amount=500.0)
+    client.open_position(
+        ticker="aapl", side=TradeSide.SELL, dollar_amount=500.0, entry_price=50.0
+    )
 
     mock_trading.submit_order.assert_called_once()
     mock_sleep.assert_called_once_with(client.rate_limit_sleep)
+
+
+_EXPECTED_SELL_QTY = 10  # int(500.0 / 50.0)
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_open_position_sell_uses_qty_not_notional(mock_sleep: MagicMock) -> None:
+    client, mock_trading = _make_client()
+
+    client.open_position(
+        ticker="AAPL",
+        side=TradeSide.SELL,
+        dollar_amount=500.0,
+        entry_price=50.0,
+        quantity=_EXPECTED_SELL_QTY,
+    )
+
+    submitted = mock_trading.submit_order.call_args
+    order_request = submitted[1]["order_data"] if submitted[1] else submitted[0][0]
+    assert order_request.side == OrderSide.SELL
+    assert order_request.qty == _EXPECTED_SELL_QTY
+    assert not hasattr(order_request, "notional") or order_request.notional is None
+    mock_sleep.assert_called_once_with(client.rate_limit_sleep)
+
+
+def test_open_position_sell_raises_value_error_for_zero_qty() -> None:
+    client, _ = _make_client()
+
+    # dollar_amount < entry_price means qty would be 0
+    with pytest.raises(ValueError, match="less than one share"):
+        client.open_position(
+            ticker="AAPL", side=TradeSide.SELL, dollar_amount=10.0, entry_price=100.0
+        )
 
 
 def test_open_position_raises_value_error_for_zero_amount() -> None:
     client, _ = _make_client()
 
     with pytest.raises(ValueError, match="non-positive dollar_amount"):
-        client.open_position(ticker="AAPL", side=TradeSide.BUY, dollar_amount=0.0)
+        client.open_position(
+            ticker="AAPL", side=TradeSide.BUY, dollar_amount=0.0, entry_price=50.0
+        )
 
 
 def test_open_position_raises_value_error_for_negative_amount() -> None:
     client, _ = _make_client()
 
     with pytest.raises(ValueError, match="non-positive dollar_amount"):
-        client.open_position(ticker="AAPL", side=TradeSide.BUY, dollar_amount=-100.0)
+        client.open_position(
+            ticker="AAPL", side=TradeSide.BUY, dollar_amount=-100.0, entry_price=50.0
+        )
 
 
 @patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
@@ -149,7 +219,9 @@ def test_open_position_raises_insufficient_buying_power_error() -> None:
     mock_trading.submit_order.side_effect = _FakeAPIError("insufficient buying power")
 
     with pytest.raises(InsufficientBuyingPowerError):
-        client.open_position(ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0)
+        client.open_position(
+            ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0, entry_price=50.0
+        )
 
 
 @patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
@@ -160,7 +232,9 @@ def test_open_position_raises_insufficient_buying_power_error_on_buying_power_ke
     mock_trading.submit_order.side_effect = _FakeAPIError("buying_power exceeded")
 
     with pytest.raises(InsufficientBuyingPowerError):
-        client.open_position(ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0)
+        client.open_position(
+            ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0, entry_price=50.0
+        )
 
 
 @patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
@@ -171,7 +245,9 @@ def test_open_position_raises_asset_not_shortable_error_on_cannot_be_sold_short(
     mock_trading.submit_order.side_effect = _FakeAPIError("cannot be sold short")
 
     with pytest.raises(AssetNotShortableError):
-        client.open_position(ticker="AAPL", side=TradeSide.SELL, dollar_amount=500.0)
+        client.open_position(
+            ticker="AAPL", side=TradeSide.SELL, dollar_amount=500.0, entry_price=50.0
+        )
 
 
 @patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
@@ -182,7 +258,24 @@ def test_open_position_raises_asset_not_shortable_error_on_not_shortable_keyword
     mock_trading.submit_order.side_effect = _FakeAPIError("asset not shortable")
 
     with pytest.raises(AssetNotShortableError):
-        client.open_position(ticker="AAPL", side=TradeSide.SELL, dollar_amount=500.0)
+        client.open_position(
+            ticker="AAPL", side=TradeSide.SELL, dollar_amount=500.0, entry_price=50.0
+        )
+
+
+@patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
+def test_open_position_raises_asset_not_shortable_error_on_not_allowed_to_short() -> (
+    None
+):
+    client, mock_trading = _make_client()
+    mock_trading.submit_order.side_effect = _FakeAPIError(
+        "account is not allowed to short"
+    )
+
+    with pytest.raises(AssetNotShortableError):
+        client.open_position(
+            ticker="AAPL", side=TradeSide.SELL, dollar_amount=500.0, entry_price=50.0
+        )
 
 
 @patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
@@ -191,7 +284,9 @@ def test_open_position_reraises_other_api_errors() -> None:
     mock_trading.submit_order.side_effect = _FakeAPIError("some unhandled error")
 
     with pytest.raises(_FakeAPIError):
-        client.open_position(ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0)
+        client.open_position(
+            ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0, entry_price=50.0
+        )
 
 
 @patch("portfolio_manager.alpaca_client.time.sleep")

--- a/applications/portfolio_manager/tests/test_alpaca_client.py
+++ b/applications/portfolio_manager/tests/test_alpaca_client.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from alpaca.trading.enums import AssetClass, AssetStatus, OrderSide
+from alpaca.trading.enums import AssetClass, AssetStatus, OrderSide, PositionIntent
 from alpaca.trading.requests import GetAssetsRequest
 from portfolio_manager.alpaca_client import AlpacaAccount, AlpacaClient
 from portfolio_manager.enums import TradeSide
@@ -182,6 +182,42 @@ def test_open_position_sell_uses_qty_not_notional(mock_sleep: MagicMock) -> None
     assert order_request.side == OrderSide.SELL
     assert order_request.qty == _EXPECTED_SELL_QTY
     assert not hasattr(order_request, "notional") or order_request.notional is None
+    mock_sleep.assert_called_once_with(client.rate_limit_sleep)
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_open_position_buy_includes_position_intent_buy_to_open(
+    mock_sleep: MagicMock,
+) -> None:
+    client, mock_trading = _make_client()
+
+    client.open_position(
+        ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0, entry_price=50.0
+    )
+
+    submitted = mock_trading.submit_order.call_args
+    order_request = submitted[1]["order_data"] if submitted[1] else submitted[0][0]
+    assert order_request.position_intent == PositionIntent.BUY_TO_OPEN
+    mock_sleep.assert_called_once_with(client.rate_limit_sleep)
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_open_position_sell_includes_position_intent_sell_to_open(
+    mock_sleep: MagicMock,
+) -> None:
+    client, mock_trading = _make_client()
+
+    client.open_position(
+        ticker="AAPL",
+        side=TradeSide.SELL,
+        dollar_amount=500.0,
+        entry_price=50.0,
+        quantity=10,
+    )
+
+    submitted = mock_trading.submit_order.call_args
+    order_request = submitted[1]["order_data"] if submitted[1] else submitted[0][0]
+    assert order_request.position_intent == PositionIntent.SELL_TO_OPEN
     mock_sleep.assert_called_once_with(client.rate_limit_sleep)
 
 

--- a/applications/portfolio_manager/tests/test_alpaca_client.py
+++ b/applications/portfolio_manager/tests/test_alpaca_client.py
@@ -213,6 +213,51 @@ def test_open_position_raises_value_error_for_negative_amount() -> None:
         )
 
 
+def test_open_position_raises_value_error_for_zero_entry_price() -> None:
+    client, _ = _make_client()
+
+    with pytest.raises(ValueError, match="entry_price must be positive"):
+        client.open_position(
+            ticker="AAPL", side=TradeSide.SELL, dollar_amount=100.0, entry_price=0.0
+        )
+
+
+def test_open_position_raises_value_error_for_negative_entry_price() -> None:
+    client, _ = _make_client()
+
+    with pytest.raises(ValueError, match="entry_price must be positive"):
+        client.open_position(
+            ticker="AAPL", side=TradeSide.BUY, dollar_amount=100.0, entry_price=-50.0
+        )
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_get_open_positions_returns_position_list(mock_sleep: MagicMock) -> None:
+    client, mock_trading = _make_client()
+    expected_quantity = 10.0
+    expected_market_value = 1500.0
+    expected_unrealized_profit_and_loss = 50.0
+    mock_position = MagicMock()
+    mock_position.symbol = "AAPL"
+    mock_position.side = "long"
+    mock_position.qty = str(int(expected_quantity))
+    mock_position.market_value = str(expected_market_value)
+    mock_position.unrealized_pl = str(expected_unrealized_profit_and_loss)
+    mock_trading.get_all_positions.return_value = [mock_position]
+
+    result = client.get_open_positions()
+
+    assert len(result) == 1
+    assert result[0]["ticker"] == "AAPL"
+    assert result[0]["side"] == "long"
+    assert result[0]["quantity"] == expected_quantity
+    assert result[0]["market_value"] == expected_market_value
+    assert result[0]["unrealized_profit_and_loss"] == (
+        expected_unrealized_profit_and_loss
+    )
+    mock_sleep.assert_called_once_with(client.rate_limit_sleep)
+
+
 @patch("portfolio_manager.alpaca_client.APIError", _FakeAPIError)
 def test_open_position_raises_insufficient_buying_power_error() -> None:
     client, mock_trading = _make_client()

--- a/applications/portfolio_manager/tests/test_portfolio_schema.py
+++ b/applications/portfolio_manager/tests/test_portfolio_schema.py
@@ -150,21 +150,22 @@ def test_portfolio_schema_unbalanced_sides_fails() -> None:
         portfolio_schema.validate(data)
 
 
-def test_portfolio_schema_imbalanced_dollar_amounts_fails() -> None:
+def test_portfolio_schema_accepts_imbalanced_dollar_amounts() -> None:
+    # Short legs are whole-share adjusted so their dollar amounts may differ from
+    # the long notional amounts. The schema no longer rejects this imbalance.
     data = pl.DataFrame(
         {
             "ticker": _TICKERS,
             "timestamp": [datetime(2025, 1, 1, 0, 0, 0, 0, tzinfo=UTC).timestamp()]
             * 20,
             "side": (["LONG"] * 10) + (["SHORT"] * 10),
-            "dollar_amount": ([2000.0] * 10)
-            + ([500.0] * 10),  # Very imbalanced amounts
+            "dollar_amount": ([2000.0] * 10) + ([500.0] * 10),
             "pair_id": _PAIR_IDS,
         }
     )
 
-    with pytest.raises(SchemaError, match="long and short dollar amount sums"):
-        portfolio_schema.validate(data)
+    validated = portfolio_schema.validate(data)
+    assert validated is not None
 
 
 def test_portfolio_schema_duplicate_tickers_fails() -> None:

--- a/applications/portfolio_manager/tests/test_portfolio_schema.py
+++ b/applications/portfolio_manager/tests/test_portfolio_schema.py
@@ -165,7 +165,7 @@ def test_portfolio_schema_accepts_imbalanced_dollar_amounts() -> None:
     )
 
     validated = portfolio_schema.validate(data)
-    assert validated is not None
+    assert validated.shape == (20, 5)
 
 
 def test_portfolio_schema_duplicate_tickers_fails() -> None:

--- a/applications/portfolio_manager/tests/test_rebalance.py
+++ b/applications/portfolio_manager/tests/test_rebalance.py
@@ -825,8 +825,125 @@ def test_run_rebalance_saves_only_opened_rows(
 
     saved_df = mock_save.call_args[0][0]
     saved_tickers = saved_df["ticker"].to_list()
-    assert "NVDA" in saved_tickers
+    assert "NVDA" not in saved_tickers
     assert "AMD" not in saved_tickers
+
+
+@patch("portfolio_manager.rebalance.execute_open_positions")
+@patch("portfolio_manager.rebalance._record_performance", new_callable=AsyncMock)
+@patch(
+    "portfolio_manager.rebalance.save_portfolio",
+    new_callable=AsyncMock,
+    return_value=True,
+)
+@patch("portfolio_manager.rebalance.get_optimal_portfolio")
+@patch(
+    "portfolio_manager.rebalance.classify_regime",
+    return_value={"state": "mean_reversion", "confidence": 0.8},
+)
+@patch(
+    "portfolio_manager.rebalance.compute_market_betas",
+    return_value=pl.DataFrame({"ticker": ["NVDA", "AMD"], "market_beta": [1.0, 1.0]}),
+)
+@patch("portfolio_manager.rebalance.pairs_schema")
+@patch(
+    "portfolio_manager.rebalance.select_pairs",
+    return_value=pl.DataFrame(
+        {
+            "pair_id": ["NVDA-AMD"],
+            "long_ticker": ["NVDA"],
+            "short_ticker": ["AMD"],
+            "z_score": [2.5],
+            "hedge_ratio": [1.0],
+            "signal_strength": [0.1],
+            "long_realized_volatility": [0.02],
+            "short_realized_volatility": [0.02],
+        }
+    ),
+)
+@patch("portfolio_manager.rebalance.get_prior_portfolio", new_callable=AsyncMock)
+@patch(
+    "portfolio_manager.rebalance.consolidate_predictions",
+    return_value=pl.DataFrame({"ticker": ["NVDA", "AMD"]}),
+)
+@patch(
+    "portfolio_manager.rebalance.get_raw_predictions",
+    new_callable=AsyncMock,
+    return_value=pl.DataFrame({"ticker": ["NVDA"]}),
+)
+@patch("portfolio_manager.rebalance.fetch_spy_prices", return_value=pl.DataFrame())
+@patch(
+    "portfolio_manager.rebalance.fetch_equity_details",
+    return_value=pl.DataFrame(),
+)
+@patch(
+    "portfolio_manager.rebalance.fetch_historical_prices",
+    return_value=pl.DataFrame(
+        schema={"ticker": pl.Utf8, "timestamp": pl.Float64, "close_price": pl.Float64}
+    ),
+)
+def test_run_rebalance_saves_complete_pairs_when_both_legs_succeed(
+    _mock_hist: MagicMock,  # noqa: PT019
+    _mock_equity: MagicMock,  # noqa: PT019
+    _mock_spy: MagicMock,  # noqa: PT019
+    _mock_predictions: AsyncMock,  # noqa: PT019
+    _mock_consolidate: MagicMock,  # noqa: PT019
+    mock_prior_portfolio: AsyncMock,
+    _mock_select: MagicMock,  # noqa: PT019
+    mock_pairs_schema: MagicMock,
+    _mock_betas: MagicMock,  # noqa: PT019
+    _mock_regime: MagicMock,  # noqa: PT019
+    mock_optimal_portfolio: MagicMock,
+    mock_save: AsyncMock,
+    _mock_record: AsyncMock,  # noqa: PT019
+    mock_execute_open: MagicMock,
+) -> None:
+    optimal = _make_optimal_portfolio()
+    mock_optimal_portfolio.return_value = optimal
+    mock_pairs_schema.validate.side_effect = lambda df: df
+    mock_prior_portfolio.return_value = pl.DataFrame(
+        schema={
+            **_PRIOR_PORTFOLIO_SCHEMA,
+            "quantity": pl.Int64,
+            "notional": pl.Float64,
+        }
+    )
+    # Both legs succeed — the full pair should be saved.
+    mock_execute_open.return_value = (
+        [
+            {
+                "ticker": "NVDA",
+                "action": "open",
+                "side": "BUY",
+                "dollar_amount": 990.0,
+                "status": "success",
+            },
+            {
+                "ticker": "AMD",
+                "action": "open",
+                "side": "SELL",
+                "dollar_amount": 990.0,
+                "status": "success",
+            },
+        ],
+        2,
+    )
+
+    mock_account = MagicMock()
+    mock_account.cash_amount = 10000.0
+    mock_account.buying_power = 10000.0
+    mock_account.equity = 50000.0
+
+    mock_client = MagicMock()
+    mock_client.get_account.return_value = mock_account
+    mock_client.get_shortable_tickers.return_value = ["NVDA", "AMD"]
+
+    asyncio.run(run_rebalance(mock_client))
+
+    saved_df = mock_save.call_args[0][0]
+    saved_tickers = saved_df["ticker"].to_list()
+    assert "NVDA" in saved_tickers
+    assert "AMD" in saved_tickers
 
 
 # --- run_rebalance: empty predictions ---

--- a/applications/portfolio_manager/tests/test_rebalance.py
+++ b/applications/portfolio_manager/tests/test_rebalance.py
@@ -66,10 +66,29 @@ def _make_optimal_portfolio() -> pl.DataFrame:
             "ticker": ["NVDA", "AMD"],
             "timestamp": [1735689600000, 1735689600000],
             "side": ["LONG", "SHORT"],
-            "dollar_amount": [1000.0, 1000.0],
+            "dollar_amount": [
+                990.0,
+                990.0,
+            ],  # long matched to short's whole-share amount
             "action": ["OPEN_POSITION", "OPEN_POSITION"],
             "pair_id": ["NVDA-AMD", "NVDA-AMD"],
-        }
+            "entry_price": [100.0, 99.0],
+            # quantity: null for LONG, whole-share count for SHORT (int(990/99)=10)
+            "quantity": [None, 10],
+            # notional: dollar amount for LONG, null for SHORT
+            "notional": [990.0, None],
+        },
+        schema={
+            "ticker": pl.Utf8,
+            "timestamp": pl.Int64,
+            "side": pl.Utf8,
+            "dollar_amount": pl.Float64,
+            "action": pl.Utf8,
+            "pair_id": pl.Utf8,
+            "entry_price": pl.Float64,
+            "quantity": pl.Int64,
+            "notional": pl.Float64,
+        },
     )
 
 
@@ -463,6 +482,16 @@ def test_get_positions_returns_correct_open_positions() -> None:
     tickers = [p["ticker"] for p in open_positions]
     assert "NVDA" in tickers
     assert "AMD" in tickers
+    # entry_price, quantity, and notional must flow through for order submission
+    for position in open_positions:
+        assert "entry_price" in position
+        assert position["entry_price"] is not None
+    nvda = next(p for p in open_positions if p["ticker"] == "NVDA")
+    amd = next(p for p in open_positions if p["ticker"] == "AMD")
+    assert nvda["quantity"] is None
+    assert nvda["notional"] == pytest.approx(990.0)
+    assert amd["quantity"] == 10  # noqa: PLR2004
+    assert amd["notional"] is None
 
 
 @pytest.mark.parametrize(
@@ -512,6 +541,7 @@ def test_run_rebalance_empty_predictions_returns_200(
     mock_account = MagicMock()
     mock_account.cash_amount = 10000.0
     mock_account.buying_power = 10000.0
+    mock_account.equity = 10000.0
 
     mock_client = MagicMock()
     mock_client.get_account.return_value = mock_account

--- a/applications/portfolio_manager/tests/test_rebalance.py
+++ b/applications/portfolio_manager/tests/test_rebalance.py
@@ -513,6 +513,105 @@ def test_get_positions_close_count_matches_non_held_prior_tickers(
     assert len(close_positions) == expected_close_count
 
 
+# --- run_rebalance: account refresh after close ---
+
+
+@patch("portfolio_manager.rebalance._record_performance", new_callable=AsyncMock)
+@patch(
+    "portfolio_manager.rebalance.save_portfolio",
+    new_callable=AsyncMock,
+    return_value=True,
+)
+@patch("portfolio_manager.rebalance.get_optimal_portfolio")
+@patch(
+    "portfolio_manager.rebalance.classify_regime",
+    return_value={"state": "mean_reversion", "confidence": 0.8},
+)
+@patch(
+    "portfolio_manager.rebalance.compute_market_betas",
+    return_value=pl.DataFrame({"ticker": ["NVDA", "AMD"], "market_beta": [1.0, 1.0]}),
+)
+@patch("portfolio_manager.rebalance.pairs_schema")
+@patch(
+    "portfolio_manager.rebalance.select_pairs",
+    return_value=pl.DataFrame(
+        {
+            "pair_id": ["NVDA-AMD"],
+            "long_ticker": ["NVDA"],
+            "short_ticker": ["AMD"],
+            "z_score": [2.5],
+            "hedge_ratio": [1.0],
+            "signal_strength": [0.1],
+            "long_realized_volatility": [0.02],
+            "short_realized_volatility": [0.02],
+        }
+    ),
+)
+@patch("portfolio_manager.rebalance.get_prior_portfolio", new_callable=AsyncMock)
+@patch(
+    "portfolio_manager.rebalance.consolidate_predictions",
+    return_value=pl.DataFrame({"ticker": ["NVDA", "AMD"]}),
+)
+@patch(
+    "portfolio_manager.rebalance.get_raw_predictions",
+    new_callable=AsyncMock,
+    return_value=pl.DataFrame({"ticker": ["NVDA"]}),
+)
+@patch("portfolio_manager.rebalance.fetch_spy_prices", return_value=pl.DataFrame())
+@patch(
+    "portfolio_manager.rebalance.fetch_equity_details",
+    return_value=pl.DataFrame(),
+)
+@patch(
+    "portfolio_manager.rebalance.fetch_historical_prices",
+    return_value=pl.DataFrame(
+        schema={"ticker": pl.Utf8, "timestamp": pl.Float64, "close_price": pl.Float64}
+    ),
+)
+def test_run_rebalance_refreshes_account_after_closing_positions(
+    _mock_hist: MagicMock,  # noqa: PT019
+    _mock_equity: MagicMock,  # noqa: PT019
+    _mock_spy: MagicMock,  # noqa: PT019
+    _mock_predictions: AsyncMock,  # noqa: PT019
+    _mock_consolidate: MagicMock,  # noqa: PT019
+    mock_prior_portfolio: AsyncMock,
+    _mock_select: MagicMock,  # noqa: PT019
+    mock_pairs_schema: MagicMock,
+    _mock_betas: MagicMock,  # noqa: PT019
+    _mock_regime: MagicMock,  # noqa: PT019
+    mock_optimal_portfolio: MagicMock,
+    _mock_save: AsyncMock,  # noqa: PT019
+    _mock_record: AsyncMock,  # noqa: PT019
+) -> None:
+    optimal = _make_optimal_portfolio()
+    mock_optimal_portfolio.return_value = optimal
+    mock_pairs_schema.validate.side_effect = lambda df: df
+    # Use the full portfolio schema (including quantity/notional) so that pl.concat
+    # in run_rebalance does not fail on schema mismatch.
+    mock_prior_portfolio.return_value = pl.DataFrame(
+        schema={
+            **_PRIOR_PORTFOLIO_SCHEMA,
+            "quantity": pl.Int64,
+            "notional": pl.Float64,
+        }
+    )
+
+    mock_account = MagicMock()
+    mock_account.cash_amount = 10000.0
+    mock_account.buying_power = 10000.0
+    mock_account.equity = 50000.0
+
+    mock_client = MagicMock()
+    mock_client.get_account.return_value = mock_account
+    mock_client.get_shortable_tickers.return_value = ["NVDA", "AMD"]
+
+    asyncio.run(run_rebalance(mock_client))
+
+    # get_account is called at the start and again after close positions
+    minimum_account_calls = 2
+    assert mock_client.get_account.call_count >= minimum_account_calls
+
+
 # --- run_rebalance: empty predictions ---
 
 

--- a/applications/portfolio_manager/tests/test_rebalance.py
+++ b/applications/portfolio_manager/tests/test_rebalance.py
@@ -516,6 +516,10 @@ def test_get_positions_close_count_matches_non_held_prior_tickers(
 # --- run_rebalance: account refresh after close ---
 
 
+@patch(
+    "portfolio_manager.rebalance.execute_open_positions",
+    return_value=([], 0),
+)
 @patch("portfolio_manager.rebalance._record_performance", new_callable=AsyncMock)
 @patch(
     "portfolio_manager.rebalance.save_portfolio",
@@ -582,6 +586,7 @@ def test_run_rebalance_refreshes_account_after_closing_positions(
     mock_optimal_portfolio: MagicMock,
     _mock_save: AsyncMock,  # noqa: PT019
     _mock_record: AsyncMock,  # noqa: PT019
+    _mock_execute_open: MagicMock,  # noqa: PT019
 ) -> None:
     optimal = _make_optimal_portfolio()
     mock_optimal_portfolio.return_value = optimal
@@ -607,9 +612,221 @@ def test_run_rebalance_refreshes_account_after_closing_positions(
 
     asyncio.run(run_rebalance(mock_client))
 
-    # get_account is called at the start and again after close positions
-    minimum_account_calls = 2
-    assert mock_client.get_account.call_count >= minimum_account_calls
+    # get_account is called exactly twice: at startup and after close positions.
+    # execute_open_positions is frozen so its get_account calls don't inflate the count.
+    assert mock_client.get_account.call_count == 2  # noqa: PLR2004
+
+
+@patch("portfolio_manager.rebalance._record_performance", new_callable=AsyncMock)
+@patch(
+    "portfolio_manager.rebalance.save_portfolio",
+    new_callable=AsyncMock,
+    return_value=True,
+)
+@patch("portfolio_manager.rebalance.get_optimal_portfolio")
+@patch(
+    "portfolio_manager.rebalance.classify_regime",
+    return_value={"state": "mean_reversion", "confidence": 0.8},
+)
+@patch(
+    "portfolio_manager.rebalance.compute_market_betas",
+    return_value=pl.DataFrame({"ticker": ["NVDA", "AMD"], "market_beta": [1.0, 1.0]}),
+)
+@patch("portfolio_manager.rebalance.pairs_schema")
+@patch(
+    "portfolio_manager.rebalance.select_pairs",
+    return_value=pl.DataFrame(
+        {
+            "pair_id": ["NVDA-AMD"],
+            "long_ticker": ["NVDA"],
+            "short_ticker": ["AMD"],
+            "z_score": [2.5],
+            "hedge_ratio": [1.0],
+            "signal_strength": [0.1],
+            "long_realized_volatility": [0.02],
+            "short_realized_volatility": [0.02],
+        }
+    ),
+)
+@patch("portfolio_manager.rebalance.get_prior_portfolio", new_callable=AsyncMock)
+@patch(
+    "portfolio_manager.rebalance.consolidate_predictions",
+    return_value=pl.DataFrame({"ticker": ["NVDA", "AMD"]}),
+)
+@patch(
+    "portfolio_manager.rebalance.get_raw_predictions",
+    new_callable=AsyncMock,
+    return_value=pl.DataFrame({"ticker": ["NVDA"]}),
+)
+@patch("portfolio_manager.rebalance.fetch_spy_prices", return_value=pl.DataFrame())
+@patch(
+    "portfolio_manager.rebalance.fetch_equity_details",
+    return_value=pl.DataFrame(),
+)
+@patch(
+    "portfolio_manager.rebalance.fetch_historical_prices",
+    return_value=pl.DataFrame(
+        schema={"ticker": pl.Utf8, "timestamp": pl.Float64, "close_price": pl.Float64}
+    ),
+)
+def test_run_rebalance_returns_500_when_account_refresh_fails(
+    _mock_hist: MagicMock,  # noqa: PT019
+    _mock_equity: MagicMock,  # noqa: PT019
+    _mock_spy: MagicMock,  # noqa: PT019
+    _mock_predictions: AsyncMock,  # noqa: PT019
+    _mock_consolidate: MagicMock,  # noqa: PT019
+    mock_prior_portfolio: AsyncMock,
+    _mock_select: MagicMock,  # noqa: PT019
+    mock_pairs_schema: MagicMock,
+    _mock_betas: MagicMock,  # noqa: PT019
+    _mock_regime: MagicMock,  # noqa: PT019
+    mock_optimal_portfolio: MagicMock,
+    _mock_save: AsyncMock,  # noqa: PT019
+    _mock_record: AsyncMock,  # noqa: PT019
+) -> None:
+    optimal = _make_optimal_portfolio()
+    mock_optimal_portfolio.return_value = optimal
+    mock_pairs_schema.validate.side_effect = lambda df: df
+    mock_prior_portfolio.return_value = pl.DataFrame(
+        schema={
+            **_PRIOR_PORTFOLIO_SCHEMA,
+            "quantity": pl.Int64,
+            "notional": pl.Float64,
+        }
+    )
+
+    mock_account = MagicMock()
+    mock_account.cash_amount = 10000.0
+    mock_account.buying_power = 10000.0
+    mock_account.equity = 50000.0
+
+    mock_client = MagicMock()
+    # First call (startup) succeeds; second call (post-close refresh) raises.
+    mock_client.get_account.side_effect = [mock_account, RuntimeError("network error")]
+    mock_client.get_shortable_tickers.return_value = ["NVDA", "AMD"]
+
+    response = asyncio.run(run_rebalance(mock_client))
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    _mock_save.assert_not_called()
+
+
+@patch("portfolio_manager.rebalance.execute_open_positions")
+@patch("portfolio_manager.rebalance._record_performance", new_callable=AsyncMock)
+@patch(
+    "portfolio_manager.rebalance.save_portfolio",
+    new_callable=AsyncMock,
+    return_value=True,
+)
+@patch("portfolio_manager.rebalance.get_optimal_portfolio")
+@patch(
+    "portfolio_manager.rebalance.classify_regime",
+    return_value={"state": "mean_reversion", "confidence": 0.8},
+)
+@patch(
+    "portfolio_manager.rebalance.compute_market_betas",
+    return_value=pl.DataFrame({"ticker": ["NVDA", "AMD"], "market_beta": [1.0, 1.0]}),
+)
+@patch("portfolio_manager.rebalance.pairs_schema")
+@patch(
+    "portfolio_manager.rebalance.select_pairs",
+    return_value=pl.DataFrame(
+        {
+            "pair_id": ["NVDA-AMD"],
+            "long_ticker": ["NVDA"],
+            "short_ticker": ["AMD"],
+            "z_score": [2.5],
+            "hedge_ratio": [1.0],
+            "signal_strength": [0.1],
+            "long_realized_volatility": [0.02],
+            "short_realized_volatility": [0.02],
+        }
+    ),
+)
+@patch("portfolio_manager.rebalance.get_prior_portfolio", new_callable=AsyncMock)
+@patch(
+    "portfolio_manager.rebalance.consolidate_predictions",
+    return_value=pl.DataFrame({"ticker": ["NVDA", "AMD"]}),
+)
+@patch(
+    "portfolio_manager.rebalance.get_raw_predictions",
+    new_callable=AsyncMock,
+    return_value=pl.DataFrame({"ticker": ["NVDA"]}),
+)
+@patch("portfolio_manager.rebalance.fetch_spy_prices", return_value=pl.DataFrame())
+@patch(
+    "portfolio_manager.rebalance.fetch_equity_details",
+    return_value=pl.DataFrame(),
+)
+@patch(
+    "portfolio_manager.rebalance.fetch_historical_prices",
+    return_value=pl.DataFrame(
+        schema={"ticker": pl.Utf8, "timestamp": pl.Float64, "close_price": pl.Float64}
+    ),
+)
+def test_run_rebalance_saves_only_opened_rows(
+    _mock_hist: MagicMock,  # noqa: PT019
+    _mock_equity: MagicMock,  # noqa: PT019
+    _mock_spy: MagicMock,  # noqa: PT019
+    _mock_predictions: AsyncMock,  # noqa: PT019
+    _mock_consolidate: MagicMock,  # noqa: PT019
+    mock_prior_portfolio: AsyncMock,
+    _mock_select: MagicMock,  # noqa: PT019
+    mock_pairs_schema: MagicMock,
+    _mock_betas: MagicMock,  # noqa: PT019
+    _mock_regime: MagicMock,  # noqa: PT019
+    mock_optimal_portfolio: MagicMock,
+    mock_save: AsyncMock,
+    _mock_record: AsyncMock,  # noqa: PT019
+    mock_execute_open: MagicMock,
+) -> None:
+    optimal = _make_optimal_portfolio()
+    mock_optimal_portfolio.return_value = optimal
+    mock_pairs_schema.validate.side_effect = lambda df: df
+    mock_prior_portfolio.return_value = pl.DataFrame(
+        schema={
+            **_PRIOR_PORTFOLIO_SCHEMA,
+            "quantity": pl.Int64,
+            "notional": pl.Float64,
+        }
+    )
+    # AMD (short) is skipped; only NVDA (long) opened successfully.
+    mock_execute_open.return_value = (
+        [
+            {
+                "ticker": "NVDA",
+                "action": "open",
+                "side": "BUY",
+                "dollar_amount": 990.0,
+                "status": "succeeded",
+            },
+            {
+                "ticker": "AMD",
+                "action": "open",
+                "side": "SELL",
+                "dollar_amount": 990.0,
+                "status": "skipped",
+                "reason": "not_shortable",
+            },
+        ],
+        1,
+    )
+
+    mock_account = MagicMock()
+    mock_account.cash_amount = 10000.0
+    mock_account.buying_power = 10000.0
+    mock_account.equity = 50000.0
+
+    mock_client = MagicMock()
+    mock_client.get_account.return_value = mock_account
+    mock_client.get_shortable_tickers.return_value = ["NVDA", "AMD"]
+
+    asyncio.run(run_rebalance(mock_client))
+
+    saved_df = mock_save.call_args[0][0]
+    saved_tickers = saved_df["ticker"].to_list()
+    assert "NVDA" in saved_tickers
+    assert "AMD" not in saved_tickers
 
 
 # --- run_rebalance: empty predictions ---

--- a/applications/portfolio_manager/tests/test_rebalance.py
+++ b/applications/portfolio_manager/tests/test_rebalance.py
@@ -798,7 +798,7 @@ def test_run_rebalance_saves_only_opened_rows(
                 "action": "open",
                 "side": "BUY",
                 "dollar_amount": 990.0,
-                "status": "succeeded",
+                "status": "success",
             },
             {
                 "ticker": "AMD",

--- a/applications/portfolio_manager/tests/test_risk_management.py
+++ b/applications/portfolio_manager/tests/test_risk_management.py
@@ -142,6 +142,27 @@ def test_size_pairs_with_volatility_parity_raises_insufficient_pairs_error() -> 
         )
 
 
+def test_size_pairs_with_volatility_parity_raises_when_partial_zero_qty() -> None:
+    # pair 0 has very low volatility → gets ~100% of capital, non-zero qty.
+    # pairs 1-9 have very high volatility → get almost nothing, zero qty.
+    # After the zero-qty filter, 1 pair remains (0 < 1 < REQUIRED_PAIRS=10);
+    # should raise InsufficientPairsError rather than returning a truncated DataFrame.
+    # maximum_per_pair_dollar = (100/1.0)*1.0*2.0/10 = 20; price=10 passes pre-filter.
+    low_vol = 0.001
+    high_vol = 1000.0
+    long_vols = [low_vol] + [high_vol] * 9
+    short_vols = [low_vol] + [high_vol] * 9
+    pairs = _make_candidate_pairs(long_vols=long_vols, short_vols=short_vols)
+    with pytest.raises(InsufficientPairsError):
+        size_pairs_with_volatility_parity(
+            pairs,
+            maximum_capital=100.0,
+            current_timestamp=_CURRENT_TIMESTAMP,
+            market_betas=_make_neutral_market_betas(),
+            entry_prices=_make_entry_prices(price=10.0),
+        )
+
+
 def test_size_pairs_with_volatility_parity_raises_when_short_price_too_high() -> None:
     # maximum_per_pair_dollar = (10000/2.33) * 1.0 * 2.0 / 10 ≈ 858.4
     # With price=1001, int(858.4/1001) = 0, so all pairs are infeasible.

--- a/applications/portfolio_manager/tests/test_risk_management.py
+++ b/applications/portfolio_manager/tests/test_risk_management.py
@@ -177,9 +177,10 @@ def test_size_pairs_with_volatility_parity_exposure_scale_halves_dollar_amounts(
     pairs = _make_candidate_pairs()
     market_betas = _make_neutral_market_betas()
     entry_prices = _make_entry_prices(price=10.0)
-    # maximum_capital=2330 gives per-pair = 2330/2.33/10 = 100.0 exactly at price=10,
-    # so exposure_scale=0.5 halves to 50.0 without any whole-share rounding loss.
-    maximum_capital = 2330.0
+    # maximum_capital=3030 gives per-pair = 3030/3.03/10 = 100.0 exactly at price=10
+    # (capital_divisor = 1 + 1.03 + max(0.30, 1.00) = 3.03), so exposure_scale=0.5
+    # halves to 50.0 without any whole-share rounding loss.
+    maximum_capital = 3030.0
 
     full_result = size_pairs_with_volatility_parity(
         pairs,
@@ -199,7 +200,7 @@ def test_size_pairs_with_volatility_parity_exposure_scale_halves_dollar_amounts(
     )
 
     # Both long and short legs are whole-share adjusted and balanced to each other;
-    # with price=10 and maximum_capital=2030 the halving is exact for both.
+    # with price=10 and maximum_capital=3030 the halving is exact for both.
     full_long = (
         full_result.filter(pl.col("side") == "LONG")
         .sort("ticker")["dollar_amount"]
@@ -210,7 +211,7 @@ def test_size_pairs_with_volatility_parity_exposure_scale_halves_dollar_amounts(
         .sort("ticker")["dollar_amount"]
         .to_list()
     )
-    for full, half in zip(full_long, half_long, strict=False):
+    for full, half in zip(full_long, half_long, strict=True):
         assert half == pytest.approx(full * 0.5)
 
     full_short = (
@@ -223,7 +224,7 @@ def test_size_pairs_with_volatility_parity_exposure_scale_halves_dollar_amounts(
         .sort("ticker")["dollar_amount"]
         .to_list()
     )
-    for full, half in zip(full_short, half_short, strict=False):
+    for full, half in zip(full_short, half_short, strict=True):
         assert half == pytest.approx(full * 0.5)
 
 
@@ -331,3 +332,34 @@ def test_size_pairs_with_volatility_parity_output_includes_quantity_and_notional
     long_rows = result.filter(pl.col("side") == "LONG")
     assert long_rows["quantity"].is_null().sum() == long_rows.height
     assert long_rows["notional"].is_null().sum() == 0
+
+
+def test_size_pairs_with_volatility_parity_uses_conservative_overnight_margin() -> None:
+    # When hold_overnight=True and the low-price margin rate exceeds the standard rate,
+    # sizing must use the higher rate so low-priced shorts are not oversized
+    # versus the buying power cost charged at execution time.
+    pairs = _make_candidate_pairs()
+    market_betas = _make_neutral_market_betas()
+    entry_prices = _make_entry_prices(price=10.0)
+    maximum_capital = 3030.0
+    standard_rate = 0.30
+    low_price_rate = 1.00
+
+    result = size_pairs_with_volatility_parity(
+        pairs,
+        maximum_capital=maximum_capital,
+        current_timestamp=_CURRENT_TIMESTAMP,
+        market_betas=market_betas,
+        entry_prices=entry_prices,
+        hold_overnight=True,
+        overnight_margin_rate_standard=standard_rate,
+        overnight_margin_rate_low_price=low_price_rate,
+    )
+
+    # capital_divisor = 1.0 + 1.03 + max(0.30, 1.00) = 3.03
+    # short total = maximum_capital / 3.03 ≈ 1000
+    # Without the fix, capital_divisor would be 2.33 and short total ≈ 1300.
+    short_total = result.filter(pl.col("side") == "SHORT")["dollar_amount"].sum()
+    assert short_total is not None
+    expected = maximum_capital / (1.0 + 1.03 + low_price_rate)
+    assert short_total == pytest.approx(expected, rel=0.05)

--- a/applications/portfolio_manager/tests/test_risk_management.py
+++ b/applications/portfolio_manager/tests/test_risk_management.py
@@ -143,8 +143,8 @@ def test_size_pairs_with_volatility_parity_raises_insufficient_pairs_error() -> 
 
 
 def test_size_pairs_with_volatility_parity_raises_when_short_price_too_high() -> None:
-    # maximum_per_pair_dollar = (10000/2.03) * 1.0 * 2.0 / 10 ≈ 985.2
-    # With price=1001, int(985.2/1001) = 0, so all pairs are infeasible.
+    # maximum_per_pair_dollar = (10000/2.33) * 1.0 * 2.0 / 10 ≈ 858.4
+    # With price=1001, int(858.4/1001) = 0, so all pairs are infeasible.
     pairs = _make_candidate_pairs()
     with pytest.raises(InsufficientPairsError):
         size_pairs_with_volatility_parity(
@@ -177,9 +177,9 @@ def test_size_pairs_with_volatility_parity_exposure_scale_halves_dollar_amounts(
     pairs = _make_candidate_pairs()
     market_betas = _make_neutral_market_betas()
     entry_prices = _make_entry_prices(price=10.0)
-    # maximum_capital=2030 gives per-pair = 2030/2.03/10 = 100.0 exactly at price=10,
+    # maximum_capital=2330 gives per-pair = 2330/2.33/10 = 100.0 exactly at price=10,
     # so exposure_scale=0.5 halves to 50.0 without any whole-share rounding loss.
-    maximum_capital = 2030.0
+    maximum_capital = 2330.0
 
     full_result = size_pairs_with_volatility_parity(
         pairs,
@@ -274,6 +274,40 @@ def test_size_pairs_with_volatility_parity_output_includes_entry_price() -> None
     assert result["entry_price"].is_null().sum() == 0
     for price in result["entry_price"].to_list():
         assert price == pytest.approx(10.0)
+
+
+def test_size_pairs_with_volatility_parity_hold_overnight_reduces_dollar_amounts() -> (
+    None
+):
+    pairs = _make_candidate_pairs()
+    market_betas = _make_neutral_market_betas()
+    entry_prices = _make_entry_prices(price=10.0)
+    maximum_capital = 10000.0
+
+    overnight_result = size_pairs_with_volatility_parity(
+        pairs,
+        maximum_capital=maximum_capital,
+        current_timestamp=_CURRENT_TIMESTAMP,
+        market_betas=market_betas,
+        entry_prices=entry_prices,
+        hold_overnight=True,
+        overnight_margin_rate_standard=0.30,
+    )
+    intraday_result = size_pairs_with_volatility_parity(
+        pairs,
+        maximum_capital=maximum_capital,
+        current_timestamp=_CURRENT_TIMESTAMP,
+        market_betas=market_betas,
+        entry_prices=entry_prices,
+        hold_overnight=False,
+        overnight_margin_rate_standard=0.30,
+    )
+
+    overnight_total = overnight_result["dollar_amount"].sum()
+    intraday_total = intraday_result["dollar_amount"].sum()
+    assert overnight_total is not None
+    assert intraday_total is not None
+    assert float(overnight_total) < float(intraday_total)
 
 
 def test_size_pairs_with_volatility_parity_output_includes_quantity_and_notional() -> (

--- a/applications/portfolio_manager/tests/test_risk_management.py
+++ b/applications/portfolio_manager/tests/test_risk_management.py
@@ -334,6 +334,31 @@ def test_size_pairs_with_volatility_parity_output_includes_quantity_and_notional
     assert long_rows["notional"].is_null().sum() == 0
 
 
+def test_size_pairs_with_volatility_parity_filters_pairs_missing_long_entry_price() -> (
+    None
+):
+    # 11 candidate pairs; pair 10's long ticker is absent from entry_prices.
+    # The prefilter must remove it so sizing completes cleanly with 10 pairs
+    # and no long position carries entry_price=0.
+    pairs = _make_candidate_pairs(count=11)
+    market_betas = _make_neutral_market_betas(count=11)
+    entry_prices = _make_entry_prices(count=10)  # pair 10's long ticker omitted
+
+    result = size_pairs_with_volatility_parity(
+        pairs,
+        maximum_capital=10000.0,
+        current_timestamp=_CURRENT_TIMESTAMP,
+        market_betas=market_betas,
+        entry_prices=entry_prices,
+    )
+
+    long_rows = result.filter(pl.col("side") == "LONG")
+    assert long_rows.height == REQUIRED_PAIRS
+    for price in long_rows["entry_price"].to_list():
+        assert price is not None
+        assert price > 0
+
+
 def test_size_pairs_with_volatility_parity_uses_conservative_overnight_margin() -> None:
     # When hold_overnight=True and the low-price margin rate exceeds the standard rate,
     # sizing must use the higher rate so low-priced shorts are not oversized

--- a/applications/portfolio_manager/tests/test_risk_management.py
+++ b/applications/portfolio_manager/tests/test_risk_management.py
@@ -11,6 +11,7 @@ from portfolio_manager.risk_management import (
 )
 
 _CURRENT_TIMESTAMP = datetime(2025, 1, 15, 9, 30, tzinfo=UTC)
+_DEFAULT_ENTRY_PRICE = 10.0
 
 
 def _make_candidate_pairs(
@@ -58,17 +59,52 @@ def _make_asymmetric_market_betas() -> pl.DataFrame:
     return pl.DataFrame({"ticker": tickers, "market_beta": betas})
 
 
-def test_size_pairs_with_volatility_parity_long_equals_short_dollar_totals() -> None:
+def _make_entry_prices(
+    count: int = 10, price: float = _DEFAULT_ENTRY_PRICE
+) -> dict[str, float]:
+    prices: dict[str, float] = {}
+    for i in range(count):
+        prices[f"TICK{i:02d}A"] = price
+        prices[f"TICK{i:02d}B"] = price
+    return prices
+
+
+def test_size_pairs_with_volatility_parity_short_uses_whole_share_dollar_amount() -> (
+    None
+):
     pairs = _make_candidate_pairs()
     result = size_pairs_with_volatility_parity(
         pairs,
         maximum_capital=10000.0,
         current_timestamp=_CURRENT_TIMESTAMP,
         market_betas=_make_neutral_market_betas(),
+        entry_prices=_make_entry_prices(price=10.0),
     )
-    long_sum = result.filter(pl.col("side") == "LONG")["dollar_amount"].sum()
-    short_sum = result.filter(pl.col("side") == "SHORT")["dollar_amount"].sum()
-    assert long_sum == pytest.approx(short_sum)
+    short_rows = result.filter(pl.col("side") == "SHORT")
+    for row in short_rows.iter_rows(named=True):
+        entry_price = row["entry_price"]
+        dollar_amount = row["dollar_amount"]
+        qty = int(dollar_amount / entry_price)
+        # dollar_amount must equal qty * entry_price (whole-share adjusted)
+        assert dollar_amount == pytest.approx(qty * entry_price)
+
+
+def test_size_pairs_with_volatility_parity_long_matches_short_dollar_amount() -> None:
+    pairs = _make_candidate_pairs()
+    result = size_pairs_with_volatility_parity(
+        pairs,
+        maximum_capital=10000.0,
+        current_timestamp=_CURRENT_TIMESTAMP,
+        market_betas=_make_neutral_market_betas(),
+        entry_prices=_make_entry_prices(price=10.0),
+    )
+    long_df = result.filter(pl.col("side") == "LONG").sort("pair_id")
+    short_df = result.filter(pl.col("side") == "SHORT").sort("pair_id")
+    # Long dollar_amount is balanced to match the short's whole-share-adjusted amount.
+    for long_row, short_row in zip(
+        long_df.iter_rows(named=True), short_df.iter_rows(named=True), strict=True
+    ):
+        assert long_row["dollar_amount"] == pytest.approx(short_row["dollar_amount"])
 
 
 def test_size_pairs_with_volatility_parity_lower_volatility_receives_more_capital() -> (
@@ -82,6 +118,7 @@ def test_size_pairs_with_volatility_parity_lower_volatility_receives_more_capita
         maximum_capital=10000.0,
         current_timestamp=_CURRENT_TIMESTAMP,
         market_betas=_make_neutral_market_betas(),
+        entry_prices=_make_entry_prices(),
     )
     long_df = result.filter(pl.col("side") == "LONG")
     low_vol_amount = long_df.filter(pl.col("ticker") == "TICK00A")[
@@ -101,6 +138,21 @@ def test_size_pairs_with_volatility_parity_raises_insufficient_pairs_error() -> 
             maximum_capital=10000.0,
             current_timestamp=_CURRENT_TIMESTAMP,
             market_betas=_make_neutral_market_betas(count=REQUIRED_PAIRS - 1),
+            entry_prices=_make_entry_prices(count=REQUIRED_PAIRS - 1),
+        )
+
+
+def test_size_pairs_with_volatility_parity_raises_when_short_price_too_high() -> None:
+    # maximum_per_pair_dollar = (10000/2.03) * 1.0 * 2.0 / 10 ≈ 985.2
+    # With price=1001, int(985.2/1001) = 0, so all pairs are infeasible.
+    pairs = _make_candidate_pairs()
+    with pytest.raises(InsufficientPairsError):
+        size_pairs_with_volatility_parity(
+            pairs,
+            maximum_capital=10000.0,
+            current_timestamp=_CURRENT_TIMESTAMP,
+            market_betas=_make_neutral_market_betas(),
+            entry_prices=_make_entry_prices(price=1001.0),
         )
 
 
@@ -113,6 +165,7 @@ def test_size_pairs_with_volatility_parity_output_passes_portfolio_schema_valida
         maximum_capital=10000.0,
         current_timestamp=_CURRENT_TIMESTAMP,
         market_betas=_make_neutral_market_betas(),
+        entry_prices=_make_entry_prices(),
     )
     validated = portfolio_schema.validate(result)
     assert validated.height == REQUIRED_PAIRS * 2
@@ -123,26 +176,54 @@ def test_size_pairs_with_volatility_parity_exposure_scale_halves_dollar_amounts(
 ):
     pairs = _make_candidate_pairs()
     market_betas = _make_neutral_market_betas()
+    entry_prices = _make_entry_prices(price=10.0)
+    # maximum_capital=2030 gives per-pair = 2030/2.03/10 = 100.0 exactly at price=10,
+    # so exposure_scale=0.5 halves to 50.0 without any whole-share rounding loss.
+    maximum_capital = 2030.0
 
     full_result = size_pairs_with_volatility_parity(
         pairs,
-        maximum_capital=10000.0,
+        maximum_capital=maximum_capital,
         current_timestamp=_CURRENT_TIMESTAMP,
         market_betas=market_betas,
+        entry_prices=entry_prices,
         exposure_scale=1.0,
     )
     half_result = size_pairs_with_volatility_parity(
         pairs,
-        maximum_capital=10000.0,
+        maximum_capital=maximum_capital,
         current_timestamp=_CURRENT_TIMESTAMP,
         market_betas=market_betas,
+        entry_prices=entry_prices,
         exposure_scale=0.5,
     )
 
-    full_amounts = full_result.sort(["ticker", "side"])["dollar_amount"].to_list()
-    half_amounts = half_result.sort(["ticker", "side"])["dollar_amount"].to_list()
+    # Both long and short legs are whole-share adjusted and balanced to each other;
+    # with price=10 and maximum_capital=2030 the halving is exact for both.
+    full_long = (
+        full_result.filter(pl.col("side") == "LONG")
+        .sort("ticker")["dollar_amount"]
+        .to_list()
+    )
+    half_long = (
+        half_result.filter(pl.col("side") == "LONG")
+        .sort("ticker")["dollar_amount"]
+        .to_list()
+    )
+    for full, half in zip(full_long, half_long, strict=False):
+        assert half == pytest.approx(full * 0.5)
 
-    for full, half in zip(full_amounts, half_amounts, strict=False):
+    full_short = (
+        full_result.filter(pl.col("side") == "SHORT")
+        .sort("ticker")["dollar_amount"]
+        .to_list()
+    )
+    half_short = (
+        half_result.filter(pl.col("side") == "SHORT")
+        .sort("ticker")["dollar_amount"]
+        .to_list()
+    )
+    for full, half in zip(full_short, half_short, strict=False):
         assert half == pytest.approx(full * 0.5)
 
 
@@ -151,22 +232,25 @@ def test_size_pairs_with_volatility_parity_beta_neutral_reduces_portfolio_beta()
 ):
     # Pairs 0-7: long_beta=2.0, short_beta=1.0 (net positive contribution)
     # Pairs 8-9: long_beta=1.0, short_beta=2.0 (net negative contribution)
-    # Equal vol-parity weights produce portfolio beta ≠ 0; optimizer drives it toward 0
+    # Equal vol-parity weights produce portfolio beta != 0; optimizer drives it toward 0
     pairs = _make_candidate_pairs()
     asymmetric_betas = _make_asymmetric_market_betas()
     neutral_betas = _make_neutral_market_betas()
+    entry_prices = _make_entry_prices(price=10.0)
 
     beta_neutral_result = size_pairs_with_volatility_parity(
         pairs,
         maximum_capital=10000.0,
         current_timestamp=_CURRENT_TIMESTAMP,
         market_betas=asymmetric_betas,
+        entry_prices=entry_prices,
     )
     vol_parity_result = size_pairs_with_volatility_parity(
         pairs,
         maximum_capital=10000.0,
         current_timestamp=_CURRENT_TIMESTAMP,
         market_betas=neutral_betas,
+        entry_prices=entry_prices,
     )
 
     beta_neutral_beta = abs(
@@ -175,3 +259,41 @@ def test_size_pairs_with_volatility_parity_beta_neutral_reduces_portfolio_beta()
     vol_parity_beta = abs(compute_portfolio_beta(vol_parity_result, asymmetric_betas))
 
     assert beta_neutral_beta < vol_parity_beta
+
+
+def test_size_pairs_with_volatility_parity_output_includes_entry_price() -> None:
+    pairs = _make_candidate_pairs()
+    result = size_pairs_with_volatility_parity(
+        pairs,
+        maximum_capital=10000.0,
+        current_timestamp=_CURRENT_TIMESTAMP,
+        market_betas=_make_neutral_market_betas(),
+        entry_prices=_make_entry_prices(price=10.0),
+    )
+    assert "entry_price" in result.columns
+    assert result["entry_price"].is_null().sum() == 0
+    for price in result["entry_price"].to_list():
+        assert price == pytest.approx(10.0)
+
+
+def test_size_pairs_with_volatility_parity_output_includes_quantity_and_notional() -> (
+    None
+):
+    pairs = _make_candidate_pairs()
+    result = size_pairs_with_volatility_parity(
+        pairs,
+        maximum_capital=10000.0,
+        current_timestamp=_CURRENT_TIMESTAMP,
+        market_betas=_make_neutral_market_betas(),
+        entry_prices=_make_entry_prices(price=10.0),
+    )
+    assert "quantity" in result.columns
+    assert "notional" in result.columns
+
+    short_rows = result.filter(pl.col("side") == "SHORT")
+    assert short_rows["quantity"].is_null().sum() == 0
+    assert short_rows["notional"].is_null().sum() == short_rows.height
+
+    long_rows = result.filter(pl.col("side") == "LONG")
+    assert long_rows["quantity"].is_null().sum() == long_rows.height
+    assert long_rows["notional"].is_null().sum() == 0

--- a/applications/portfolio_manager/tests/test_scheduler.py
+++ b/applications/portfolio_manager/tests/test_scheduler.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from zoneinfo import ZoneInfo
 
+from portfolio_manager.configuration import Configuration
 from portfolio_manager.scheduler import (
     _already_rebalanced_today,
     _rebalance_loop,
@@ -235,7 +236,9 @@ def _run_loop(
 
     async def run() -> None:
         lock = asyncio.Lock()
-        await _rebalance_loop(mock_alpaca, "http://data-manager:8080", lock)
+        await _rebalance_loop(
+            mock_alpaca, Configuration(), "http://data-manager:8080", lock
+        )
 
     with (
         patch("portfolio_manager.scheduler.datetime") as mock_dt,
@@ -371,7 +374,9 @@ def test_rebalance_loop_skips_when_lock_is_held() -> None:
     async def run() -> None:
         lock = asyncio.Lock()
         await lock.acquire()
-        await _rebalance_loop(mock_alpaca, "http://data-manager:8080", lock)
+        await _rebalance_loop(
+            mock_alpaca, Configuration(), "http://data-manager:8080", lock
+        )
 
     with (
         patch("portfolio_manager.scheduler.datetime") as mock_dt,
@@ -400,7 +405,9 @@ def test_rebalance_loop_handles_market_open_exception() -> None:
 
     async def run() -> None:
         lock = asyncio.Lock()
-        await _rebalance_loop(mock_alpaca, "http://data-manager:8080", lock)
+        await _rebalance_loop(
+            mock_alpaca, Configuration(), "http://data-manager:8080", lock
+        )
 
     with (
         patch("portfolio_manager.scheduler.datetime") as mock_dt,
@@ -429,7 +436,9 @@ def test_rebalance_loop_handles_run_rebalance_exception() -> None:
 
     async def run() -> None:
         lock = asyncio.Lock()
-        await _rebalance_loop(mock_alpaca, "http://data-manager:8080", lock)
+        await _rebalance_loop(
+            mock_alpaca, Configuration(), "http://data-manager:8080", lock
+        )
 
     with (
         patch("portfolio_manager.scheduler.datetime") as mock_dt,
@@ -460,7 +469,9 @@ def test_rebalance_loop_logs_warning_on_non_200_response() -> None:
 
     async def run() -> None:
         lock = asyncio.Lock()
-        await _rebalance_loop(mock_alpaca, "http://data-manager:8080", lock)
+        await _rebalance_loop(
+            mock_alpaca, Configuration(), "http://data-manager:8080", lock
+        )
 
     with (
         patch("portfolio_manager.scheduler.datetime") as mock_dt,
@@ -490,7 +501,9 @@ def test_rebalance_loop_retries_after_unexpected_error() -> None:
 
     async def run() -> None:
         lock = asyncio.Lock()
-        await _rebalance_loop(mock_alpaca, "http://data-manager:8080", lock)
+        await _rebalance_loop(
+            mock_alpaca, Configuration(), "http://data-manager:8080", lock
+        )
 
     with (
         patch("portfolio_manager.scheduler.datetime") as mock_dt,

--- a/applications/portfolio_manager/tests/test_server_app.py
+++ b/applications/portfolio_manager/tests/test_server_app.py
@@ -6,6 +6,7 @@ import portfolio_manager.server as server_module
 import pytest
 from alpaca.common.exceptions import APIError
 from fastapi import Response, status
+from portfolio_manager.configuration import Configuration
 from portfolio_manager.server import (
     _lifespan,
     application,
@@ -195,7 +196,9 @@ def test_create_portfolio_calls_run_rebalance() -> None:
     mock_response.status_code = status.HTTP_200_OK
     mock_run = AsyncMock(return_value=mock_response)
 
+    mock_configuration = Configuration()
     application.state.alpaca_client = mock_alpaca
+    application.state.configuration = mock_configuration
 
     async def run() -> Response:
         lock = asyncio.Lock()
@@ -208,4 +211,4 @@ def test_create_portfolio_calls_run_rebalance() -> None:
     response = asyncio.run(run())
 
     assert response.status_code == status.HTTP_200_OK
-    mock_run.assert_called_once_with(mock_alpaca)
+    mock_run.assert_called_once_with(mock_alpaca, mock_configuration)

--- a/applications/portfolio_manager/tests/test_trade_execution.py
+++ b/applications/portfolio_manager/tests/test_trade_execution.py
@@ -27,9 +27,11 @@ def _long(
     ticker: str = "AAPL",
     dollar_amount: float = 1000.0,
     entry_price: float = 100.0,
+    pair_id: str = "pair-1",
 ) -> dict:
     return {
         "ticker": ticker,
+        "pair_id": pair_id,
         "side": TradeSide.BUY,
         "dollar_amount": dollar_amount,
         "entry_price": entry_price,
@@ -43,9 +45,11 @@ def _short(
     dollar_amount: float = 1000.0,
     entry_price: float = 100.0,
     quantity: int | None = 10,
+    pair_id: str = "pair-1",
 ) -> dict:
     return {
         "ticker": ticker,
+        "pair_id": pair_id,
         "side": TradeSide.SELL,
         "dollar_amount": dollar_amount,
         "entry_price": entry_price,
@@ -116,71 +120,115 @@ def test_execute_close_positions_handles_multiple_positions() -> None:
 # --- execute_open_positions ---
 
 
-def test_execute_open_positions_opens_long_successfully() -> None:
+def test_execute_open_positions_opens_pair_successfully() -> None:
     client = _make_mock_client()
+    positions = [_long(ticker="AAPL"), _short(ticker="MSFT", quantity=10)]
     results, count = execute_open_positions(
-        client, [_long()], 10000.0, 50000.0, _DEFAULT_CONFIG
+        client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG
     )
-    assert count == 1
+    assert count == 2  # noqa: PLR2004
     assert results[0]["status"] == "success"
     assert results[0]["side"] == TradeSide.BUY
+    assert results[1]["status"] == "success"
+    assert results[1]["side"] == TradeSide.SELL
 
 
-def test_execute_open_positions_refreshes_buying_power_after_open() -> None:
+def test_execute_open_positions_refreshes_buying_power_after_each_leg() -> None:
     client = _make_mock_client()
     client.get_account.return_value = AlpacaAccount(
         cash_amount=9000.0, buying_power=18000.0, equity=50000.0
     )
-    execute_open_positions(client, [_long()], 10000.0, 50000.0, _DEFAULT_CONFIG)
-    client.get_account.assert_called_once()
+    positions = [_long(ticker="AAPL"), _short(ticker="MSFT", quantity=10)]
+    execute_open_positions(client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG)
+    # get_account called once per successful leg
+    assert client.get_account.call_count == 2  # noqa: PLR2004
 
 
 def test_execute_open_positions_uses_buying_power_estimate_when_refresh_fails() -> None:
     client = _make_mock_client()
     client.get_account.side_effect = RuntimeError("account unavailable")
 
+    positions = [
+        _long(ticker="AAPL", dollar_amount=500.0),
+        _short(ticker="MSFT", quantity=10),
+    ]
     results, count = execute_open_positions(
-        client, [_long(dollar_amount=500.0)], 10000.0, 50000.0, _DEFAULT_CONFIG
+        client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG
     )
 
-    assert count == 1
+    assert count == 2  # noqa: PLR2004
     assert results[0]["status"] == "success"
+    assert results[1]["status"] == "success"
 
 
 def test_execute_open_positions_skips_long_when_insufficient_buying_power() -> None:
     client = _make_mock_client()
+    positions = [
+        _long(ticker="AAPL", dollar_amount=5000.0),
+        _short(ticker="MSFT", quantity=10),
+    ]
     results, count = execute_open_positions(
-        client, [_long(dollar_amount=5000.0)], 100.0, 50000.0, _DEFAULT_CONFIG
+        client, positions, 100.0, 50000.0, _DEFAULT_CONFIG
     )
     assert count == 0
     assert results[0]["status"] == "skipped"
     assert results[0]["reason"] == "insufficient_buying_power"
+    # Short is skipped as a consequence of long failing
+    assert results[1]["status"] == "skipped"
+    assert results[1]["reason"] == "long_leg_failed"
 
 
 def test_execute_open_positions_handles_insufficient_buying_power_error() -> None:
     client = _make_mock_client()
-    client.open_position.side_effect = InsufficientBuyingPowerError("not enough")
+    # Long raises the error; short should not be attempted
+    client.open_position.side_effect = [
+        InsufficientBuyingPowerError("not enough"),
+        None,
+    ]
 
+    positions = [_long(ticker="AAPL"), _short(ticker="MSFT", quantity=10)]
     results, count = execute_open_positions(
-        client, [_long()], 10000.0, 50000.0, _DEFAULT_CONFIG
+        client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG
     )
 
     assert count == 0
     assert results[0]["status"] == "skipped"
     assert results[0]["reason"] == "insufficient_buying_power"
+    assert results[1]["status"] == "skipped"
+    assert results[1]["reason"] == "long_leg_failed"
+    client.open_position.assert_called_once()
 
 
-def test_execute_open_positions_handles_generic_exception() -> None:
+def test_execute_open_positions_handles_generic_exception_on_long() -> None:
     client = _make_mock_client()
-    client.open_position.side_effect = RuntimeError("unexpected error")
+    client.open_position.side_effect = [RuntimeError("unexpected error"), None]
 
+    positions = [_long(ticker="AAPL"), _short(ticker="MSFT", quantity=10)]
     results, count = execute_open_positions(
-        client, [_long()], 10000.0, 50000.0, _DEFAULT_CONFIG
+        client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG
     )
 
     assert count == 0
     assert results[0]["status"] == "failed"
     assert "unexpected error" in results[0]["error"]
+    assert results[1]["status"] == "skipped"
+    assert results[1]["reason"] == "long_leg_failed"
+    client.open_position.assert_called_once()
+
+
+def test_execute_open_positions_handles_generic_exception_on_short() -> None:
+    client = _make_mock_client()
+    client.open_position.side_effect = [None, RuntimeError("unexpected error")]
+
+    positions = [_long(ticker="AAPL"), _short(ticker="MSFT", quantity=10)]
+    results, count = execute_open_positions(
+        client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG
+    )
+
+    assert count == 1
+    assert results[0]["status"] == "success"
+    assert results[1]["status"] == "failed"
+    assert "unexpected error" in results[1]["error"]
 
 
 def test_execute_open_positions_opens_short_overnight_standard_rate() -> None:
@@ -192,12 +240,15 @@ def test_execute_open_positions_opens_short_overnight_standard_rate() -> None:
     )
     client = _make_mock_client()
     # entry_price=100.0 >= low_price_threshold=5.0 → standard rate
-    # buying_power_cost = 10 * 100 * (1.03 + 0.30) = 1330
-    results, count = execute_open_positions(
-        client, [_short(entry_price=100.0, quantity=10)], 5000.0, 50000.0, config
-    )
-    assert count == 1
-    assert results[0]["status"] == "success"
+    # short buying_power_cost = 10 * 100 * (1.03 + 0.30) = 1330
+    positions = [
+        _long(ticker="AAPL", dollar_amount=1000.0),
+        _short(ticker="MSFT", entry_price=100.0, quantity=10),
+    ]
+    results, count = execute_open_positions(client, positions, 5000.0, 50000.0, config)
+    assert count == 2  # noqa: PLR2004
+    assert results[1]["status"] == "success"
+    assert results[1]["side"] == TradeSide.SELL
 
 
 def test_execute_open_positions_opens_short_overnight_low_price_rate() -> None:
@@ -209,98 +260,108 @@ def test_execute_open_positions_opens_short_overnight_low_price_rate() -> None:
     )
     client = _make_mock_client()
     # entry_price=3.0 < low_price_threshold=5.0 → low price rate
-    # buying_power_cost = 100 * 3.0 * (1.03 + 1.00) = 609
-    results, count = execute_open_positions(
-        client,
-        [_short(entry_price=3.0, dollar_amount=300.0, quantity=100)],
-        10000.0,
-        50000.0,
-        config,
-    )
-    assert count == 1
-    assert results[0]["status"] == "success"
+    # short buying_power_cost = 100 * 3.0 * (1.03 + 1.00) = 609
+    positions = [
+        _long(ticker="AAPL", dollar_amount=300.0),
+        _short(ticker="MSFT", entry_price=3.0, dollar_amount=300.0, quantity=100),
+    ]
+    results, count = execute_open_positions(client, positions, 10000.0, 50000.0, config)
+    assert count == 2  # noqa: PLR2004
+    assert results[1]["status"] == "success"
+    assert results[1]["side"] == TradeSide.SELL
 
 
 def test_execute_open_positions_opens_short_intraday_no_margin() -> None:
     config = Configuration(hold_overnight=False, short_buying_power_buffer=1.03)
     client = _make_mock_client()
-    # buying_power_cost = 10 * 100 * 1.03 = 1030
-    results, count = execute_open_positions(
-        client, [_short(entry_price=100.0, quantity=10)], 2000.0, 50000.0, config
-    )
-    assert count == 1
-    assert results[0]["status"] == "success"
+    # short buying_power_cost = 10 * 100 * 1.03 = 1030
+    positions = [
+        _long(ticker="AAPL", dollar_amount=1000.0),
+        _short(ticker="MSFT", entry_price=100.0, quantity=10),
+    ]
+    results, count = execute_open_positions(client, positions, 5000.0, 50000.0, config)
+    assert count == 2  # noqa: PLR2004
+    assert results[1]["status"] == "success"
+    assert results[1]["side"] == TradeSide.SELL
 
 
 def test_execute_open_positions_skips_short_with_insufficient_equity() -> None:
     config = Configuration(minimum_short_equity=2000.0)
     client = _make_mock_client()
 
-    results, count = execute_open_positions(client, [_short()], 10000.0, 500.0, config)
+    positions = [_long(ticker="AAPL"), _short(ticker="MSFT")]
+    results, count = execute_open_positions(client, positions, 10000.0, 500.0, config)
 
-    assert count == 0
-    assert results[0]["status"] == "skipped"
-    assert results[0]["reason"] == "insufficient_equity_for_short"
+    assert count == 1  # long succeeded
+    assert results[0]["status"] == "success"
+    assert results[1]["status"] == "skipped"
+    assert results[1]["reason"] == "insufficient_equity_for_short"
 
 
 def test_execute_open_positions_skips_short_with_zero_quantity() -> None:
     client = _make_mock_client()
     # quantity=None, dollar_amount=50 < entry_price=100 → int(0.5) = 0
+    positions = [
+        _long(ticker="AAPL"),
+        _short(ticker="MSFT", dollar_amount=50.0, entry_price=100.0, quantity=None),
+    ]
     results, count = execute_open_positions(
-        client,
-        [_short(dollar_amount=50.0, entry_price=100.0, quantity=None)],
-        10000.0,
-        50000.0,
-        _DEFAULT_CONFIG,
+        client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG
     )
-    assert count == 0
-    assert results[0]["status"] == "skipped"
-    assert results[0]["reason"] == "zero_short_quantity"
+    assert count == 1  # long succeeded
+    assert results[0]["status"] == "success"
+    assert results[1]["status"] == "skipped"
+    assert results[1]["reason"] == "zero_short_quantity"
 
 
 def test_execute_open_positions_uses_precomputed_quantity_for_short() -> None:
     client = _make_mock_client()
+    positions = [
+        _long(ticker="AAPL"),
+        _short(ticker="MSFT", quantity=5, dollar_amount=500.0, entry_price=100.0),
+    ]
     results, count = execute_open_positions(
-        client,
-        [_short(quantity=5, dollar_amount=500.0, entry_price=100.0)],
-        10000.0,
-        50000.0,
-        _DEFAULT_CONFIG,
+        client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG
     )
-    assert count == 1
-    assert results[0]["status"] == "success"
+    assert count == 2  # noqa: PLR2004
+    assert results[1]["status"] == "success"
 
 
 def test_execute_open_positions_skips_short_when_insufficient_buying_power() -> None:
     config = Configuration(hold_overnight=False, short_buying_power_buffer=1.03)
     client = _make_mock_client()
-    # buying_power_cost = 10 * 100 * 1.03 = 1030 > initial=100
-    results, count = execute_open_positions(
-        client,
-        [_short(entry_price=100.0, quantity=10)],
-        100.0,
-        50000.0,
-        config,
+    # short buying_power_cost = 10 * 100 * 1.03 = 1030
+    # Long (1000) fits; after refresh short (1030) exceeds the new 100 balance
+    client.get_account.return_value = AlpacaAccount(
+        cash_amount=100.0, buying_power=100.0, equity=50000.0
     )
-    assert count == 0
-    assert results[0]["status"] == "skipped"
-    assert results[0]["reason"] == "insufficient_buying_power"
+    positions = [
+        _long(ticker="AAPL", dollar_amount=1000.0),
+        _short(ticker="MSFT", entry_price=100.0, quantity=10),
+    ]
+    results, count = execute_open_positions(client, positions, 10000.0, 50000.0, config)
+    assert count == 1  # long succeeded
+    assert results[0]["status"] == "success"
+    assert results[1]["status"] == "skipped"
+    assert results[1]["reason"] == "insufficient_buying_power"
 
 
 def test_execute_open_positions_handles_asset_not_shortable_error() -> None:
     client = _make_mock_client()
-    client.open_position.side_effect = AssetNotShortableError("not shortable")
+    client.open_position.side_effect = [None, AssetNotShortableError("not shortable")]
 
+    positions = [_long(ticker="AAPL"), _short(ticker="MSFT", quantity=10)]
     results, count = execute_open_positions(
-        client, [_short(quantity=10)], 10000.0, 50000.0, _DEFAULT_CONFIG
+        client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG
     )
 
-    assert count == 0
-    assert results[0]["status"] == "skipped"
-    assert results[0]["reason"] == "not_shortable"
+    assert count == 1  # long succeeded
+    assert results[0]["status"] == "success"
+    assert results[1]["status"] == "skipped"
+    assert results[1]["reason"] == "not_shortable"
 
 
-def test_execute_open_positions_submits_longs_before_shorts() -> None:
+def test_execute_open_positions_submits_long_before_short_within_pair() -> None:
     client = _make_mock_client()
     submitted_sides: list[TradeSide] = []
 
@@ -315,11 +376,40 @@ def test_execute_open_positions_submits_longs_before_shorts() -> None:
 
     client.open_position.side_effect = capture_side
 
+    # Pass short first to confirm ordering is driven by pair logic, not input order
     positions = [_short(ticker="MSFT", quantity=10), _long(ticker="AAPL")]
     execute_open_positions(client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG)
 
     assert submitted_sides[0] == TradeSide.BUY
     assert submitted_sides[1] == TradeSide.SELL
+
+
+def test_execute_open_positions_skips_short_when_long_leg_fails() -> None:
+    client = _make_mock_client()
+    client.open_position.side_effect = InsufficientBuyingPowerError("not enough")
+
+    positions = [_long(ticker="AAPL"), _short(ticker="MSFT", quantity=10)]
+    results, count = execute_open_positions(
+        client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG
+    )
+
+    assert count == 0
+    assert results[1]["ticker"] == "MSFT"
+    assert results[1]["status"] == "skipped"
+    assert results[1]["reason"] == "long_leg_failed"
+    # open_position called only once — for the long leg
+    client.open_position.assert_called_once()
+
+
+def test_execute_open_positions_skips_incomplete_pair() -> None:
+    client = _make_mock_client()
+    # Only a long leg — no matching short in the same pair_id
+    results, count = execute_open_positions(
+        client, [_long(ticker="AAPL")], 10000.0, 50000.0, _DEFAULT_CONFIG
+    )
+    assert count == 0
+    assert results == []
+    client.open_position.assert_not_called()
 
 
 def test_execute_open_positions_returns_empty_for_no_positions() -> None:
@@ -329,3 +419,36 @@ def test_execute_open_positions_returns_empty_for_no_positions() -> None:
     )
     assert results == []
     assert count == 0
+
+
+def test_execute_open_positions_uses_computed_short_qty_when_quantity_is_none() -> None:
+    client = _make_mock_client()
+    submitted_quantities: list[int | None] = []
+
+    def capture_quantity(
+        ticker: str,  # noqa: ARG001
+        side: TradeSide,  # noqa: ARG001
+        dollar_amount: float,  # noqa: ARG001
+        entry_price: float,  # noqa: ARG001
+        quantity: int | None = None,
+    ) -> None:
+        submitted_quantities.append(quantity)
+
+    client.open_position.side_effect = capture_quantity
+
+    # quantity=None; fallback = int(300 / 30) = 10
+    positions = [
+        _long(ticker="AAPL"),
+        _short(ticker="MSFT", dollar_amount=300.0, entry_price=30.0, quantity=None),
+    ]
+    _results, count = execute_open_positions(
+        client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG
+    )
+
+    expected_short_qty = 10  # int(300 / 30)
+    expected_count = 2  # both legs succeed
+    assert count == expected_count
+    # Long uses position.get("quantity") → None
+    assert submitted_quantities[0] is None
+    # Short uses computed short_qty = int(300 / 30) = 10, not None
+    assert submitted_quantities[1] == expected_short_qty

--- a/applications/portfolio_manager/tests/test_trade_execution.py
+++ b/applications/portfolio_manager/tests/test_trade_execution.py
@@ -1,0 +1,331 @@
+from unittest.mock import MagicMock
+
+from portfolio_manager.alpaca_client import AlpacaAccount, AlpacaClient
+from portfolio_manager.configuration import Configuration
+from portfolio_manager.enums import TradeSide
+from portfolio_manager.exceptions import (
+    AssetNotShortableError,
+    InsufficientBuyingPowerError,
+)
+from portfolio_manager.trade_execution import (
+    execute_close_positions,
+    execute_open_positions,
+)
+
+_DEFAULT_CONFIG = Configuration()
+
+
+def _make_mock_client() -> MagicMock:
+    client = MagicMock(spec=AlpacaClient)
+    client.get_account.return_value = AlpacaAccount(
+        cash_amount=10000.0, buying_power=20000.0, equity=50000.0
+    )
+    return client
+
+
+def _long(
+    ticker: str = "AAPL",
+    dollar_amount: float = 1000.0,
+    entry_price: float = 100.0,
+) -> dict:
+    return {
+        "ticker": ticker,
+        "side": TradeSide.BUY,
+        "dollar_amount": dollar_amount,
+        "entry_price": entry_price,
+        "quantity": None,
+        "notional": dollar_amount,
+    }
+
+
+def _short(
+    ticker: str = "MSFT",
+    dollar_amount: float = 1000.0,
+    entry_price: float = 100.0,
+    quantity: int | None = 10,
+) -> dict:
+    return {
+        "ticker": ticker,
+        "side": TradeSide.SELL,
+        "dollar_amount": dollar_amount,
+        "entry_price": entry_price,
+        "quantity": quantity,
+        "notional": None,
+    }
+
+
+# --- execute_close_positions ---
+
+
+def test_execute_close_positions_returns_success_when_position_closed() -> None:
+    client = _make_mock_client()
+    client.close_position.return_value = True
+
+    results, count = execute_close_positions(client, [{"ticker": "AAPL"}])
+
+    assert count == 1
+    assert results[0]["status"] == "success"
+    assert results[0]["action"] == "close"
+    assert results[0]["ticker"] == "AAPL"
+
+
+def test_execute_close_positions_returns_skipped_when_position_not_found() -> None:
+    client = _make_mock_client()
+    client.close_position.return_value = False
+
+    results, count = execute_close_positions(client, [{"ticker": "AAPL"}])
+
+    assert count == 0
+    assert results[0]["status"] == "skipped"
+    assert results[0]["reason"] == "position_not_found"
+
+
+def test_execute_close_positions_returns_failed_on_exception() -> None:
+    client = _make_mock_client()
+    client.close_position.side_effect = RuntimeError("network error")
+
+    results, count = execute_close_positions(client, [{"ticker": "AAPL"}])
+
+    assert count == 0
+    assert results[0]["status"] == "failed"
+    assert "network error" in results[0]["error"]
+
+
+def test_execute_close_positions_returns_empty_for_no_positions() -> None:
+    client = _make_mock_client()
+    results, count = execute_close_positions(client, [])
+    assert results == []
+    assert count == 0
+
+
+def test_execute_close_positions_handles_multiple_positions() -> None:
+    client = _make_mock_client()
+    client.close_position.side_effect = [True, False, RuntimeError("err")]
+
+    results, count = execute_close_positions(
+        client,
+        [{"ticker": "AAPL"}, {"ticker": "MSFT"}, {"ticker": "GOOG"}],
+    )
+
+    assert count == 1
+    assert results[0]["status"] == "success"
+    assert results[1]["status"] == "skipped"
+    assert results[2]["status"] == "failed"
+
+
+# --- execute_open_positions ---
+
+
+def test_execute_open_positions_opens_long_successfully() -> None:
+    client = _make_mock_client()
+    results, count = execute_open_positions(
+        client, [_long()], 10000.0, 50000.0, _DEFAULT_CONFIG
+    )
+    assert count == 1
+    assert results[0]["status"] == "success"
+    assert results[0]["side"] == TradeSide.BUY
+
+
+def test_execute_open_positions_refreshes_buying_power_after_open() -> None:
+    client = _make_mock_client()
+    client.get_account.return_value = AlpacaAccount(
+        cash_amount=9000.0, buying_power=18000.0, equity=50000.0
+    )
+    execute_open_positions(client, [_long()], 10000.0, 50000.0, _DEFAULT_CONFIG)
+    client.get_account.assert_called_once()
+
+
+def test_execute_open_positions_uses_buying_power_estimate_when_refresh_fails() -> None:
+    client = _make_mock_client()
+    client.get_account.side_effect = RuntimeError("account unavailable")
+
+    results, count = execute_open_positions(
+        client, [_long(dollar_amount=500.0)], 10000.0, 50000.0, _DEFAULT_CONFIG
+    )
+
+    assert count == 1
+    assert results[0]["status"] == "success"
+
+
+def test_execute_open_positions_skips_long_when_insufficient_buying_power() -> None:
+    client = _make_mock_client()
+    results, count = execute_open_positions(
+        client, [_long(dollar_amount=5000.0)], 100.0, 50000.0, _DEFAULT_CONFIG
+    )
+    assert count == 0
+    assert results[0]["status"] == "skipped"
+    assert results[0]["reason"] == "insufficient_buying_power"
+
+
+def test_execute_open_positions_handles_insufficient_buying_power_error() -> None:
+    client = _make_mock_client()
+    client.open_position.side_effect = InsufficientBuyingPowerError("not enough")
+
+    results, count = execute_open_positions(
+        client, [_long()], 10000.0, 50000.0, _DEFAULT_CONFIG
+    )
+
+    assert count == 0
+    assert results[0]["status"] == "skipped"
+    assert results[0]["reason"] == "insufficient_buying_power"
+
+
+def test_execute_open_positions_handles_generic_exception() -> None:
+    client = _make_mock_client()
+    client.open_position.side_effect = RuntimeError("unexpected error")
+
+    results, count = execute_open_positions(
+        client, [_long()], 10000.0, 50000.0, _DEFAULT_CONFIG
+    )
+
+    assert count == 0
+    assert results[0]["status"] == "failed"
+    assert "unexpected error" in results[0]["error"]
+
+
+def test_execute_open_positions_opens_short_overnight_standard_rate() -> None:
+    config = Configuration(
+        hold_overnight=True,
+        short_buying_power_buffer=1.03,
+        overnight_margin_rate_standard=0.30,
+        low_price_threshold=5.0,
+    )
+    client = _make_mock_client()
+    # entry_price=100.0 >= low_price_threshold=5.0 → standard rate
+    # buying_power_cost = 10 * 100 * (1.03 + 0.30) = 1330
+    results, count = execute_open_positions(
+        client, [_short(entry_price=100.0, quantity=10)], 5000.0, 50000.0, config
+    )
+    assert count == 1
+    assert results[0]["status"] == "success"
+
+
+def test_execute_open_positions_opens_short_overnight_low_price_rate() -> None:
+    config = Configuration(
+        hold_overnight=True,
+        short_buying_power_buffer=1.03,
+        overnight_margin_rate_low_price=1.00,
+        low_price_threshold=5.0,
+    )
+    client = _make_mock_client()
+    # entry_price=3.0 < low_price_threshold=5.0 → low price rate
+    # buying_power_cost = 100 * 3.0 * (1.03 + 1.00) = 609
+    results, count = execute_open_positions(
+        client,
+        [_short(entry_price=3.0, dollar_amount=300.0, quantity=100)],
+        10000.0,
+        50000.0,
+        config,
+    )
+    assert count == 1
+    assert results[0]["status"] == "success"
+
+
+def test_execute_open_positions_opens_short_intraday_no_margin() -> None:
+    config = Configuration(hold_overnight=False, short_buying_power_buffer=1.03)
+    client = _make_mock_client()
+    # buying_power_cost = 10 * 100 * 1.03 = 1030
+    results, count = execute_open_positions(
+        client, [_short(entry_price=100.0, quantity=10)], 2000.0, 50000.0, config
+    )
+    assert count == 1
+    assert results[0]["status"] == "success"
+
+
+def test_execute_open_positions_skips_short_with_insufficient_equity() -> None:
+    config = Configuration(minimum_short_equity=2000.0)
+    client = _make_mock_client()
+
+    results, count = execute_open_positions(client, [_short()], 10000.0, 500.0, config)
+
+    assert count == 0
+    assert results[0]["status"] == "skipped"
+    assert results[0]["reason"] == "insufficient_equity_for_short"
+
+
+def test_execute_open_positions_skips_short_with_zero_quantity() -> None:
+    client = _make_mock_client()
+    # quantity=None, dollar_amount=50 < entry_price=100 → int(0.5) = 0
+    results, count = execute_open_positions(
+        client,
+        [_short(dollar_amount=50.0, entry_price=100.0, quantity=None)],
+        10000.0,
+        50000.0,
+        _DEFAULT_CONFIG,
+    )
+    assert count == 0
+    assert results[0]["status"] == "skipped"
+    assert results[0]["reason"] == "zero_short_quantity"
+
+
+def test_execute_open_positions_uses_precomputed_quantity_for_short() -> None:
+    client = _make_mock_client()
+    results, count = execute_open_positions(
+        client,
+        [_short(quantity=5, dollar_amount=500.0, entry_price=100.0)],
+        10000.0,
+        50000.0,
+        _DEFAULT_CONFIG,
+    )
+    assert count == 1
+    assert results[0]["status"] == "success"
+
+
+def test_execute_open_positions_skips_short_when_insufficient_buying_power() -> None:
+    config = Configuration(hold_overnight=False, short_buying_power_buffer=1.03)
+    client = _make_mock_client()
+    # buying_power_cost = 10 * 100 * 1.03 = 1030 > initial=100
+    results, count = execute_open_positions(
+        client,
+        [_short(entry_price=100.0, quantity=10)],
+        100.0,
+        50000.0,
+        config,
+    )
+    assert count == 0
+    assert results[0]["status"] == "skipped"
+    assert results[0]["reason"] == "insufficient_buying_power"
+
+
+def test_execute_open_positions_handles_asset_not_shortable_error() -> None:
+    client = _make_mock_client()
+    client.open_position.side_effect = AssetNotShortableError("not shortable")
+
+    results, count = execute_open_positions(
+        client, [_short(quantity=10)], 10000.0, 50000.0, _DEFAULT_CONFIG
+    )
+
+    assert count == 0
+    assert results[0]["status"] == "skipped"
+    assert results[0]["reason"] == "not_shortable"
+
+
+def test_execute_open_positions_submits_longs_before_shorts() -> None:
+    client = _make_mock_client()
+    submitted_sides: list[TradeSide] = []
+
+    def capture_side(
+        ticker: str,  # noqa: ARG001
+        side: TradeSide,
+        dollar_amount: float,  # noqa: ARG001
+        entry_price: float,  # noqa: ARG001
+        quantity: int | None = None,  # noqa: ARG001
+    ) -> None:
+        submitted_sides.append(side)
+
+    client.open_position.side_effect = capture_side
+
+    positions = [_short(ticker="MSFT", quantity=10), _long(ticker="AAPL")]
+    execute_open_positions(client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG)
+
+    assert submitted_sides[0] == TradeSide.BUY
+    assert submitted_sides[1] == TradeSide.SELL
+
+
+def test_execute_open_positions_returns_empty_for_no_positions() -> None:
+    client = _make_mock_client()
+    results, count = execute_open_positions(
+        client, [], 10000.0, 50000.0, _DEFAULT_CONFIG
+    )
+    assert results == []
+    assert count == 0

--- a/devenv.nix
+++ b/devenv.nix
@@ -109,12 +109,14 @@ in {
     awscli2
     clang
     bacon
+    cargo-llvm-cov
     cargo-watch
     curl
     duckdb
     gh
     git
     jq
+    llvmPackages.llvm
     markdownlint-cli
     ruff
     rustup
@@ -201,6 +203,7 @@ in {
     uv run coverage run -m pytest --tb=short -q
     uv run coverage combine 2>/dev/null || true
     uv run coverage xml -o .coverage_output/python.xml
+    uv run coverage report --fail-under=80
     echo "Python tests completed successfully"
   '';
 
@@ -230,26 +233,28 @@ in {
   '';
 
   scripts.rust-test.exec = ''
-    set -euo pipefail
-    echo "Running Rust tests"
+        set -euo pipefail
+        echo "Running Rust tests"
 
-    TEST_ARGS="--workspace --verbose --lib --bins"
+        TEST_ARGS="--workspace --verbose --lib --bins"
 
-    mkdir -p .coverage_output
-    if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
-      echo "cargo-llvm-cov not available - running tests without coverage"
-      cargo test $TEST_ARGS
-    elif ! command -v llvm-cov >/dev/null 2>&1 || ! command -v llvm-profdata >/dev/null 2>&1; then
-      echo "LLVM tools not available - running tests without coverage"
-      cargo test $TEST_ARGS
-    else
-      export LLVM_COV=$(which llvm-cov)
-      export LLVM_PROFDATA=$(which llvm-profdata)
-      cargo llvm-cov $TEST_ARGS \
-        --cobertura \
-        --output-path .coverage_output/rust.xml
-      echo "Rust tests with coverage completed successfully"
-    fi
+        mkdir -p .coverage_output
+        export LLVM_COV=$(which llvm-cov)
+        export LLVM_PROFDATA=$(which llvm-profdata)
+        cargo llvm-cov $TEST_ARGS \
+          --cobertura \
+          --output-path .coverage_output/rust.xml
+        python3 -c "
+    import xml.etree.ElementTree as ET, sys
+    root = ET.parse('.coverage_output/rust.xml').getroot()
+    rate = float(root.get('line-rate', 0)) * 100
+    threshold = 10
+    print(f'Rust line coverage: {rate:.1f}%')
+    if rate < threshold:
+        print(f'Coverage failure: {rate:.1f}% is below threshold of {threshold}%')
+        sys.exit(1)
+    "
+        echo "Rust tests with coverage completed successfully"
   '';
 
   scripts.rust-checks.exec = ''

--- a/uv.lock
+++ b/uv.lock
@@ -229,29 +229,29 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.3"
+version = "1.43.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/50/ea184e159c4ac64fef816a72094fb8656eb071361a39ed22c0e3b15a35b4/boto3-1.43.3.tar.gz", hash = "sha256:7c7777862ffc898f05efa566032bbabfe226dbb810e35ec11125817f128bc5c5", size = 113111, upload-time = "2026-05-04T19:34:09.731Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/cc/42d798fc5305e4636170b50cdfb305ff0a81f470e35131f4a0d2641976ae/boto3-1.43.9.tar.gz", hash = "sha256:37dac72f2921095378c0200caf07918d5e10a82b7c1f611abb70e44f69d0b962", size = 113135, upload-time = "2026-05-15T19:28:31.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/ad/8a6946a329f0127322108e537dc1c0d9f8eea4f1d1231702c073d2e85f46/boto3-1.43.3-py3-none-any.whl", hash = "sha256:fb9fe51849ef2a78198d582756fc06f14f7de27f73e0fa90275d6aa4171eb4d0", size = 140501, upload-time = "2026-05-04T19:34:07.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/dc/51286e9551f7852a79ce5d2a57468d9d905c30d32bcace55204551db202d/boto3-1.43.9-py3-none-any.whl", hash = "sha256:5e967292d361482793471bd80fad1e714515b7401f65a0d5b4aa6ef9d009c030", size = 140523, upload-time = "2026-05-15T19:28:28.948Z" },
 ]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.43.3"
+version = "1.43.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/48/0b57f1f7cfe85a5c0c14b9e61334a5ae66a55e1eb74d9dd9c954a475de24/boto3_stubs-1.43.3.tar.gz", hash = "sha256:1c17fb4003c8d3ac324385f1d7a366721436eab3b6dc7838239dea53137ba9de", size = 102653, upload-time = "2026-05-04T20:11:17.742Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/21/c81de9b74be84e7a1f35998adae6e0560862da00328cf6375dfaacb9737d/boto3_stubs-1.43.9.tar.gz", hash = "sha256:afb9de061aa5667ca3247c47057fc792bf03b4c483da1659697c32317e1d2efa", size = 102691, upload-time = "2026-05-15T20:09:55.809Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/e8/0d53950bbe8daa3bba0554782a08a2ecab4e52f9377a0572d69471496ed1/boto3_stubs-1.43.3-py3-none-any.whl", hash = "sha256:dd43fb68fe1d6db450588609a96013a9baf86d1cfc45bbbee7fd97bac971a3c0", size = 70653, upload-time = "2026-05-04T20:11:10.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ad/bfd434b0e4f16169efd174e3e8a000fd04f35c1baf683e343b0c2b778380/boto3_stubs-1.43.9-py3-none-any.whl", hash = "sha256:d046be3b956f494134e0c59af630b327319c9eb72fae4032e586e8057b986010", size = 70652, upload-time = "2026-05-15T20:09:50.647Z" },
 ]
 
 [package.optional-dependencies]
@@ -264,16 +264,16 @@ ssm = [
 
 [[package]]
 name = "botocore"
-version = "1.43.3"
+version = "1.43.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/ac/cd55f886e17b6b952dbc95b792d3645a73d58586a1400ababe54406073bd/botocore-1.43.3.tar.gz", hash = "sha256:eac6da0fffccf87888ebf4d89f0b2378218a707efa748cd955b838995e944695", size = 15308705, upload-time = "2026-05-04T19:33:56.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/e8/f696c80982685a4cdb3df5f0781919afa50262f40e1aac7066c9c2520deb/botocore-1.43.9.tar.gz", hash = "sha256:93e91c7160678182860f5902ee4cfe6d643cac0d9ee84d3eb65becc9f4c00228", size = 15357963, upload-time = "2026-05-15T19:28:19.342Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/99/1d9e296edf244f47e0508032f20999f8fd40704dd3c5b601fed099424eb6/botocore-1.43.3-py3-none-any.whl", hash = "sha256:ec0769eb0f7c5034856bb406a92698dbc02a3d4be0f78a384747106b161d8ea3", size = 14989027, upload-time = "2026-05-04T19:33:50.81Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c9/a1b51a74d476f5cb2f555ce8274f0f6b9fb21d75cc3f57b87dd0632ee17a/botocore-1.43.9-py3-none-any.whl", hash = "sha256:b9bdcd9c87fc552aad30006f00167d9ebb3480e1b06f1902bac5b2c41014fdab", size = 15039827, upload-time = "2026-05-15T19:28:14.543Z" },
 ]
 
 [[package]]
@@ -290,27 +290,27 @@ wheels = [
 
 [[package]]
 name = "burner-redis"
-version = "0.1.6"
+version = "0.1.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/6f/ec3eeb9e3e9d7fedc51fcb56dd09da0f164495ab6fdf4caaa3754ceed659/burner_redis-0.1.6.tar.gz", hash = "sha256:362091d98c09953ef99be8bd026d75fad42599a0f153211e1a22d3e3029c7cfb", size = 843118, upload-time = "2026-04-27T17:11:41.879Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/89/54706febafc135095b2a9d797cfbd4eed2ab1ad7819808b99b587020471b/burner_redis-0.1.7.tar.gz", hash = "sha256:7474ff092669fd11ef765411572cdafcc3d89b8054aef4ca0617be6d6be4c680", size = 638644, upload-time = "2026-05-08T15:01:42.961Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/cc/061897380b88c637e4bea1f6715ffba851d10b16d6610f2832ab61fa15b5/burner_redis-0.1.6-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5dc9c170b9994b8d57958041857f240d1b0b9ac1559d0d35473f03fb62386dea", size = 1275400, upload-time = "2026-04-27T17:11:27.07Z" },
-    { url = "https://files.pythonhosted.org/packages/db/24/e4c6fb37d059b268c2a26b173d3f84b49547e837340983d3d018c08191c6/burner_redis-0.1.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f29caae7f80fea2e47350df24264a049aeaa934454210cddcadc2336ee8b423a", size = 1223570, upload-time = "2026-04-27T17:11:28.782Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/be/718af7f42bbebbfbfd771ba43697526c922dff54d1b0d62654e21418b25e/burner_redis-0.1.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0ce82edea4ed1ec34448a8610c62665517b3d2030254f31af32828b070a92a8", size = 1325624, upload-time = "2026-04-27T17:11:30.648Z" },
-    { url = "https://files.pythonhosted.org/packages/06/8a/4f72de7f967532d3739caa461625dc9122f0ca0d46faa883c153a10d0117/burner_redis-0.1.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e3dff7d691ab0035468c17f51632e452b075065a30e026278ed1b297441ce93", size = 1356531, upload-time = "2026-04-27T17:11:32.201Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/22/369338d6372abd12dee51965566428c06f3badd95f668ff1c11680b99b30/burner_redis-0.1.6-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3b43f983b6e8fbc208734f04b0bae8cf95323fc43105f977d20f0993fc28c1b3", size = 1526049, upload-time = "2026-04-27T17:11:33.93Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/23/0651cf86bc5ed390fef09e30ff4a4664cc3c5b88ddf4c6b8d905acc0d60e/burner_redis-0.1.6-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b6ba097d910effff00a4610160a4a759503ad590e2c47a580bdcdac9a325823", size = 1579068, upload-time = "2026-04-27T17:11:35.964Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/8c/302638fdad4476d4760d477b0f3c6b96c0f88d3f278e5f14d06eb048f788/burner_redis-0.1.6-cp310-abi3-win_amd64.whl", hash = "sha256:98c6b6fc397617cd5a6778ac020e4ed9985c393ad204f9f5cf524b68ae16070b", size = 1103735, upload-time = "2026-04-27T17:11:38.38Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ba/18668d92e18210150f7f93e2930264ad77a82e4d3e5f74ca1aecc002f78f/burner_redis-0.1.6-cp310-abi3-win_arm64.whl", hash = "sha256:c2583e98f9a3836ac2c6243ea0c8d56b40e7017b46617991e329bc807c544bad", size = 1029386, upload-time = "2026-04-27T17:11:40.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/5d/198bd1d22e504b3034353430703afbdb3efe6e25cb90bf52d896e1d266a7/burner_redis-0.1.7-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f80c866996e0455d584eb3c0f3b067e411c632fb0519eab454e0968edf01e62c", size = 1288888, upload-time = "2026-05-08T15:01:26.103Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/4e/ce5c91b884ac37fcd380756402536f8810964014097950900517ce8bd30c/burner_redis-0.1.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a3d9569a376b690fb5876d454e4904443332dc3ad5c0057e149fc2ad220bf599", size = 1234282, upload-time = "2026-05-08T15:01:28.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/31c25cc88143eac2dddcc394151a0db627923d44c94376a83768552c9f13/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20eba1917e3bca9eea5957d5700ff8defcb5a209e57a7841d005549aa0151f44", size = 1337341, upload-time = "2026-05-08T15:01:30.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/32/95cfa1833316ca2b6b2e58150a4900bc1ad256043cdd36198f1887618ccc/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39111467059b8a28f15ea061d2414ec25c3e57c65759983f90f4d358e7d6a72d", size = 1366800, upload-time = "2026-05-08T15:01:32.891Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ad/93c3916f053f89b7b5760da5bf855cd78b7885d480f9cfcc64f3732c1dc2/burner_redis-0.1.7-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9b5adfe99aeb8407f468078f3769b2a63e9168fea12f7709df5d2a3b152706e4", size = 1538160, upload-time = "2026-05-08T15:01:34.667Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/b9/19bae42cb124932d71168bc8e5bcb1da33aa62b908e5e632b3d298d7cb15/burner_redis-0.1.7-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:591a9d20685f9d6d22bf0c863b50b12dfcf328b06111b3f62c33cd3185d48ce0", size = 1591491, upload-time = "2026-05-08T15:01:36.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/30/207f47f406619a5b564355d2946c3171f84231a28b800709b5645b06a5ae/burner_redis-0.1.7-cp310-abi3-win_amd64.whl", hash = "sha256:f6cf4ac666766b32fd63940aad0c120847905fd3102c17e5b6b305f91a21d079", size = 1117564, upload-time = "2026-05-08T15:01:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6f/e9beaf46c5e9fd10dfcdb889ebf7d3aa85142c650c0ab17ab284194f58e1/burner_redis-0.1.7-cp310-abi3-win_arm64.whl", hash = "sha256:458f88feeddfb40a586cc3fcbd8e9384bbdfd2a4512a695af4900e06052570d4", size = 1040407, upload-time = "2026-05-08T15:01:41.235Z" },
 ]
 
 [[package]]
 name = "cachetools"
-version = "7.1.1"
+version = "7.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/e2/85f227594656000ff4d8adadae91a21f536d4a84c6c716a86bd6685874be/cachetools-7.1.1.tar.gz", hash = "sha256:27bdf856d68fd3c71c26c01b5edc312124ed427524d1ddb31aa2b7746fe20d4b", size = 40202, upload-time = "2026-05-03T20:00:29.391Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/53/984d70974279207f676fbd525cbe7533b95da34d829f2adc0797a6860718/cachetools-7.1.2.tar.gz", hash = "sha256:c1373e3cad0933dfb46bb04d04ef67b5204f8220eb906096dd89a76196053d57", size = 39828, upload-time = "2026-05-16T19:59:03.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/0f/f897abe4ea0a8c408ae65c8c83bffab4936ad65d6032d4fb4cd35bbdc3ee/cachetools-7.1.1-py3-none-any.whl", hash = "sha256:0335cd7a0952d2b22327441fb0628139e234c565559eeb91a8a4ac7551c5353d", size = 16775, upload-time = "2026-05-03T20:00:27.857Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9b/56cf24737a6756d8751659c8809a67c23b7b256a587bcb147a6d24fddea3/cachetools-7.1.2-py3-none-any.whl", hash = "sha256:89386be5bece29963e0f22bb7e1aba91c8395c7ad107780e2ce7af3ab315ae40", size = 16805, upload-time = "2026-05-16T19:59:01.927Z" },
 ]
 
 [[package]]
@@ -372,14 +372,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.3"
+version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
 ]
 
 [[package]]
@@ -433,26 +433,26 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.13.5"
+version = "7.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/7f/d0720730a397a999ffc0fd3f5bebef347338e3a47b727da66fbb228e2ff2/coverage-7.14.0.tar.gz", hash = "sha256:057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74", size = 919489, upload-time = "2026-05-10T18:02:31.397Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
-    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
-    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
-    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
-    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
-    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
-    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+    { url = "https://files.pythonhosted.org/packages/09/1e/2f996b2c8415cbb6f54b0f5ec1ee850c96d7911961afb4fc05f4a89d8c58/coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5", size = 219967, upload-time = "2026-05-10T18:00:13.756Z" },
+    { url = "https://files.pythonhosted.org/packages/34/23/35c7aea1274aef7525bdd2dc92f710bdde6d11652239d71d1ec450067939/coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:829994cfe1aeb773ca27bf246d4badc1e764893e3bfb98fff820fcecd1ca4662", size = 220329, upload-time = "2026-05-10T18:00:15.264Z" },
+    { url = "https://files.pythonhosted.org/packages/75/cf/a8f4b43a16e194b0261257ad28ded5853ec052570afef4a84e1d81189f3b/coverage-7.14.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b4f07cf7edcb7ec39431a5074d7ea83b29a9f71fcfc494f0f40af4e65180420f", size = 251839, upload-time = "2026-05-10T18:00:17.16Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ff/6699e7b71e60d3049eb2bdcbc95ee3f35707b2b0e48f32e9e63d3ce30c08/coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67", size = 254576, upload-time = "2026-05-10T18:00:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ec/c936d495fcd67f48f03a9c4ad3297ff80d1f222a5df3980f15b34c186c21/coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9", size = 255690, upload-time = "2026-05-10T18:00:20.648Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5af63f636cc62a4a2b1b3ba9146f6ee6f53a35a50d5cefc54d5670f60999/coverage-7.14.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7b2bb6c9d7e769360d0f20a0f219603fd64f0c8f97de17ab25853261602be0fb", size = 257949, upload-time = "2026-05-10T18:00:22.28Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d3/a225317bd2012132a27e1176d51660b826f99bb975876463c44ea0d7ee5a/coverage-7.14.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1c9ed6ef99f88fb8c14aa8e2bf8eb0fe55fa2edfea68f8675d78741df1a5ac0e", size = 252242, upload-time = "2026-05-10T18:00:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/7f/9e65495298c3ea414742998539c37d048b5e81cc818fb1828cc6b51d10bf/coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8231ade007f37959fbf58acc677f26b922c02eda6f0428ea307da0fd39681bf3", size = 253608, upload-time = "2026-05-10T18:00:25.588Z" },
+    { url = "https://files.pythonhosted.org/packages/94/46/1522b524a35bdad22b2b8c4f9d32d0a104b524726ec380b2db68db1746f5/coverage-7.14.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d8b013632cc1ce1d09dbe4f32667b4d320ec2f54fc326ebeffcd0b0bcc2bb6c4", size = 251753, upload-time = "2026-05-10T18:00:27.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e9/cdf00d38817742c541ade405e115a3f7bf36e6f2a8b99d4f209861b85a2d/coverage-7.14.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1733198802d71ec4c524f322e2867ee05c62e9e75df86bdca545407a221827d1", size = 255823, upload-time = "2026-05-10T18:00:29.038Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fc/5e7877cf5f902d08a17ff1c532511476d87e1bea355bd5028cb97f902e79/coverage-7.14.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:72a305291fa8ee01332f1aaf38b348ca34097f6aa0b0ef627eef2837e57bbba5", size = 251323, upload-time = "2026-05-10T18:00:30.647Z" },
+    { url = "https://files.pythonhosted.org/packages/18/9d/50f05a72dff8487464fdd4178dda5daed642a060e60afb644e3d45123559/coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcaba850dd317c65423a9d63d88f9573c53b00354d6dd95724576cc98a131595", size = 253197, upload-time = "2026-05-10T18:00:32.211Z" },
+    { url = "https://files.pythonhosted.org/packages/00/3f/6f61ffe6439df266c3cf60f5c99cfaa21103d0210d706a42fc6c30683ff8/coverage-7.14.0-cp312-cp312-win32.whl", hash = "sha256:5ac83957a80d0701310e96d8bec68cdcf4f90a7674b7d13f15a344315b41ab27", size = 222515, upload-time = "2026-05-10T18:00:33.717Z" },
+    { url = "https://files.pythonhosted.org/packages/85/19/93853133df2cb371083285ef6a93982a0173e7a233b0f61373ba9fd30eb2/coverage-7.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:70390b0da32cb90b501953716302906e8bcce087cb283e70d8c97729f22e92b2", size = 223324, upload-time = "2026-05-10T18:00:35.172Z" },
+    { url = "https://files.pythonhosted.org/packages/74/18/9f7fe62f659f24b7a82a0be56bf94c1bd0a89e0ae7ab4c668f6e82404294/coverage-7.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:91b993743d959b8be85b4abf9d5478216a69329c321efe5be0433c1a841d691d", size = 221944, upload-time = "2026-05-10T18:00:37.014Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl", hash = "sha256:8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1", size = 211764, upload-time = "2026-05-10T18:02:29.538Z" },
 ]
 
 [[package]]
@@ -513,7 +513,7 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "4.11.2"
+version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -521,23 +521,23 @@ dependencies = [
     { name = "rich" },
     { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/f7/3ee212c1bc314551094fc8fda7b4b63c647ac5c32d06daa285d04d33edfc/cyclopts-4.11.2.tar.gz", hash = "sha256:8c9b77921660fa1ee52c150e2217ced672323efb3434e9b338077de1bc551ff4", size = 175935, upload-time = "2026-05-04T00:11:57.857Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/fb/d953a011e5768b808cec4ab845b6443de3acbea47061d89eb54220a6d559/cyclopts-4.13.0.tar.gz", hash = "sha256:9539dc298d2e7c229f22402e67e47210e4aa7bbbf7c60024b617d7e0340f68b7", size = 177280, upload-time = "2026-05-16T23:51:04.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl", hash = "sha256:838020120b939549ff7c8423aca29c86764b5dd1d8a5d7f3753a6327861f537b", size = 213537, upload-time = "2026-05-04T00:11:56.103Z" },
+    { url = "https://files.pythonhosted.org/packages/56/63/932d51674d5d96e818e41e4c2dfb68addccd4588e4b8e3d7fe46132e7e6c/cyclopts-4.13.0-py3-none-any.whl", hash = "sha256:b2e55e6bb51c33c78f5df23f8c8e0caa3df7e68639d2fb0cf8aa451a7d58b3e4", size = 214930, upload-time = "2026-05-16T23:51:05.86Z" },
 ]
 
 [[package]]
 name = "databricks-sdk"
-version = "0.106.0"
+version = "0.108.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/b7/ef86e7b8c3d135c844f972e06efb628e147eed0a7b9a0ecbf9511437a3c2/databricks_sdk-0.106.0.tar.gz", hash = "sha256:6bbd492cb8593747aced037b9186f8632e9d553fc358e6f3d83b7e959851d9d3", size = 930953, upload-time = "2026-04-30T12:33:19.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/13/05a1dbf9c2c43639b032128c18227953777a2a2da66e4b97d1914ceacb68/databricks_sdk-0.108.0.tar.gz", hash = "sha256:c43f1099b8228e5e9ecb4569381ec8f49b739129d35a826be72a61bc5eaaf1a6", size = 940266, upload-time = "2026-05-12T09:04:03.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/a9/63b4f6ef3078e4d060faaad85c4e43667189c3429edd68d5cbddc45187ca/databricks_sdk-0.106.0-py3-none-any.whl", hash = "sha256:db9de5566279ae80dfea0ecd37231e8968523ef984e83cbe4bd77e50c59aa6a5", size = 879452, upload-time = "2026-04-30T12:33:18.116Z" },
+    { url = "https://files.pythonhosted.org/packages/56/38/9b59ebb34ccaef79095f168eff1fab5f8d645b961680c7bcbc320434acd0/databricks_sdk-0.108.0-py3-none-any.whl", hash = "sha256:010528183abb475acf7f4058e331049dc7932e73a314d9808b123f5cbb722579", size = 887647, upload-time = "2026-05-12T09:04:01.771Z" },
 ]
 
 [[package]]
@@ -686,19 +686,19 @@ wheels = [
 
 [[package]]
 name = "fonttools"
-version = "4.62.1"
+version = "4.63.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", hash = "sha256:e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d", size = 3580737, upload-time = "2026-03-13T13:54:25.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/d4/dbacced3953544b9a93088cc10ef2b596d348c983d5c67a404fa41ec51ba/fonttools-4.62.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:90365821debbd7db678809c7491ca4acd1e0779b9624cdc6ddaf1f31992bf974", size = 2870219, upload-time = "2026-03-13T13:52:53.664Z" },
-    { url = "https://files.pythonhosted.org/packages/66/9e/a769c8e99b81e5a87ab7e5e7236684de4e96246aae17274e5347d11ebd78/fonttools-4.62.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12859ff0b47dd20f110804c3e0d0970f7b832f561630cd879969011541a464a9", size = 2414891, upload-time = "2026-03-13T13:52:56.493Z" },
-    { url = "https://files.pythonhosted.org/packages/69/64/f19a9e3911968c37e1e620e14dfc5778299e1474f72f4e57c5ec771d9489/fonttools-4.62.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c125ffa00c3d9003cdaaf7f2c79e6e535628093e14b5de1dccb08859b680936", size = 5033197, upload-time = "2026-03-13T13:52:59.179Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392", size = 4988768, upload-time = "2026-03-13T13:53:02.761Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/c6/0f904540d3e6ab463c1243a0d803504826a11604c72dd58c2949796a1762/fonttools-4.62.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0aa72c43a601cfa9273bb1ae0518f1acadc01ee181a6fc60cd758d7fdadffc04", size = 4971512, upload-time = "2026-03-13T13:53:05.678Z" },
-    { url = "https://files.pythonhosted.org/packages/29/0b/5cbef6588dc9bd6b5c9ad6a4d5a8ca384d0cea089da31711bbeb4f9654a6/fonttools-4.62.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:19177c8d96c7c36359266e571c5173bcee9157b59cfc8cb0153c5673dc5a3a7d", size = 5122723, upload-time = "2026-03-13T13:53:08.662Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/47/b3a5342d381595ef439adec67848bed561ab7fdb1019fa522e82101b7d9c/fonttools-4.62.1-cp312-cp312-win32.whl", hash = "sha256:a24decd24d60744ee8b4679d38e88b8303d86772053afc29b19d23bb8207803c", size = 2281278, upload-time = "2026-03-13T13:53:10.998Z" },
-    { url = "https://files.pythonhosted.org/packages/28/b1/0c2ab56a16f409c6c8a68816e6af707827ad5d629634691ff60a52879792/fonttools-4.62.1-cp312-cp312-win_amd64.whl", hash = "sha256:9e7863e10b3de72376280b515d35b14f5eeed639d1aa7824f4cf06779ec65e42", size = 2331414, upload-time = "2026-03-13T13:53:13.992Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ef/b3c6b9b5be2f82416d73fe2ed2e96e2793cd80e7510bd6a17ca79cdd88ec/fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02", size = 2881131, upload-time = "2026-05-14T12:03:13.386Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/c815bea63117fa63e4e1c01f8a1110d2112fa003f838e6467094ec2432ce/fonttools-4.63.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a9faff9e0c1f76f9fd55899d2ce785832efebab37eb8ae13995853aef178bef0", size = 2426704, upload-time = "2026-05-14T12:03:15.801Z" },
+    { url = "https://files.pythonhosted.org/packages/44/04/0b91d8e916e92ad1fac9e4624760baf0fd5ff2ead614c2f68fb21373f03f/fonttools-4.63.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef3048ef05dbb552b89817713d9cac912e00d0fde4a3105c00d29e52e10c89af", size = 5044298, upload-time = "2026-05-14T12:03:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58dc6bb86a78d782f00f9190ca02c119cf5bbe2807536e361e18d42019f877d8", size = 4999800, upload-time = "2026-05-14T12:03:20.161Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/6d/67fe16c48d7ce050979b33f47e0d28a318f02da030602e944c34f7a16ef3/fonttools-4.63.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee08ebfa58f6e1aeff5697ab9582105bb620008c1caafb681e4c557e7483027b", size = 4982666, upload-time = "2026-05-14T12:03:22.87Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/3bbab338c07c71fa56269953845e92c951a61457bbbb0f1022551ea266d9/fonttools-4.63.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:27fdc65af8da6f88b9c6121c47a464cbe359fcfff7ff6fc2d37a1f395d755b78", size = 5133598, upload-time = "2026-05-14T12:03:25.168Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/aa27c7f98db5b064883dadcc5283947e81e034de42e22a33675878d98b54/fonttools-4.63.0-cp312-cp312-win32.whl", hash = "sha256:af2fd1664d00a397d75f806985ddb36282091c2131a73a6485c23b4a34722263", size = 2292575, upload-time = "2026-05-14T12:03:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/87/36/cccb9bc2a6ab63d1b2980374f0dca72ce95ae267c9b4cfe77455bb70d0d4/fonttools-4.63.0-cp312-cp312-win_amd64.whl", hash = "sha256:59ac449f8cca9b4ffa08d2e7bbadad87ce710d69d1eda5c3c1ce579baa987272", size = 2343211, upload-time = "2026-05-14T12:03:30.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
 ]
 
 [[package]]
@@ -749,27 +749,27 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.49"
+version = "3.1.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
 name = "google-auth"
-version = "2.50.0"
+version = "2.53.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/18/238d7021d151bdab868f23433817b027dd759135202f4dfce0670d1230ca/google_auth-2.50.0.tar.gz", hash = "sha256:f35eafb191195328e8ce10a7883970877e7aeb49c2bfaa54aa0e394316d353d0", size = 336523, upload-time = "2026-04-30T21:19:29.659Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/cf/4880c2137c14280b2f59975cdf12cc442bc0ae1f9ea473a26eaa0c146786/google_auth-2.50.0-py3-none-any.whl", hash = "sha256:04382175e28b94f49694977f0a792688b59a668def1499e9d8de996dc9ce5b15", size = 246495, upload-time = "2026-04-30T21:19:27.664Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
 ]
 
 [[package]]
@@ -975,11 +975,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -1170,14 +1170,14 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -1236,7 +1236,7 @@ wheels = [
 
 [[package]]
 name = "mlflow"
-version = "3.11.1"
+version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1260,14 +1260,14 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "waitress", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/34/e328c073cd32c186fb242a957e5bade82433c06bc45b7d1695bf4d02f166/mlflow-3.11.1.tar.gz", hash = "sha256:84e54c4be91b5b2a19039a2673fe688b1d7307ceddacc08af51f8df05b19ee56", size = 9797469, upload-time = "2026-04-07T14:26:58.463Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/e3/b2148a6d6f38731d3dda49a7e46cf6932a458aa0aa5414b80e6e7251fa1d/mlflow-3.12.0.tar.gz", hash = "sha256:227ee31c6abf7ae3b3c38d4ca87c356e107578740c1efee89da43f2a5b9e3b47", size = 9939137, upload-time = "2026-05-05T10:28:58.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/62/96826c340354638dfedcbdbcd35d67754566bd45f6592300e0c215c80e30/mlflow-3.11.1-py3-none-any.whl", hash = "sha256:8f6bf1238ac04f97664c229dd480380c5c254a78bdb3c0e433e3a0397508b1af", size = 10479141, upload-time = "2026-04-07T14:26:55.709Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/f8/47f28975c1c1b70d351fa19c5aef21cef5ae1e1aca36bd1858798384bdbb/mlflow-3.12.0-py3-none-any.whl", hash = "sha256:e1c28ed4c48557cc52c766f17f1ca5826753ddf241d43f30f99c45f7ea6b3ce0", size = 10625639, upload-time = "2026-05-05T10:28:55.777Z" },
 ]
 
 [[package]]
 name = "mlflow-skinny"
-version = "3.11.1"
+version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -1287,17 +1287,18 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sqlparse" },
+    { name = "starlette" },
     { name = "typing-extensions" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/77/fe2027ddad9e52ed1ac360fbc262169e6366f6678632e350cbd0d901bb9b/mlflow_skinny-3.11.1.tar.gz", hash = "sha256:86ce63491349f6713afc8a4ef0bf77a8314d0e79e03753cb150d6c860a0b0475", size = 2642799, upload-time = "2026-04-07T14:26:43.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/c0/9cbe24b4abcbadb3a3cdab65bfd552b6b75de64374b477abac89190d25d0/mlflow_skinny-3.12.0.tar.gz", hash = "sha256:74d27066bc9553d281e0c31d25f07deb39dbe99d190e4f7c257703e5c8ee6d10", size = 2723866, upload-time = "2026-05-05T10:28:46.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/a7/e61ec397b34dc3c9e91572f45e41617f429d5c524d38a4e1aa2316ee1b5e/mlflow_skinny-3.11.1-py3-none-any.whl", hash = "sha256:82ffd5f6980320b4ac19f741e7a754faa1d01707e632b002ea68e04fd25a0535", size = 3171551, upload-time = "2026-04-07T14:26:41.762Z" },
+    { url = "https://files.pythonhosted.org/packages/95/05/2df60fab37881c490e9364ea697a6c3a78d3b593fde2d9332a75f8cdf1f8/mlflow_skinny-3.12.0-py3-none-any.whl", hash = "sha256:0498f3697abcabcc6204c432ef179840f6a7a34ce123837c98c1913064fda6dd", size = 3261903, upload-time = "2026-05-05T10:28:44.24Z" },
 ]
 
 [[package]]
 name = "mlflow-tracing"
-version = "3.11.1"
+version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -1309,9 +1310,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/77/73af163432f3c66e2d213045250972e504a6683c76f63dd1abfba441a16a/mlflow_tracing-3.11.1.tar.gz", hash = "sha256:cb63cee16385d081467ec5bee4807fe1af59ddfdf04be4c79e7a7813b1002193", size = 1314550, upload-time = "2026-04-07T14:26:32.785Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/13/d32fe4cca53dde68f09fd38c545ea709e8565fd7c2ffd7c5eff99e504aaf/mlflow_tracing-3.12.0.tar.gz", hash = "sha256:8702a34a1d4f1517ba904d716f5a8fca4675e6526f7d164d02bdaabececa2d80", size = 1352412, upload-time = "2026-05-05T10:28:51.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/ab/d980c84e7df4224ab8db2457afbe135b430f371ca081a37cf89f8ef18ca1/mlflow_tracing-3.11.1-py3-none-any.whl", hash = "sha256:fa82df64dacf8293b714ae666440fe7c1902c6470c024df389bb91e9de3106d9", size = 1575790, upload-time = "2026-04-07T14:26:30.804Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/bf/e22b778addbe19a7a912400c37a197ee9cdebc1641e3b0a3882c30da6ee4/mlflow_tracing-3.12.0-py3-none-any.whl", hash = "sha256:c6072553f47b42505dc7ee62946688a4a0dde8f06b78fbc60e946397b20e1518", size = 1618720, upload-time = "2026-05-05T10:28:48.999Z" },
 ]
 
 [[package]]
@@ -1360,11 +1361,11 @@ wheels = [
 
 [[package]]
 name = "mypy-boto3-s3"
-version = "1.43.0"
+version = "1.43.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7a/9e/7e7d7d412824e117b2e8bf51d167f0ab380c2cbd9bd89bbd912e7bf14ab8/mypy_boto3_s3-1.43.0.tar.gz", hash = "sha256:3bfb027b1f3df9316ff72ff29f4b2dc0d7d65ed5032d8bcf4892222994228588", size = 77067, upload-time = "2026-04-29T23:05:16.94Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/f9/f6bb5e1b3d8d9087ab9e2142df640a1be853e371ec5e16ea519a60061b56/mypy_boto3_s3-1.43.5.tar.gz", hash = "sha256:ba67dbc3da825b6818839db3823722f3b12304dd116e94ed398eb7ade86b0f62", size = 77042, upload-time = "2026-05-06T20:47:46.655Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/c6/e97695c41b28bd16465260c20be1e7880d6eb74c7b65536cc1e52c512fad/mypy_boto3_s3-1.43.0-py3-none-any.whl", hash = "sha256:aaa7991e7ffafcf8ff4fb23c5fb4cc4554ef5724c889ff016b87e60f27405b5b", size = 84261, upload-time = "2026-04-29T23:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/db/02/f597a5c373fb755433e194a69885c78b2f0db7dcca7fac1247f586b59ec1/mypy_boto3_s3-1.43.5-py3-none-any.whl", hash = "sha256:7cd836cf3ec384b6a05b108047034ece03bb7dd0bd0890c527673eafc44907bb", size = 84262, upload-time = "2026-05-06T20:47:42.976Z" },
 ]
 
 [[package]]
@@ -1396,21 +1397,21 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.4.4"
+version = "2.4.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/8e/b8041bc719f056afd864478029d52214789341ac6583437b0ee5031e9530/numpy-2.4.5.tar.gz", hash = "sha256:ca670567a5683b7c1670ec03e0ddd5862e10934e92a70751d68d7b7b74ca7f9f", size = 20735669, upload-time = "2026-05-15T20:25:19.492Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
-    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
-    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
-    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
-    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/18/3275231e98620002681c922e792db04d72c356e9d8073c387344fc0e4ff1/numpy-2.4.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:654fb8674b61b1c4bd568f944d13a908566fdcb0d797303521d4149d16da05ef", size = 16689166, upload-time = "2026-05-15T20:22:50.761Z" },
+    { url = "https://files.pythonhosted.org/packages/db/23/000aab6a16bdec53307f0f72546b57a3ac9266a62d8c257bee97d85fd078/numpy-2.4.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4cd9f6fa7ce10dc4627f2bb81dd9075dab67e94632e04c2b638e12575ddaa862", size = 14699514, upload-time = "2026-05-15T20:22:53.678Z" },
+    { url = "https://files.pythonhosted.org/packages/47/cc/ddaf3af9c46966fef5be879256f213d85a0c56c75d07a3b7defec7cf6b4c/numpy-2.4.5-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:4f5bc96d35d94e4ceab8b38a92241b4611e95dc44e63b9f1fa2a331858ee3507", size = 5204601, upload-time = "2026-05-15T20:22:56.257Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ea/627fadd11959b3c7759008f34c92a35af8ff942dd8284a66ced648bbe516/numpy-2.4.5-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:4bb33e900ee81730ad77a258965134aa8ceac805124f7e5229347beda4b8d0aa", size = 6551360, upload-time = "2026-05-15T20:22:58.334Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/47/0728b986b8682d742ff68c16baa5af9d185484abfc635c5cc700f44e62be/numpy-2.4.5-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32f8f852273ef32b291201ac2a2c97629c4a1ee8632bb670e3443eaa09fc2e72", size = 15671157, upload-time = "2026-05-15T20:23:01.081Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/0b/b905ae82d9419dc38123523862db64978ca2954b69609c3ae8fdaca1084c/numpy-2.4.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685681e956fc8dcb75adc6ff26694e1dfd738b24bd8d4696c51ca0110157f912", size = 16645703, upload-time = "2026-05-15T20:23:04.358Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/24/e27fc3f5236b4118ed9eed67111675f5c61a07ea333acec87c869c3b359d/numpy-2.4.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6f64dd84b277a737eb59513f6b9bb6195bf41ab11941ef15b2562dbab43fa8ef", size = 17021018, upload-time = "2026-05-15T20:23:07.021Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/a7/9041af38d527ab80a06a93570a77e29425b41507ad41f6acf5da78cfb4a4/numpy-2.4.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b42d9496f79e3a728192f05a42d86e36163217b7cdecb3813d0028a0aa6b72d7", size = 18368768, upload-time = "2026-05-15T20:23:09.44Z" },
+    { url = "https://files.pythonhosted.org/packages/49/82/326a014442f32c2663434fd424d9298791f47f8a0f17585ad60519a5606e/numpy-2.4.5-cp312-cp312-win32.whl", hash = "sha256:86d980970f5110595ca14855768073b08585fc1acc36895de303e039e7dee4a5", size = 5962819, upload-time = "2026-05-15T20:23:11.631Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/cbf5d391b0b3a5e8cad264603e2fae256b0bde8ce43566b13b78faedc659/numpy-2.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:3333dba6a4e611d666f69e177ba8fe4140366ff681a5feb2374d3fd4fff3acb6", size = 12321621, upload-time = "2026-05-15T20:23:14.305Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d0/0f18909d9bc37a5f3f969fc737d2bb5df9f2ff295f71b467e6f52a0d6c4e/numpy-2.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:4593d197270b894efeb538dcbe227e4bcf1c77f88c4c6bf933ead812cfaa4453", size = 10221430, upload-time = "2026-05-15T20:23:16.887Z" },
 ]
 
 [[package]]
@@ -1476,25 +1477,25 @@ wheels = [
 
 [[package]]
 name = "orjson"
-version = "3.11.8"
+version = "3.11.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/1b/2024d06792d0779f9dbc51531b61c24f76c75b9f4ce05e6f3377a1814cea/orjson-3.11.8.tar.gz", hash = "sha256:96163d9cdc5a202703e9ad1b9ae757d5f0ca62f4fa0cc93d1f27b0e180cc404e", size = 5603832, upload-time = "2026-03-31T16:16:27.878Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/f6/8d58b32ab32d9215973a1688aebd098252ee8af1766c0e4e36e7831f0295/orjson-3.11.8-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:1cd0b77e77c95758f8e1100139844e99f3ccc87e71e6fc8e1c027e55807c549f", size = 229233, upload-time = "2026-03-31T16:15:12.762Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/8b/2ffe35e71f6b92622e8ea4607bf33ecf7dfb51b3619dcfabfd36cbe2d0a5/orjson-3.11.8-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:6a3d159d5ffa0e3961f353c4b036540996bf8b9697ccc38261c0eac1fd3347a6", size = 128772, upload-time = "2026-03-31T16:15:14.237Z" },
-    { url = "https://files.pythonhosted.org/packages/27/d2/1f8682ae50d5c6897a563cb96bc106da8c9cb5b7b6e81a52e4cc086679b9/orjson-3.11.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76070a76e9c5ae661e2d9848f216980d8d533e0f8143e6ed462807b242e3c5e8", size = 131946, upload-time = "2026-03-31T16:15:15.607Z" },
-    { url = "https://files.pythonhosted.org/packages/52/4b/5500f76f0eece84226e0689cb48dcde081104c2fa6e2483d17ca13685ffb/orjson-3.11.8-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:54153d21520a71a4c82a0dbb4523e468941d549d221dc173de0f019678cf3813", size = 130368, upload-time = "2026-03-31T16:15:17.066Z" },
-    { url = "https://files.pythonhosted.org/packages/da/4e/58b927e08fbe9840e6c920d9e299b051ea667463b1f39a56e668669f8508/orjson-3.11.8-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:469ac2125611b7c5741a0b3798cd9e5786cbad6345f9f400c77212be89563bec", size = 135540, upload-time = "2026-03-31T16:15:18.404Z" },
-    { url = "https://files.pythonhosted.org/packages/56/7c/ba7cb871cba1bcd5cd02ee34f98d894c6cea96353ad87466e5aef2429c60/orjson-3.11.8-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:14778ffd0f6896aa613951a7fbf4690229aa7a543cb2bfbe9f358e08aafa9546", size = 146877, upload-time = "2026-03-31T16:15:19.833Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/5d/eb9c25fc1386696c6a342cd361c306452c75e0b55e86ad602dd4827a7fd7/orjson-3.11.8-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea56a955056a6d6c550cf18b3348656a9d9a4f02e2d0c02cabf3c73f1055d506", size = 132837, upload-time = "2026-03-31T16:15:21.282Z" },
-    { url = "https://files.pythonhosted.org/packages/37/87/5ddeb7fc1fbd9004aeccab08426f34c81a5b4c25c7061281862b015fce2b/orjson-3.11.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53a0f57e59a530d18a142f4d4ba6dfc708dc5fdedce45e98ff06b44930a2a48f", size = 133624, upload-time = "2026-03-31T16:15:22.641Z" },
-    { url = "https://files.pythonhosted.org/packages/22/09/90048793db94ee4b2fcec4ac8e5ddb077367637d6650be896b3494b79bb7/orjson-3.11.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b48e274f8824567d74e2158199e269597edf00823a1b12b63d48462bbf5123e", size = 141904, upload-time = "2026-03-31T16:15:24.435Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/cf/eb284847487821a5d415e54149a6449ba9bfc5872ce63ab7be41b8ec401c/orjson-3.11.8-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:3f262401086a3960586af06c054609365e98407151f5ea24a62893a40d80dbbb", size = 423742, upload-time = "2026-03-31T16:15:26.155Z" },
-    { url = "https://files.pythonhosted.org/packages/44/09/e12423d327071c851c13e76936f144a96adacfc037394dec35ac3fc8d1e8/orjson-3.11.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8e8c6218b614badf8e229b697865df4301afa74b791b6c9ade01d19a9953a942", size = 147806, upload-time = "2026-03-31T16:15:27.909Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/6d/37c2589ba864e582ffe7611643314785c6afb1f83c701654ef05daa8fcc7/orjson-3.11.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:093d489fa039ddade2db541097dbb484999fcc65fc2b0ff9819141e2ab364f25", size = 136485, upload-time = "2026-03-31T16:15:29.749Z" },
-    { url = "https://files.pythonhosted.org/packages/be/c9/135194a02ab76b04ed9a10f68624b7ebd238bbe55548878b11ff15a0f352/orjson-3.11.8-cp312-cp312-win32.whl", hash = "sha256:e0950ed1bcb9893f4293fd5c5a7ee10934fbf82c4101c70be360db23ce24b7d2", size = 131966, upload-time = "2026-03-31T16:15:31.687Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/9a/9796f8fbe3cf30ce9cb696748dbb535e5c87be4bf4fe2e9ca498ef1fa8cf/orjson-3.11.8-cp312-cp312-win_amd64.whl", hash = "sha256:3cf17c141617b88ced4536b2135c552490f07799f6ad565948ea07bef0dcb9a6", size = 127441, upload-time = "2026-03-31T16:15:33.333Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/47/5aaf54524a7a4a0dd09dd778f3fa65dd2108290615b652e23d944152bc8e/orjson-3.11.8-cp312-cp312-win_arm64.whl", hash = "sha256:48854463b0572cc87dac7d981aa72ed8bf6deedc0511853dc76b8bbd5482d36d", size = 127364, upload-time = "2026-03-31T16:15:34.748Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6d/11867a3ffa3a3608d84a4de51ef4dd0896d6b5cc9132fbe1daf593e677bc/orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9ef6fe90aadef185c7b128859f40beb24720b4ecea95379fc9000931179c3a49", size = 228515, upload-time = "2026-05-06T15:09:57.265Z" },
+    { url = "https://files.pythonhosted.org/packages/24/75/05912954c8b288f34fcf5cd4b9b071cb4f6e77b9961e175e56ebb258089f/orjson-3.11.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5c9b8f28e726e97d97696c826bc7bea5d71cecd63576dba92924a32c1961291", size = 128409, upload-time = "2026-05-06T15:09:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/1c3a47df3bc8191ea9ac51603bbb872a95167a364320c269f2557911f406/orjson-3.11.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a473dbb4162108b27901492546f83c76fdcea3d0eadff00ae7a07e18dcce09", size = 132106, upload-time = "2026-05-06T15:10:00.798Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/cf/b33b5f3e695ae7d63feef9d915c37cc3b8f465493dcd4f8e0b4c697a2366/orjson-3.11.9-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:011382e2a60fda9d46f1cdee31068cfc52ffe952b587d683ec0463002802a0f4", size = 127864, upload-time = "2026-05-06T15:10:02.15Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6a/6cf69385a58208024fcb8c014e2141b8ce838aba6492b589f8acfff97fab/orjson-3.11.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2d3dc759490128c5c1711a53eeaa8ee1d437fd0038ffd2b6008abf46db3f882", size = 135213, upload-time = "2026-05-06T15:10:03.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f8/0b1bd3e8f2efcdd376af5c8cfd79eaf13f018080c0089c80ebd724e3c7fb/orjson-3.11.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8ea516b3726d190e1b4297e6f4e7a8650347ae053868a18163b4dd3641d1fff", size = 145994, upload-time = "2026-05-06T15:10:05.083Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/59/dab79f61044c529d2c81aecdc589b1f833a1c8dec11ba3b1c2498a02ca7e/orjson-3.11.9-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:380cdce7ba24989af81d0a7013d0aaec5d0e2a21734c0e2681b1bc4f141957fe", size = 132744, upload-time = "2026-05-06T15:10:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4fa4f0af7fa18951f7ab3fc2148e223af211bf03f59e1c6034ec3f97f21d61", size = 134014, upload-time = "2026-05-06T15:10:08.213Z" },
+    { url = "https://files.pythonhosted.org/packages/50/c7/375e83a76851b73b2e39f3bcf0e5a19e2b89bad13e5bca97d0b293d27f24/orjson-3.11.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a8f5f8bc7ce7d59f08d9f99fa510c06496164a24cb5f3d34537dbd9ca30132e2", size = 141509, upload-time = "2026-05-06T15:10:09.595Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7c/49d5d82a3d3097f641f094f552131f1e2723b0b8cb0fa2874ab65ecfffa6/orjson-3.11.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4d7fde5501b944f83b3e665e1b31343ff6e154b15560a16b7130ea1e594a4206", size = 415127, upload-time = "2026-05-06T15:10:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/dc/7446c538590d55f455647e5f3c61fc33f7108714e7afcffa6a2a033f8350/orjson-3.11.9-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cde1a448023ba7d5bb4c01c5afb48894380b5e4956e0627266526587ef4e535f", size = 148025, upload-time = "2026-05-06T15:10:12.842Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e5/4d2d8af06f788329b4f78f8cc3679bb395392fcaa1e4d8d3c33e85308fa4/orjson-3.11.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e63adb0e1f1ed5d9e168f50a91ceb93ae6420731d222dc7da5c69409aa47aa", size = 136943, upload-time = "2026-05-06T15:10:14.405Z" },
+    { url = "https://files.pythonhosted.org/packages/06/69/850264ccf6d80f6b174620d30a87f65c9b1490aba33fe6b62798e618cad3/orjson-3.11.9-cp312-cp312-win32.whl", hash = "sha256:2d057a602cdd19a0ad680417527c45b6961a095081c0f46fe0e03e304aac6470", size = 131606, upload-time = "2026-05-06T15:10:15.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/973a43fc9c55e20f2051e9830997649f669be0cb3ca52192087c0143f118/orjson-3.11.9-cp312-cp312-win_amd64.whl", hash = "sha256:59e403b1cc5a676da8eaf31f6254801b7341b3e29efa85f92b48d272637e77be", size = 127101, upload-time = "2026-05-06T15:10:17.129Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/495470f0e4a18f73fa10b7f6b84b464ec4cc5291c4e0c7c2a6c400bef006/orjson-3.11.9-cp312-cp312-win_arm64.whl", hash = "sha256:9af678d6488357948f1f84c6cd1c1d397c014e1ae2f98ae082a44eb48f602624", size = 126736, upload-time = "2026-05-06T15:10:18.645Z" },
 ]
 
 [[package]]
@@ -1671,7 +1672,7 @@ requires-dist = [
 
 [[package]]
 name = "prefect"
-version = "3.6.29"
+version = "3.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1730,9 +1731,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/11/df2cd0c702d4180b2c3d44b7bf3fdebfdc67f108926ba8f5f90c9a2ad88f/prefect-3.6.29.tar.gz", hash = "sha256:0c90479367ce31dc41b37d1e2fdb61e4f0e253456306ceec3fbb534d543b0be0", size = 11115533, upload-time = "2026-05-01T21:49:46.169Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/12/dde80bca1378f19ef5b45bbab75d30367796ff9358eafc21ff3c6aa43b55/prefect-3.7.1.tar.gz", hash = "sha256:7e1c59491f7d31f700539ed9084dade3b7e3bdb6c08b5a417c6a0a7502ba9c9d", size = 14056819, upload-time = "2026-05-16T02:43:21.545Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/35/d61322b6b24d95346d6a3ad924403581ff6c4c0f22b8fa29287d59710d40/prefect-3.6.29-py3-none-any.whl", hash = "sha256:1d53728cd5646d70b4158dc2517d5d3d4037a2fc2116edbb5b531fe56f2689e5", size = 11917034, upload-time = "2026-05-01T21:49:42.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/88/bc1d779c8680e75fe77746511004a0963984b51aec65f5fb0bc64392c371/prefect-3.7.1-py3-none-any.whl", hash = "sha256:5113ecc7b6274eeea97bac29bdce9b45b3dd6bb5048202b8e5c4e2eacac5f968", size = 14933114, upload-time = "2026-05-16T02:43:17.972Z" },
 ]
 
 [[package]]
@@ -1776,40 +1777,43 @@ wheels = [
 
 [[package]]
 name = "propcache"
-version = "0.4.1"
+version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/0f/f17b1b2b221d5ca28b4b876e8bb046ac40466513960646bda8e1853cdfa2/propcache-0.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e153e9cd40cc8945138822807139367f256f89c6810c2634a4f6902b52d3b4e2", size = 80061, upload-time = "2025-10-08T19:46:46.075Z" },
-    { url = "https://files.pythonhosted.org/packages/76/47/8ccf75935f51448ba9a16a71b783eb7ef6b9ee60f5d14c7f8a8a79fbeed7/propcache-0.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cd547953428f7abb73c5ad82cbb32109566204260d98e41e5dfdc682eb7f8403", size = 46037, upload-time = "2025-10-08T19:46:47.23Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/b6/5c9a0e42df4d00bfb4a3cbbe5cf9f54260300c88a0e9af1f47ca5ce17ac0/propcache-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f048da1b4f243fc44f205dfd320933a951b8d89e0afd4c7cacc762a8b9165207", size = 47324, upload-time = "2025-10-08T19:46:48.384Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/d3/6c7ee328b39a81ee877c962469f1e795f9db87f925251efeb0545e0020d0/propcache-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ec17c65562a827bba85e3872ead335f95405ea1674860d96483a02f5c698fa72", size = 225505, upload-time = "2025-10-08T19:46:50.055Z" },
-    { url = "https://files.pythonhosted.org/packages/01/5d/1c53f4563490b1d06a684742cc6076ef944bc6457df6051b7d1a877c057b/propcache-0.4.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:405aac25c6394ef275dee4c709be43745d36674b223ba4eb7144bf4d691b7367", size = 230242, upload-time = "2025-10-08T19:46:51.815Z" },
-    { url = "https://files.pythonhosted.org/packages/20/e1/ce4620633b0e2422207c3cb774a0ee61cac13abc6217763a7b9e2e3f4a12/propcache-0.4.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0013cb6f8dde4b2a2f66903b8ba740bdfe378c943c4377a200551ceb27f379e4", size = 238474, upload-time = "2025-10-08T19:46:53.208Z" },
-    { url = "https://files.pythonhosted.org/packages/46/4b/3aae6835b8e5f44ea6a68348ad90f78134047b503765087be2f9912140ea/propcache-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15932ab57837c3368b024473a525e25d316d8353016e7cc0e5ba9eb343fbb1cf", size = 221575, upload-time = "2025-10-08T19:46:54.511Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/a5/8a5e8678bcc9d3a1a15b9a29165640d64762d424a16af543f00629c87338/propcache-0.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:031dce78b9dc099f4c29785d9cf5577a3faf9ebf74ecbd3c856a7b92768c3df3", size = 216736, upload-time = "2025-10-08T19:46:56.212Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/63/b7b215eddeac83ca1c6b934f89d09a625aa9ee4ba158338854c87210cc36/propcache-0.4.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ab08df6c9a035bee56e31af99be621526bd237bea9f32def431c656b29e41778", size = 213019, upload-time = "2025-10-08T19:46:57.595Z" },
-    { url = "https://files.pythonhosted.org/packages/57/74/f580099a58c8af587cac7ba19ee7cb418506342fbbe2d4a4401661cca886/propcache-0.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4d7af63f9f93fe593afbf104c21b3b15868efb2c21d07d8732c0c4287e66b6a6", size = 220376, upload-time = "2025-10-08T19:46:59.067Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/ee/542f1313aff7eaf19c2bb758c5d0560d2683dac001a1c96d0774af799843/propcache-0.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cfc27c945f422e8b5071b6e93169679e4eb5bf73bbcbf1ba3ae3a83d2f78ebd9", size = 226988, upload-time = "2025-10-08T19:47:00.544Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/18/9c6b015dd9c6930f6ce2229e1f02fb35298b847f2087ea2b436a5bfa7287/propcache-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:35c3277624a080cc6ec6f847cbbbb5b49affa3598c4535a0a4682a697aaa5c75", size = 215615, upload-time = "2025-10-08T19:47:01.968Z" },
-    { url = "https://files.pythonhosted.org/packages/80/9e/e7b85720b98c45a45e1fca6a177024934dc9bc5f4d5dd04207f216fc33ed/propcache-0.4.1-cp312-cp312-win32.whl", hash = "sha256:671538c2262dadb5ba6395e26c1731e1d52534bfe9ae56d0b5573ce539266aa8", size = 38066, upload-time = "2025-10-08T19:47:03.503Z" },
-    { url = "https://files.pythonhosted.org/packages/54/09/d19cff2a5aaac632ec8fc03737b223597b1e347416934c1b3a7df079784c/propcache-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:cb2d222e72399fcf5890d1d5cc1060857b9b236adff2792ff48ca2dfd46c81db", size = 41655, upload-time = "2025-10-08T19:47:04.973Z" },
-    { url = "https://files.pythonhosted.org/packages/68/ab/6b5c191bb5de08036a8c697b265d4ca76148efb10fa162f14af14fb5f076/propcache-0.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:204483131fb222bdaaeeea9f9e6c6ed0cac32731f75dfc1d4a567fc1926477c1", size = 37789, upload-time = "2025-10-08T19:47:06.077Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/cb/e27bc2b2737a0bb49962b275efa051e8f1c35a936df7d5139b6b658b7dc9/propcache-0.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:806719138ecd720339a12410fb9614ac9b2b2d3a5fdf8235d56981c36f4039ba", size = 95887, upload-time = "2026-05-08T21:00:11.277Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/13/b8ae04c59392f8d11c6cd9fb4011d1dc7c86b81225c770280300e259ffe1/propcache-0.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:db2b80ea58eab4f86b2beec3cc8b39e8ff9276ac20e96b7cce43c8ae84cd6b5a", size = 54654, upload-time = "2026-05-08T21:00:12.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7d/49777a3e20b55863d4794384a38acd460c04157b0a00f8602b0d508b8431/propcache-0.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e5cbfac9f61484f7e9f3597775500cd3ebe8274e9b050c38f9525c77c97520bf", size = 55190, upload-time = "2026-05-08T21:00:13.935Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c7/085d0cd63062e84044e3f05797749c3f8e3938ff3aeb0eb2f69d43fafc91/propcache-0.5.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbc581d2814337da56222fab8dc5f161cd798a434e49bac27930aaef798e144", size = 59995, upload-time = "2026-05-08T21:00:15.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/42/32cf8e3009e92b2645cf1e944f701e8ea4e924dffde1ee26db860bcbf7e4/propcache-0.5.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:857187f381f88c8e2fa2fe56ab94879d011b883d5a2ee5a1b60a8cd2a06846d9", size = 63422, upload-time = "2026-05-08T21:00:16.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/f112433f99fc979431b87a39ef169e3f8df070d99a72792c56d6937ac48b/propcache-0.5.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:178b4a2cdaac1818e2bf1c5a99b94383fa73ea5382e032a48dec07dc5668dc42", size = 64342, upload-time = "2026-05-08T21:00:18.362Z" },
+    { url = "https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f328175a2cde1f0ff2c4ed8ce968b9dcfb55f3a7153f39e2957ed994da13476", size = 61639, upload-time = "2026-05-08T21:00:19.692Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/da/4d775080b1490c0ae604acda868bd71aabe3a89ed16f2aa4339eb8a283e7/propcache-0.5.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5671d09a36b06d0fd4a3da0fccbcae360e9b1570924171a15e9e0997f0249fba", size = 61588, upload-time = "2026-05-08T21:00:21.155Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ac/f076982cbe2195ee9cf32de5a1e46951d9fb399fc207f390562dd0fd8fb2/propcache-0.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80168e2ebe4d3ec6599d10ad8f520304ae1cad9b6c5a95372aef1b66b7bfb53a", size = 60029, upload-time = "2026-05-08T21:00:22.713Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/189be62e0dd898dce3b331e1b8c7a543cd3a405ac0c81fe8ee8a9d5d77e1/propcache-0.5.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:45f11346f884bc47444f6e6647131055844134c3175b629f84952e2b5cd62b64", size = 56774, upload-time = "2026-05-08T21:00:24.001Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/9e/93377b9c7939c1ffae98f878dee955efadfd638078bc86dbc21f9d52f651/propcache-0.5.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e778ebd44ef4f66ed60a0416b06b489687db264a9c0b3620362f26489492913", size = 63532, upload-time = "2026-05-08T21:00:25.545Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f9/590ef6cfb9b8028d516d287812ece32bb0bc5f11fbb9c8bf6b2e6313fec8/propcache-0.5.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c0cb9ed24c8964e172768d455a38254c2dd8a552905729ce006cad3d3dda59b1", size = 61592, upload-time = "2026-05-08T21:00:27.186Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5e/70958b3034c297a630bba2f17ca7abc2d5f39a803ad7e370ab79d1ecd022/propcache-0.5.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1d1ad32d9d4355e2be65574fd0bfd3677e7066b009cd5b9b2dee8aa6a6393b33", size = 64788, upload-time = "2026-05-08T21:00:28.8Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fd/77fe5936d8c3086ca9048f7f415f122ed82e53884a9ec193646b42deef06/propcache-0.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c80f4ba3e8f00189165999a742ee526ebeccedf6c3f7beb0c7df821e9772435a", size = 62514, upload-time = "2026-05-08T21:00:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/74/66bd798b5b3be70aa1b391f5cc9d6a0a5532d7fd3b19ec0b213e72e6ad9d/propcache-0.5.2-cp312-cp312-win32.whl", hash = "sha256:8c7972d8f193740d9175f0998ab38717e6cd322d5935c5b0fef8c0d323fd9031", size = 39018, upload-time = "2026-05-08T21:00:31.622Z" },
+    { url = "https://files.pythonhosted.org/packages/61/7c/5c0d34aa3024694d6dcb9271cdbdd08c4e47c1c0ad95ec7e7bc74cdea145/propcache-0.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:d9ee8826a7d47863a08ac44e1a5f611a462eefc3a194b492da242128bec75b42", size = 42322, upload-time = "2026-05-08T21:00:32.918Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/875812f1a3feb20ceba818ef39fbe4d92f1081e04ac815c822496d0d038b/propcache-0.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:2800a4a8ead6b28cccd1ec54b59346f0def7922ee1c7598e8499c733cfbb7c84", size = 38172, upload-time = "2026-05-08T21:00:35.124Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
 ]
 
 [[package]]
 name = "protobuf"
-version = "5.29.6"
+version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/57/394a763c103e0edf87f0938dafcd918d53b4c011dfc5c8ae80f3b0452dbb/protobuf-5.29.6.tar.gz", hash = "sha256:da9ee6a5424b6b30fd5e45c5ea663aef540ca95f9ad99d1e887e819cdf9b8723", size = 425623, upload-time = "2026-02-04T22:54:40.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/88/9ee58ff7863c479d6f8346686d4636dd4c415b0cbeed7a6a7d0617639c2a/protobuf-5.29.6-cp310-abi3-win32.whl", hash = "sha256:62e8a3114992c7c647bce37dcc93647575fc52d50e48de30c6fcb28a6a291eb1", size = 423357, upload-time = "2026-02-04T22:54:25.805Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/66/2dc736a4d576847134fb6d80bd995c569b13cdc7b815d669050bf0ce2d2c/protobuf-5.29.6-cp310-abi3-win_amd64.whl", hash = "sha256:7e6ad413275be172f67fdee0f43484b6de5a904cc1c3ea9804cb6fe2ff366eda", size = 435175, upload-time = "2026-02-04T22:54:28.592Z" },
-    { url = "https://files.pythonhosted.org/packages/06/db/49b05966fd208ae3f44dcd33837b6243b4915c57561d730a43f881f24dea/protobuf-5.29.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:b5a169e664b4057183a34bdc424540e86eea47560f3c123a0d64de4e137f9269", size = 418619, upload-time = "2026-02-04T22:54:30.266Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/d7/48cbf6b0c3c39761e47a99cb483405f0fde2be22cf00d71ef316ce52b458/protobuf-5.29.6-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:a8866b2cff111f0f863c1b3b9e7572dc7eaea23a7fae27f6fc613304046483e6", size = 320284, upload-time = "2026-02-04T22:54:31.782Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/dd/cadd6ec43069247d91f6345fa7a0d2858bef6af366dbd7ba8f05d2c77d3b/protobuf-5.29.6-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:e3387f44798ac1106af0233c04fb8abf543772ff241169946f698b3a9a3d3ab9", size = 320478, upload-time = "2026-02-04T22:54:32.909Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/cb/e3065b447186cb70aa65acc70c86baf482d82bf75625bf5a2c4f6919c6a3/protobuf-5.29.6-py3-none-any.whl", hash = "sha256:6b9edb641441b2da9fa8f428760fc136a49cf97a52076010cf22a2ff73438a86", size = 173126, upload-time = "2026-02-04T22:54:39.462Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -1880,7 +1884,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.13.3"
+version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -1888,39 +1892,39 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.46.3"
+version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946, upload-time = "2026-04-20T14:40:52.581Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612, upload-time = "2026-04-20T14:42:42.996Z" },
-    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027, upload-time = "2026-04-20T14:42:02.001Z" },
-    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008, upload-time = "2026-04-20T14:44:17.952Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082, upload-time = "2026-04-20T14:40:57.934Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615, upload-time = "2026-04-20T14:42:12.584Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380, upload-time = "2026-04-20T14:43:05.522Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429, upload-time = "2026-04-20T14:41:55.549Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582, upload-time = "2026-04-20T14:41:45.96Z" },
-    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533, upload-time = "2026-04-20T14:40:55.367Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985, upload-time = "2026-04-20T14:44:13.05Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670, upload-time = "2026-04-20T14:41:53.421Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722, upload-time = "2026-04-20T14:44:30.588Z" },
-    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970, upload-time = "2026-04-20T14:42:54.248Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963, upload-time = "2026-04-20T14:44:20.4Z" },
-    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877, upload-time = "2026-04-20T14:43:27.091Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
-    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
-    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
 ]
 
 [[package]]
@@ -1938,21 +1942,21 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.0"
+version = "2.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
 ]
 
 [[package]]
 name = "pydocket"
-version = "0.20.0"
+version = "0.20.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "burner-redis" },
@@ -1969,9 +1973,9 @@ dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "uncalled-for" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/9d/05d54dccfaa505c0bc2e480bc331c44552cdc16af3f44f5893c75293a165/pydocket-0.20.0.tar.gz", hash = "sha256:4b5132a5754ba54f894d46bf2cbdc12e237adada73bc76ca367017536098df7f", size = 361050, upload-time = "2026-05-04T00:27:34.393Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/c3/8df43eeb0151c73f6514417a3adcaaa3c10fc301326ae16bcbb1d3d4a13b/pydocket-0.20.2.tar.gz", hash = "sha256:e5444ad28beeccfbe43370291333030ae61516c5197d9c2269cf2cc55bcb8d97", size = 380338, upload-time = "2026-05-11T14:51:35.913Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/cb/635665c07be980ec48c92b830907e6796012801b107cb1166a213e49ec38/pydocket-0.20.0-py3-none-any.whl", hash = "sha256:1f745278be09d3526f1bdd579c2d92f77fa0a534a39b893e9ef21dfc2ee52378", size = 102483, upload-time = "2026-05-04T00:27:32.799Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/51/cf9c41add3b51102f0f716ed1a6bfb6ceb6274ad67b4096ef2f69524032b/pydocket-0.20.2-py3-none-any.whl", hash = "sha256:35676bd376ce932018473e7db6d078e0880088824abdb135105bcb8a7b7482b7", size = 110290, upload-time = "2026-05-11T14:51:34.255Z" },
 ]
 
 [[package]]
@@ -2121,31 +2125,31 @@ wheels = [
 
 [[package]]
 name = "regex"
-version = "2026.4.4"
+version = "2026.5.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000, upload-time = "2026-04-03T20:56:28.155Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/28/b972a4d3df61e1d7bcf1b59fdb3cddef22f88b6be43f161bb41ebc0e4081/regex-2026.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c07ab8794fa929e58d97a0e1796b8b76f70943fa39df225ac9964615cf1f9d52", size = 490434, upload-time = "2026-04-03T20:53:40.219Z" },
-    { url = "https://files.pythonhosted.org/packages/84/20/30041446cf6dc3e0eab344fc62770e84c23b6b68a3b657821f9f80cb69b4/regex-2026.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c785939dc023a1ce4ec09599c032cc9933d258a998d16ca6f2b596c010940eb", size = 292061, upload-time = "2026-04-03T20:53:41.862Z" },
-    { url = "https://files.pythonhosted.org/packages/62/c8/3baa06d75c98c46d4cc4262b71fd2edb9062b5665e868bca57859dadf93a/regex-2026.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b1ce5c81c9114f1ce2f9288a51a8fd3aeea33a0cc440c415bf02da323aa0a76", size = 289628, upload-time = "2026-04-03T20:53:43.701Z" },
-    { url = "https://files.pythonhosted.org/packages/31/87/3accf55634caad8c0acab23f5135ef7d4a21c39f28c55c816ae012931408/regex-2026.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:760ef21c17d8e6a4fe8cf406a97cf2806a4df93416ccc82fc98d25b1c20425be", size = 796651, upload-time = "2026-04-03T20:53:45.379Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/0c/aaa2c83f34efedbf06f61cb1942c25f6cf1ee3b200f832c4d05f28306c2e/regex-2026.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7088fcdcb604a4417c208e2169715800d28838fefd7455fbe40416231d1d47c1", size = 865916, upload-time = "2026-04-03T20:53:47.064Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/f6/8c6924c865124643e8f37823eca845dc27ac509b2ee58123685e71cd0279/regex-2026.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07edca1ba687998968f7db5bc355288d0c6505caa7374f013d27356d93976d13", size = 912287, upload-time = "2026-04-03T20:53:49.422Z" },
-    { url = "https://files.pythonhosted.org/packages/11/0e/a9f6f81013e0deaf559b25711623864970fe6a098314e374ccb1540a4152/regex-2026.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f657a7c1c6ec51b5e0ba97c9817d06b84ea5fa8d82e43b9405de0defdc2b9", size = 801126, upload-time = "2026-04-03T20:53:51.096Z" },
-    { url = "https://files.pythonhosted.org/packages/71/61/3a0cc8af2dc0c8deb48e644dd2521f173f7e6513c6e195aad9aa8dd77ac5/regex-2026.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2b69102a743e7569ebee67e634a69c4cb7e59d6fa2e1aa7d3bdbf3f61435f62d", size = 776788, upload-time = "2026-04-03T20:53:52.889Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0b/8bb9cbf21ef7dee58e49b0fdb066a7aded146c823202e16494a36777594f/regex-2026.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dac006c8b6dda72d86ea3d1333d45147de79a3a3f26f10c1cf9287ca4ca0ac3", size = 785184, upload-time = "2026-04-03T20:53:55.627Z" },
-    { url = "https://files.pythonhosted.org/packages/99/c2/d3e80e8137b25ee06c92627de4e4d98b94830e02b3e6f81f3d2e3f504cf5/regex-2026.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:50a766ee2010d504554bfb5f578ed2e066898aa26411d57e6296230627cdefa0", size = 859913, upload-time = "2026-04-03T20:53:57.249Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e6/9d5d876157d969c804622456ef250017ac7a8f83e0e14f903b9e6df5ce95/regex-2026.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9e2f5217648f68e3028c823df58663587c1507a5ba8419f4fdfc8a461be76043", size = 765732, upload-time = "2026-04-03T20:53:59.428Z" },
-    { url = "https://files.pythonhosted.org/packages/82/80/b568935b4421388561c8ed42aff77247285d3ae3bb2a6ca22af63bae805e/regex-2026.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39d8de85a08e32632974151ba59c6e9140646dcc36c80423962b1c5c0a92e244", size = 852152, upload-time = "2026-04-03T20:54:01.505Z" },
-    { url = "https://files.pythonhosted.org/packages/39/29/f0f81217e21cd998245da047405366385d5c6072048038a3d33b37a79dc0/regex-2026.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:55d9304e0e7178dfb1e106c33edf834097ddf4a890e2f676f6c5118f84390f73", size = 789076, upload-time = "2026-04-03T20:54:03.323Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1d/1d957a61976ab9d4e767dd4f9d04b66cc0c41c5e36cf40e2d43688b5ae6f/regex-2026.4.4-cp312-cp312-win32.whl", hash = "sha256:04bb679bc0bde8a7bfb71e991493d47314e7b98380b083df2447cda4b6edb60f", size = 266700, upload-time = "2026-04-03T20:54:05.639Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/5c/bf575d396aeb58ea13b06ef2adf624f65b70fafef6950a80fc3da9cae3bc/regex-2026.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:db0ac18435a40a2543dbb3d21e161a6c78e33e8159bd2e009343d224bb03bb1b", size = 277768, upload-time = "2026-04-03T20:54:07.312Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/27/049df16ec6a6828ccd72add3c7f54b4df029669bea8e9817df6fff58be90/regex-2026.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:4ce255cc05c1947a12989c6db801c96461947adb7a59990f1360b5983fab4983", size = 270568, upload-time = "2026-04-03T20:54:09.484Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
 ]
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2153,9 +2157,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -2417,15 +2421,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
 ]
 
 [[package]]
@@ -2554,14 +2558,14 @@ dev = [{ name = "boto3-stubs", extras = ["s3"], specifier = ">=1.38.0" }]
 
 [[package]]
 name = "typeguard"
-version = "4.5.1"
+version = "4.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/e8/66e25efcc18542d58706ce4e50415710593721aae26e794ab1dec34fb66f/typeguard-4.5.1.tar.gz", hash = "sha256:f6f8ecbbc819c9bc749983cc67c02391e16a9b43b8b27f15dc70ed7c4a007274", size = 80121, upload-time = "2026-02-19T16:09:03.392Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz", hash = "sha256:5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423", size = 80240, upload-time = "2026-05-14T12:59:40.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl", hash = "sha256:44d2bf329d49a244110a090b55f5f91aa82d9a9834ebfd30bcc73651e4a8cc40", size = 36745, upload-time = "2026-02-19T16:09:01.6Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl", hash = "sha256:fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf", size = 36748, upload-time = "2026-05-14T12:59:39.473Z" },
 ]
 
 [[package]]
@@ -2654,33 +2658,33 @@ wheels = [
 
 [[package]]
 name = "uncalled-for"
-version = "0.3.1"
+version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/68/35c1d87e608940badbcfeb630347aa0509897284684f61fab6423d02b253/uncalled_for-0.3.1.tar.gz", hash = "sha256:5e412ac6708f04b56bef5867b5dcf6690ebce4eb7316058d9c50787492bb4bca", size = 49693, upload-time = "2026-04-07T13:05:06.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/e1/7ec67882ad8fc9f86384bef6421fa252c9cbe5744f8df6ce77afc9eca1f5/uncalled_for-0.3.1-py3-none-any.whl", hash = "sha256:074cdc92da8356278f93d0ded6f2a66dd883dbecaf9bc89437646ee2289cc200", size = 11361, upload-time = "2026-04-07T13:05:05.341Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
 ]
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
 name = "uvicorn"
-version = "0.46.0"
+version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b1/8e7077a8641086aea449e1b5752a570f1b5906c64e0a33cd6d93b63a066b/uvicorn-0.47.0.tar.gz", hash = "sha256:7c9a0ea1a9414106bbab7324609c162d8fa0cdcdcb703060987269d77c7bb533", size = 90582, upload-time = "2026-05-14T18:16:54.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl", hash = "sha256:2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432", size = 71301, upload-time = "2026-05-14T18:16:51.762Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Overview

## Changes

- Create centralized configuration
- Update sizing logic for non-fractional short selling constraint
- Update order ordering to facilitate short selling
- Include buying power constraint for short selling
- Remove Coveralls coverage upload steps and README coverage badge (coverage thresholds now enforced locally via devenv checks)

## Context

This is broadly to fix the bug in Production. I have not tried testing this out locally yet. Additionally, I'll need to create new Alpaca paper account(s) to update the starting cash balance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Short-position support with explicit entry prices; open orders now include entry_price plus quantity or notional.
  * New configurable portfolio settings for overnight holding, short-equity thresholds, buying-power buffer, and margin rates.

* **Improvements**
  * Whole-share short sizing with preserved dollar neutrality and safer buying-power/overnight margin checks.
  * Rebalance and execution flows surface account equity and normalized open-position data; longs executed before paired shorts with clearer skip reasons.

* **Tests**
  * Expanded unit tests covering sizing, short flows, execution, schema, and account equity.

* **Documentation / CI**
  * README header updated; CI and local tooling coverage behavior revised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->