### PR TITLE
Fix ShapeError when concatenating new and held positions during rebalance

### DIFF
--- a/applications/portfolio_manager/src/portfolio_manager/portfolio_state.py
+++ b/applications/portfolio_manager/src/portfolio_manager/portfolio_state.py
@@ -28,6 +28,8 @@ _PRIOR_ALLOCATION_SCHEMA: dict[str, type] = {
     "action": pl.String,
     "pair_id": pl.String,
     "entry_price": pl.Float64,
+    "quantity": pl.Int64,
+    "notional": pl.Float64,
 }
 
 

--- a/applications/portfolio_manager/src/portfolio_manager/rebalance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/rebalance.py
@@ -328,7 +328,7 @@ async def run_rebalance(  # noqa: PLR0911, PLR0912, PLR0915, C901
         pl.col("pair_id").is_in(successful_pair_ids)
     )
     held_rows = prior_allocation.filter(pl.col("ticker").is_in(held_tickers))
-    final_allocation = pl.concat([successful_open_rows, held_rows])
+    final_allocation = pl.concat([successful_open_rows, held_rows], how="diagonal")
     save_succeeded = await save_allocation(final_allocation, current_timestamp)
 
     all_results = close_results + open_results

--- a/applications/portfolio_manager/tests/test_rebalance.py
+++ b/applications/portfolio_manager/tests/test_rebalance.py
@@ -196,6 +196,8 @@ def test_evaluate_prior_pairs_skips_malformed_pair_missing_long_leg() -> None:
             "action": ["OPEN_POSITION"],
             "pair_id": ["AAPL-MSFT"],
             "entry_price": [100.0],
+            "quantity": [None],
+            "notional": [None],
         },
         schema=_PRIOR_ALLOCATION_SCHEMA,
     )
@@ -591,15 +593,7 @@ def test_run_rebalance_refreshes_account_after_closing_positions(
     optimal = _make_optimal_portfolio()
     mock_optimal_portfolio.return_value = optimal
     mock_pairs_schema.validate.side_effect = lambda df: df
-    # Use the full portfolio schema (including quantity/notional) so that pl.concat
-    # in run_rebalance does not fail on schema mismatch.
-    mock_prior_portfolio.return_value = pl.DataFrame(
-        schema={
-            **_PRIOR_ALLOCATION_SCHEMA,
-            "quantity": pl.Int64,
-            "notional": pl.Float64,
-        }
-    )
+    mock_prior_portfolio.return_value = pl.DataFrame(schema=_PRIOR_ALLOCATION_SCHEMA)
 
     mock_account = MagicMock()
     mock_account.cash_amount = 10000.0
@@ -687,13 +681,7 @@ def test_run_rebalance_returns_500_when_account_refresh_fails(
     optimal = _make_optimal_portfolio()
     mock_optimal_portfolio.return_value = optimal
     mock_pairs_schema.validate.side_effect = lambda df: df
-    mock_prior_portfolio.return_value = pl.DataFrame(
-        schema={
-            **_PRIOR_ALLOCATION_SCHEMA,
-            "quantity": pl.Int64,
-            "notional": pl.Float64,
-        }
-    )
+    mock_prior_portfolio.return_value = pl.DataFrame(schema=_PRIOR_ALLOCATION_SCHEMA)
 
     mock_account = MagicMock()
     mock_account.cash_amount = 10000.0
@@ -783,13 +771,7 @@ def test_run_rebalance_saves_only_opened_rows(
     optimal = _make_optimal_portfolio()
     mock_optimal_portfolio.return_value = optimal
     mock_pairs_schema.validate.side_effect = lambda df: df
-    mock_prior_portfolio.return_value = pl.DataFrame(
-        schema={
-            **_PRIOR_ALLOCATION_SCHEMA,
-            "quantity": pl.Int64,
-            "notional": pl.Float64,
-        }
-    )
+    mock_prior_portfolio.return_value = pl.DataFrame(schema=_PRIOR_ALLOCATION_SCHEMA)
     # AMD (short) is skipped; only NVDA (long) opened successfully.
     mock_execute_open.return_value = (
         [
@@ -901,13 +883,7 @@ def test_run_rebalance_saves_complete_pairs_when_both_legs_succeed(
     optimal = _make_optimal_portfolio()
     mock_optimal_portfolio.return_value = optimal
     mock_pairs_schema.validate.side_effect = lambda df: df
-    mock_prior_portfolio.return_value = pl.DataFrame(
-        schema={
-            **_PRIOR_ALLOCATION_SCHEMA,
-            "quantity": pl.Int64,
-            "notional": pl.Float64,
-        }
-    )
+    mock_prior_portfolio.return_value = pl.DataFrame(schema=_PRIOR_ALLOCATION_SCHEMA)
     # Both legs succeed — the full pair should be saved.
     mock_execute_open.return_value = (
         [


### PR DESCRIPTION
## Summary
- `pl.concat` at `rebalance.py:331` crashed with `ShapeError: unable to append DataFrame of width 9 with DataFrame of width 7` because `optimal_portfolio` includes `quantity` and `notional` columns that `_PRIOR_ALLOCATION_SCHEMA` lacked
- Use `how="diagonal"` in the concat to handle column mismatches defensively (fills missing columns with null)
- Add `quantity` and `notional` to `_PRIOR_ALLOCATION_SCHEMA` so held positions preserve execution details across rebalance cycles

## Test plan
- [x] All 34 existing tests in `test_rebalance.py` pass
- [ ] Verify next scheduled rebalance completes without ShapeError when held positions exist alongside new positions


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Extended portfolio allocation data structure to capture additional tracking metrics
  * Refined data consolidation approach during portfolio rebalancing operations

* **Tests**
  * Updated test scenarios and fixtures to reflect portfolio data schema changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oscmcompany/fund/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->