### PR TITLE
fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ data/
 .scratchpad/
 .devenv
 .env
+.understand-anything

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ data/
 .claude/tasks/
 .scratchpad/
 .devenv
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2921,6 +2921,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/applications/portfolio_manager/src/portfolio_manager/portfolio_state.py
+++ b/applications/portfolio_manager/src/portfolio_manager/portfolio_state.py
@@ -28,6 +28,8 @@ _PRIOR_ALLOCATION_SCHEMA: dict[str, type] = {
     "action": pl.String,
     "pair_id": pl.String,
     "entry_price": pl.Float64,
+    "quantity": pl.Int64,
+    "notional": pl.Float64,
 }
 
 

--- a/applications/portfolio_manager/src/portfolio_manager/rebalance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/rebalance.py
@@ -328,7 +328,7 @@ async def run_rebalance(  # noqa: PLR0911, PLR0912, PLR0915, C901
         pl.col("pair_id").is_in(successful_pair_ids)
     )
     held_rows = prior_allocation.filter(pl.col("ticker").is_in(held_tickers))
-    final_allocation = pl.concat([successful_open_rows, held_rows])
+    final_allocation = pl.concat([successful_open_rows, held_rows], how="diagonal")
     save_succeeded = await save_allocation(final_allocation, current_timestamp)
 
     all_results = close_results + open_results

--- a/applications/portfolio_manager/tests/test_rebalance.py
+++ b/applications/portfolio_manager/tests/test_rebalance.py
@@ -196,6 +196,8 @@ def test_evaluate_prior_pairs_skips_malformed_pair_missing_long_leg() -> None:
             "action": ["OPEN_POSITION"],
             "pair_id": ["AAPL-MSFT"],
             "entry_price": [100.0],
+            "quantity": [None],
+            "notional": [None],
         },
         schema=_PRIOR_ALLOCATION_SCHEMA,
     )
@@ -591,15 +593,7 @@ def test_run_rebalance_refreshes_account_after_closing_positions(
     optimal = _make_optimal_portfolio()
     mock_optimal_portfolio.return_value = optimal
     mock_pairs_schema.validate.side_effect = lambda df: df
-    # Use the full portfolio schema (including quantity/notional) so that pl.concat
-    # in run_rebalance does not fail on schema mismatch.
-    mock_prior_portfolio.return_value = pl.DataFrame(
-        schema={
-            **_PRIOR_ALLOCATION_SCHEMA,
-            "quantity": pl.Int64,
-            "notional": pl.Float64,
-        }
-    )
+    mock_prior_portfolio.return_value = pl.DataFrame(schema=_PRIOR_ALLOCATION_SCHEMA)
 
     mock_account = MagicMock()
     mock_account.cash_amount = 10000.0
@@ -687,13 +681,7 @@ def test_run_rebalance_returns_500_when_account_refresh_fails(
     optimal = _make_optimal_portfolio()
     mock_optimal_portfolio.return_value = optimal
     mock_pairs_schema.validate.side_effect = lambda df: df
-    mock_prior_portfolio.return_value = pl.DataFrame(
-        schema={
-            **_PRIOR_ALLOCATION_SCHEMA,
-            "quantity": pl.Int64,
-            "notional": pl.Float64,
-        }
-    )
+    mock_prior_portfolio.return_value = pl.DataFrame(schema=_PRIOR_ALLOCATION_SCHEMA)
 
     mock_account = MagicMock()
     mock_account.cash_amount = 10000.0
@@ -783,13 +771,7 @@ def test_run_rebalance_saves_only_opened_rows(
     optimal = _make_optimal_portfolio()
     mock_optimal_portfolio.return_value = optimal
     mock_pairs_schema.validate.side_effect = lambda df: df
-    mock_prior_portfolio.return_value = pl.DataFrame(
-        schema={
-            **_PRIOR_ALLOCATION_SCHEMA,
-            "quantity": pl.Int64,
-            "notional": pl.Float64,
-        }
-    )
+    mock_prior_portfolio.return_value = pl.DataFrame(schema=_PRIOR_ALLOCATION_SCHEMA)
     # AMD (short) is skipped; only NVDA (long) opened successfully.
     mock_execute_open.return_value = (
         [
@@ -901,13 +883,7 @@ def test_run_rebalance_saves_complete_pairs_when_both_legs_succeed(
     optimal = _make_optimal_portfolio()
     mock_optimal_portfolio.return_value = optimal
     mock_pairs_schema.validate.side_effect = lambda df: df
-    mock_prior_portfolio.return_value = pl.DataFrame(
-        schema={
-            **_PRIOR_ALLOCATION_SCHEMA,
-            "quantity": pl.Int64,
-            "notional": pl.Float64,
-        }
-    )
+    mock_prior_portfolio.return_value = pl.DataFrame(schema=_PRIOR_ALLOCATION_SCHEMA)
     # Both legs succeed — the full pair should be saved.
     mock_execute_open.return_value = (
         [

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,4 +1,8 @@
-{pkgs, lib, ...}: let
+{
+  pkgs,
+  lib,
+  ...
+}: let
   awsRegion = "us-east-1";
 
   rawFundProfile = builtins.getEnv "FUND_PROFILE";
@@ -138,6 +142,8 @@ in {
     duckdb
     gh
     git
+    gobang
+    rainfrog
     jq
     llvmPackages.llvm
     markdownlint-cli

--- a/devenv.nix
+++ b/devenv.nix
@@ -10,6 +10,7 @@
 
   bucketSlug = builtins.replaceStrings ["/"] ["-"] fundProfile;
 in {
+  cachix.enable = false;
   dotenv.enable = true;
 
   languages = {

--- a/devenv.nix
+++ b/devenv.nix
@@ -142,7 +142,6 @@ in {
     duckdb
     gh
     git
-    gobang
     rainfrog
     jq
     llvmPackages.llvm

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,4 +1,4 @@
-{pkgs, ...}: let
+{pkgs, lib, ...}: let
   awsRegion = "us-east-1";
 
   rawFundProfile = builtins.getEnv "FUND_PROFILE";

--- a/models/tide/src/tide/data.py
+++ b/models/tide/src/tide/data.py
@@ -674,6 +674,8 @@ class Data:
                     quantile_values * daily_return_standard_deviation
                 ) + daily_return_mean
 
+                unscaled_quantiles = np.sort(unscaled_quantiles)
+
                 row = {
                     "ticker": ticker_str,
                     "timestamp": timestamp,

--- a/tools/bootstrap-machine
+++ b/tools/bootstrap-machine
@@ -46,18 +46,37 @@ step() {
 }
 
 ensure_nix_trusted_user() {
-  local nix_conf="/etc/nix/nix.conf"
   local user
   user="$(whoami)"
-  if [[ -f "$nix_conf" ]] && ! grep -qE "^trusted-users\s*=.*\b${user}\b" "$nix_conf"; then
-    echo "Adding $user to Nix trusted-users..."
-    if grep -qE "^trusted-users\s*=" "$nix_conf"; then
-      sudo sed -i "s/^trusted-users\s*=.*/& $user/" "$nix_conf"
-    else
-      echo "trusted-users = root $user" | sudo tee -a "$nix_conf" >/dev/null
+
+  # Determinate Systems installer manages /etc/nix/nix.conf as read-only;
+  # custom settings must go in /etc/nix/nix.custom.conf.
+  # Fall back to /etc/nix/nix.conf for traditional Nix installs.
+  local custom_conf="/etc/nix/nix.custom.conf"
+  local nix_conf="/etc/nix/nix.conf"
+
+  # Check whether the user is already trusted in either config file
+  for conf in "$custom_conf" "$nix_conf"; do
+    if [[ -f "$conf" ]] && grep -qE "^trusted-users\s*=.*\b${user}\b" "$conf"; then
+      return 0
     fi
-    sudo systemctl restart nix-daemon 2>/dev/null || true
+  done
+
+  echo "Adding $user to Nix trusted-users..."
+
+  # Prefer nix.custom.conf (Determinate installer); fall back to nix.conf
+  local target="$nix_conf"
+  if [[ -L "$nix_conf" ]] || [[ -f "$custom_conf" ]]; then
+    target="$custom_conf"
   fi
+
+  if [[ -f "$target" ]] && grep -qE "^trusted-users\s*=" "$target"; then
+    sudo sed -i "s/^trusted-users\s*=.*/& $user/" "$target"
+  else
+    echo "trusted-users = root $user" | sudo tee -a "$target" >/dev/null
+  fi
+
+  sudo systemctl restart nix-daemon 2>/dev/null || true
 }
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on schema consistency in the portfolio manager, improved configuration handling for Nix environments, and a minor bug fix in the TIDE model code. The most important changes are summarized below:

**Portfolio Manager Schema Consistency and Testing:**
* Added `quantity` (`pl.Int64`) and `notional` (`pl.Float64`) fields to `_PRIOR_ALLOCATION_SCHEMA` in `portfolio_state.py` to ensure consistent schema usage throughout the portfolio manager.
* Updated tests in `test_rebalance.py` to use `_PRIOR_ALLOCATION_SCHEMA` directly, removing redundant manual extensions with `quantity` and `notional` fields. This ensures that test schemas match the production schema and reduces duplication. [[1]](diffhunk://#diff-8886c905935d26e607624d2b64c3f7e5f9562f32dfed0a36d565d38d4106743aL594-R596) [[2]](diffhunk://#diff-8886c905935d26e607624d2b64c3f7e5f9562f32dfed0a36d565d38d4106743aL690-R684) [[3]](diffhunk://#diff-8886c905935d26e607624d2b64c3f7e5f9562f32dfed0a36d565d38d4106743aL786-R774) [[4]](diffhunk://#diff-8886c905935d26e607624d2b64c3f7e5f9562f32dfed0a36d565d38d4106743aL904-R886) [[5]](diffhunk://#diff-8886c905935d26e607624d2b64c3f7e5f9562f32dfed0a36d565d38d4106743aR199-R200)
* Modified the `pl.concat` call in `rebalance.py` to use `how="diagonal"`, improving robustness when concatenating DataFrames with potentially mismatched columns.

**Nix Environment Improvements:**
* Enhanced the `ensure_nix_trusted_user` logic in `bootstrap-machine` to support Determinate Systems' Nix installer by preferring `/etc/nix/nix.custom.conf` and falling back to `/etc/nix/nix.conf`, ensuring the current user is properly added as a trusted user.
* Updated `devenv.nix` to add the `rainfrog` tool, disable Cachix, and improve argument handling for better development environment reproducibility and tool availability. [[1]](diffhunk://#diff-cef540503c67fa4a36d1b9fe95a62f979c4b8b2bc43a6e023e250b7154341afcL1-R5) [[2]](diffhunk://#diff-cef540503c67fa4a36d1b9fe95a62f979c4b8b2bc43a6e023e250b7154341afcR17) [[3]](diffhunk://#diff-cef540503c67fa4a36d1b9fe95a62f979c4b8b2bc43a6e023e250b7154341afcR141)

**Model Bug Fix:**
* Fixed a bug in `tide/data.py` by explicitly sorting `unscaled_quantiles` before further processing, ensuring quantile outputs are always in order.