### PR TITLE
Additional cleanup: profiles, S3 consolidation, unwrap audit, risk constants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-FUND_PROFILE=dev/yourname
+FUND_PROFILE=development/your.name

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argminmax"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.133.0"
+version = "1.134.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237aba2985e3c0a83e199cc7aa9a64a16c599875bc98170f00932f6199f19922"
+checksum = "be06bdfdf00371318253d74776567512d1229d1f3cd5546d27d333c89e013b84"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -501,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.99.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4055e6099b2ec264abdc0d9bbfffce306c1601809275c861594779a0b04b45"
+checksum = "bee2719d4a5e5e147bb9e9b77490df6ece750df1094968aa857b09b618a1881a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -525,10 +534,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.101.0"
+version = "1.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f009ba0284c5d696425fd7b4dcc5b189f5726f4041b7a5794daecb3a68d598"
+checksum = "b30d254992d56ef19f430396e5765b11e0f5bd21a7a557cb12fca1c8c18b9636"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -549,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.104.0"
+version = "1.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
+checksum = "59f4f8065fe615dbed9096458ba98dda6d641553ffd5aedd27e37e65211aca9f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -679,7 +689,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.9",
  "hyper-util",
@@ -853,7 +863,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1014,7 +1024,7 @@ dependencies = [
  "home",
  "http 1.4.1",
  "http-body-util",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-named-pipe",
  "hyper-rustls 0.27.9",
  "hyper-util",
@@ -1199,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1256,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colored"
@@ -2428,9 +2438,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2455,7 +2465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2485,7 +2495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.1",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls 0.23.40",
  "rustls-native-certs",
@@ -2503,7 +2513,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2523,7 +2533,7 @@ dependencies = [
  "futures-util",
  "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2544,7 +2554,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3095,7 +3105,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-util",
  "log",
  "pin-project-lite",
@@ -3237,7 +3247,7 @@ dependencies = [
  "http 1.4.1",
  "http-body-util",
  "humantime",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "itertools",
  "parking_lot",
  "percent-encoding",
@@ -4428,7 +4438,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
@@ -4471,7 +4481,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
@@ -5103,9 +5113,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -6126,9 +6136,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-bidi"
@@ -6229,9 +6239,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6987,18 +6997,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ Production runs on a VM with `devenv --profile apps up` and secretspec for secre
 
 An unordered and non-exhaustive list we work towards:
 
-> Test in production
-> Always roll forward
-> Systems over process
-> No code is good code
-> Never write documentation
-> Be explicit
-> Git is truth
+> Test in production  
+> Always roll forward  
+> Systems over process  
+> No code is good code  
+> Never write documentation  
+> Be explicit  
+> Git is truth  
 
 ### Links
 

--- a/applications/data_manager/src/database.rs
+++ b/applications/data_manager/src/database.rs
@@ -313,48 +313,15 @@ pub async fn populate_equity_details_if_empty(
     Ok(rows_affected)
 }
 
-pub async fn set_data_bucket_guc(pool: &PgPool, bucket_name: &str) -> Result<(), sqlx::Error> {
+pub async fn set_bucket_guc(pool: &PgPool, bucket_name: &str) -> Result<(), sqlx::Error> {
     let alter_statement: String = sqlx::query_scalar(
-        r#"SELECT format('ALTER DATABASE %I SET "app.data_bucket_name" = %L', current_database(), $1)"#,
+        r#"SELECT format('ALTER DATABASE %I SET "app.bucket_name" = %L', current_database(), $1)"#,
     )
     .bind(bucket_name)
     .fetch_one(pool)
     .await?;
     sqlx::query(&alter_statement).execute(pool).await?;
-    info!("Set app.data_bucket_name database GUC to {}", bucket_name);
-    Ok(())
-}
-
-pub async fn set_training_bucket_guc(pool: &PgPool, bucket_name: &str) -> Result<(), sqlx::Error> {
-    let alter_statement: String = sqlx::query_scalar(
-        r#"SELECT format('ALTER DATABASE %I SET "app.training_bucket_name" = %L', current_database(), $1)"#,
-    )
-    .bind(bucket_name)
-    .fetch_one(pool)
-    .await?;
-    sqlx::query(&alter_statement).execute(pool).await?;
-    info!(
-        "Set app.training_bucket_name database GUC to {}",
-        bucket_name
-    );
-    Ok(())
-}
-
-pub async fn set_cold_storage_bucket_guc(
-    pool: &PgPool,
-    bucket_name: &str,
-) -> Result<(), sqlx::Error> {
-    let alter_statement: String = sqlx::query_scalar(
-        r#"SELECT format('ALTER DATABASE %I SET "app.cold_storage_bucket_name" = %L', current_database(), $1)"#,
-    )
-    .bind(bucket_name)
-    .fetch_one(pool)
-    .await?;
-    sqlx::query(&alter_statement).execute(pool).await?;
-    info!(
-        "Set app.cold_storage_bucket_name database GUC to {}",
-        bucket_name
-    );
+    info!("Set app.bucket_name database GUC to {}", bucket_name);
     Ok(())
 }
 
@@ -512,7 +479,7 @@ mod tests {
     }
 
     #[test]
-    fn test_set_data_bucket_guc_compiles() {
+    fn test_set_bucket_guc_compiles() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -520,35 +487,7 @@ mod tests {
         rt.block_on(async {
             let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
                 .expect("lazy pool creation should not fail");
-            let result = set_data_bucket_guc(&pool, "test-bucket").await;
-            assert!(result.is_err());
-        });
-    }
-
-    #[test]
-    fn test_set_training_bucket_guc_compiles() {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
-            let result = set_training_bucket_guc(&pool, "test-training-bucket").await;
-            assert!(result.is_err());
-        });
-    }
-
-    #[test]
-    fn test_set_cold_storage_bucket_guc_compiles() {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
-            let result = set_cold_storage_bucket_guc(&pool, "test-cold-storage-bucket").await;
+            let result = set_bucket_guc(&pool, "test-bucket").await;
             assert!(result.is_err());
         });
     }

--- a/applications/data_manager/src/database.rs
+++ b/applications/data_manager/src/database.rs
@@ -56,15 +56,25 @@ pub async fn insert_equity_bars(pool: &PgPool, bars: &[EquityBar]) -> Result<u64
         query_builder.push_values(
             chunk.iter().zip(transaction_values.iter()),
             |mut builder, (bar, transactions)| {
-                let time = DateTime::<Utc>::from_timestamp_millis(bar.timestamp).unwrap();
+                let time = DateTime::<Utc>::from_timestamp_millis(bar.timestamp)
+                    .expect("Alpaca API timestamp must be a valid millisecond epoch value");
                 builder
                     .push_bind(&bar.ticker)
                     .push_bind(time)
-                    .push_bind(bar.open_price.unwrap())
-                    .push_bind(bar.high_price.unwrap())
-                    .push_bind(bar.low_price.unwrap())
-                    .push_bind(bar.close_price.unwrap())
-                    .push_bind(bar.volume.unwrap())
+                    .push_bind(
+                        bar.open_price
+                            .expect("equity bar open_price must be present"),
+                    )
+                    .push_bind(
+                        bar.high_price
+                            .expect("equity bar high_price must be present"),
+                    )
+                    .push_bind(bar.low_price.expect("equity bar low_price must be present"))
+                    .push_bind(
+                        bar.close_price
+                            .expect("equity bar close_price must be present"),
+                    )
+                    .push_bind(bar.volume.expect("equity bar volume must be present"))
                     .push_bind(bar.volume_weighted_average_price)
                     .push_bind(*transactions);
             },

--- a/applications/data_manager/src/equity_quotes.rs
+++ b/applications/data_manager/src/equity_quotes.rs
@@ -65,7 +65,7 @@ async fn refresh_active_symbols(state: &State, pool: &sqlx::PgPool) {
 }
 
 async fn run_quote_stream(state: &State) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let pool = state.pool.as_ref().unwrap();
+    let pool = state.pool.as_ref().ok_or("database pool not initialized")?;
 
     refresh_active_symbols(state, pool).await;
 

--- a/applications/data_manager/src/main.rs
+++ b/applications/data_manager/src/main.rs
@@ -48,12 +48,7 @@ mod tests {
         // 1. Test is marked with #[serial] to prevent concurrent execution
         // 2. Env vars are set synchronously before spawning async tasks
         unsafe {
-            std::env::set_var("AWS_S3_DATA_BUCKET_NAME", "test-bucket");
-            std::env::set_var("AWS_S3_TRAINING_BUCKET_NAME", "test-training-bucket");
-            std::env::set_var(
-                "AWS_S3_COLD_STORAGE_BUCKET_NAME",
-                "test-cold-storage-bucket",
-            );
+            std::env::set_var("AWS_S3_BUCKET_NAME", "test-bucket");
             std::env::set_var("MASSIVE_BASE_URL", "http://test");
             std::env::set_var("MASSIVE_API_KEY", "test-key");
             std::env::set_var("ALPACA_KEY_ID", "test-key-id");
@@ -67,9 +62,7 @@ mod tests {
         assert_eq!(exit_code, 1);
 
         unsafe {
-            std::env::remove_var("AWS_S3_DATA_BUCKET_NAME");
-            std::env::remove_var("AWS_S3_TRAINING_BUCKET_NAME");
-            std::env::remove_var("AWS_S3_COLD_STORAGE_BUCKET_NAME");
+            std::env::remove_var("AWS_S3_BUCKET_NAME");
             std::env::remove_var("MASSIVE_BASE_URL");
             std::env::remove_var("MASSIVE_API_KEY");
             std::env::remove_var("ALPACA_KEY_ID");

--- a/applications/data_manager/src/startup.rs
+++ b/applications/data_manager/src/startup.rs
@@ -306,13 +306,7 @@ mod tests {
         let _secret_key_guard =
             EnvironmentVariableGuard::set("AWS_SECRET_ACCESS_KEY", "test-secret-key");
         let _metadata_guard = EnvironmentVariableGuard::set("AWS_EC2_METADATA_DISABLED", "true");
-        let _bucket_guard = EnvironmentVariableGuard::set("AWS_S3_DATA_BUCKET_NAME", "test-bucket");
-        let _training_bucket_guard =
-            EnvironmentVariableGuard::set("AWS_S3_TRAINING_BUCKET_NAME", "test-training-bucket");
-        let _cold_storage_bucket_guard = EnvironmentVariableGuard::set(
-            "AWS_S3_COLD_STORAGE_BUCKET_NAME",
-            "test-cold-storage-bucket",
-        );
+        let _bucket_guard = EnvironmentVariableGuard::set("AWS_S3_BUCKET_NAME", "test-bucket");
         let _massive_base_guard =
             EnvironmentVariableGuard::set("MASSIVE_BASE_URL", "http://127.0.0.1:1");
         let _massive_key_guard = EnvironmentVariableGuard::set("MASSIVE_API_KEY", "test-api-key");

--- a/applications/data_manager/src/state.rs
+++ b/applications/data_manager/src/state.rs
@@ -9,7 +9,7 @@ use sqlx::PgPool;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
-use crate::database::{set_cold_storage_bucket_guc, set_data_bucket_guc, set_training_bucket_guc};
+use crate::database::set_bucket_guc;
 
 #[derive(Clone)]
 pub struct MassiveSecrets {
@@ -23,8 +23,6 @@ pub struct State {
     pub massive: MassiveSecrets,
     pub s3_client: S3Client,
     pub bucket_name: String,
-    pub training_bucket_name: String,
-    pub cold_storage_bucket_name: String,
     pub last_s3_ok_epoch: Arc<AtomicU64>,
     pub last_sync_epoch: Arc<AtomicU64>,
     pub pool: Option<PgPool>,
@@ -56,17 +54,9 @@ impl State {
 
         let s3_client = S3Client::new(&config);
 
-        let bucket_name = std::env::var("AWS_S3_DATA_BUCKET_NAME")
-            .expect("AWS_S3_DATA_BUCKET_NAME environment variable must be set");
-        info!("Using S3 data bucket: {}", bucket_name);
-
-        let training_bucket_name = std::env::var("AWS_S3_TRAINING_BUCKET_NAME")
-            .expect("AWS_S3_TRAINING_BUCKET_NAME environment variable must be set");
-        info!("Using S3 training bucket: {}", training_bucket_name);
-
-        let cold_storage_bucket_name = std::env::var("AWS_S3_COLD_STORAGE_BUCKET_NAME")
-            .expect("AWS_S3_COLD_STORAGE_BUCKET_NAME environment variable must be set");
-        info!("Using S3 cold storage bucket: {}", cold_storage_bucket_name);
+        let bucket_name = std::env::var("AWS_S3_BUCKET_NAME")
+            .expect("AWS_S3_BUCKET_NAME environment variable must be set");
+        info!("Using S3 bucket: {}", bucket_name);
 
         let massive_base_url = std::env::var("MASSIVE_BASE_URL")
             .expect("MASSIVE_BASE_URL environment variable must be set");
@@ -86,24 +76,8 @@ impl State {
                 match PgPool::connect(&database_url).await {
                     Ok(pool) => {
                         info!("Connected to PostgreSQL");
-                        if let Err(error) = set_data_bucket_guc(&pool, &bucket_name).await {
-                            warn!("Failed to set app.data_bucket_name database GUC: {}", error);
-                        }
-                        if let Err(error) =
-                            set_training_bucket_guc(&pool, &training_bucket_name).await
-                        {
-                            warn!(
-                                "Failed to set app.training_bucket_name database GUC: {}",
-                                error
-                            );
-                        }
-                        if let Err(error) =
-                            set_cold_storage_bucket_guc(&pool, &cold_storage_bucket_name).await
-                        {
-                            warn!(
-                                "Failed to set app.cold_storage_bucket_name database GUC: {}",
-                                error
-                            );
+                        if let Err(error) = set_bucket_guc(&pool, &bucket_name).await {
+                            warn!("Failed to set app.bucket_name database GUC: {}", error);
                         }
                         (Some(pool), true)
                     }
@@ -129,8 +103,6 @@ impl State {
             },
             s3_client,
             bucket_name,
-            training_bucket_name,
-            cold_storage_bucket_name,
             last_s3_ok_epoch: Arc::new(AtomicU64::new(0)),
             last_sync_epoch: Arc::new(AtomicU64::new(0)),
             pool,
@@ -153,8 +125,6 @@ impl State {
             massive,
             s3_client,
             bucket_name,
-            training_bucket_name: String::new(),
-            cold_storage_bucket_name: String::new(),
             last_s3_ok_epoch: Arc::new(AtomicU64::new(0)),
             last_sync_epoch: Arc::new(AtomicU64::new(0)),
             pool: None,

--- a/applications/data_manager/src/storage.rs
+++ b/applications/data_manager/src/storage.rs
@@ -8,7 +8,7 @@ use polars::prelude::*;
 use std::io::Cursor;
 use tracing::{debug, error, info, warn};
 
-const EQUITY_DETAILS_KEY: &str = "equity/details/details.csv";
+const EQUITY_DETAILS_KEY: &str = "data/equity/details/details.csv";
 pub const DUCKDB_CONFIG_VALUE_MAX_LENGTH: usize = 4096;
 
 pub fn is_valid_ticker(ticker: &str) -> bool {
@@ -184,7 +184,7 @@ pub async fn query_equity_bars_parquet_from_s3(
     );
 
     // Use glob pattern with hive partitioning to handle missing files gracefully
-    let s3_glob = format!("s3://{}/equity/bars/daily/**/*.parquet", state.bucket_name);
+    let s3_glob = format!("s3://{}/data/equity/bars/**/*.parquet", state.bucket_name);
 
     info!("Using S3 glob pattern: {}", s3_glob);
 

--- a/applications/data_manager/tests/test_database.rs
+++ b/applications/data_manager/tests/test_database.rs
@@ -3,7 +3,7 @@ mod common;
 use data_manager::data::EquityBar;
 use data_manager::database::{
     claim_pending_job, complete_job, fail_job, insert_equity_bars, query_recent_equity_bars,
-    set_data_bucket_guc,
+    set_bucket_guc,
 };
 use serial_test::serial;
 use sqlx::PgPool;
@@ -311,10 +311,10 @@ async fn test_complete_job() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
-async fn test_set_data_bucket_guc_persists() {
+async fn test_set_bucket_guc_persists() {
     let pool = get_pg_pool().await;
 
-    set_data_bucket_guc(&pool, "fund-test-data").await.unwrap();
+    set_bucket_guc(&pool, "fund-test-data").await.unwrap();
 
     // ALTER DATABASE persists the GUC in pg_db_role_setting for all future connections.
     // Verify the setting appears there with the expected value.
@@ -328,11 +328,10 @@ async fn test_set_data_bucket_guc_persists() {
     .unwrap();
 
     assert!(
-        settings
-            .iter()
-            .any(|setting| setting.contains("app.data_bucket_name")
-                && setting.contains("fund-test-data")),
-        "Expected app.data_bucket_name GUC to be persisted, got: {:?}",
+        settings.iter().any(
+            |setting| setting.contains("app.bucket_name") && setting.contains("fund-test-data")
+        ),
+        "Expected app.bucket_name GUC to be persisted, got: {:?}",
         settings
     );
 }

--- a/applications/data_manager/tests/test_handlers.rs
+++ b/applications/data_manager/tests/test_handlers.rs
@@ -62,7 +62,7 @@ async fn test_equity_details_get_returns_csv_content() {
 
     put_test_object(
         &s3,
-        "equity/details/details.csv",
+        "data/equity/details/details.csv",
         b"ticker,sector,industry\nAAPL,Technology,Consumer Electronics\n".to_vec(),
     )
     .await;

--- a/applications/data_manager/tests/test_state_and_health.rs
+++ b/applications/data_manager/tests/test_state_and_health.rs
@@ -76,9 +76,9 @@ async fn test_state_new_sets_all_fields() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[serial]
-#[should_panic(expected = "AWS_S3_DATA_BUCKET_NAME environment variable must be set")]
+#[should_panic(expected = "AWS_S3_BUCKET_NAME environment variable must be set")]
 async fn test_state_from_env_panics_when_required_variables_are_missing() {
-    let _aws_bucket_guard = EnvironmentVariableGuard::remove("AWS_S3_DATA_BUCKET_NAME");
+    let _aws_bucket_guard = EnvironmentVariableGuard::remove("AWS_S3_BUCKET_NAME");
     let _massive_base_guard = EnvironmentVariableGuard::remove("MASSIVE_BASE_URL");
     let _massive_key_guard = EnvironmentVariableGuard::remove("MASSIVE_API_KEY");
     let _region_guard = EnvironmentVariableGuard::set("AWS_REGION", "us-east-1");
@@ -90,7 +90,7 @@ async fn test_state_from_env_panics_when_required_variables_are_missing() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[serial]
 async fn test_state_from_env_uses_environment_values() {
-    let _aws_bucket_guard = EnvironmentVariableGuard::set("AWS_S3_DATA_BUCKET_NAME", "env-bucket");
+    let _aws_bucket_guard = EnvironmentVariableGuard::set("AWS_S3_BUCKET_NAME", "env-bucket");
     let _massive_base_guard =
         EnvironmentVariableGuard::set("MASSIVE_BASE_URL", "https://massive.example");
     let _massive_key_guard = EnvironmentVariableGuard::set("MASSIVE_API_KEY", "env-api-key");

--- a/applications/data_manager/tests/test_storage.rs
+++ b/applications/data_manager/tests/test_storage.rs
@@ -59,7 +59,7 @@ async fn seed_equity_bars_parquet(
         .finish(&mut dataframe)
         .unwrap();
     let key = format!(
-        "equity/bars/daily/year={}/month={}/day={}/data.parquet",
+        "data/equity/bars/year={}/month={}/day={}/data.parquet",
         timestamp.format("%Y"),
         timestamp.format("%m"),
         timestamp.format("%d")
@@ -185,7 +185,7 @@ async fn test_read_equity_details_dataframe_from_s3_success() {
 
     put_test_object(
         &s3,
-        "equity/details/details.csv",
+        "data/equity/details/details.csv",
         b"ticker,sector,industry\nAAPL,Technology,Consumer Electronics\n".to_vec(),
     )
     .await;
@@ -205,7 +205,12 @@ async fn test_read_equity_details_dataframe_from_s3_returns_error_for_invalid_ut
     let (endpoint, s3, _env_guard) = setup_test_bucket().await;
     let state = create_state(&endpoint).await;
 
-    put_test_object(&s3, "equity/details/details.csv", vec![0xff, 0xfe, 0xfd]).await;
+    put_test_object(
+        &s3,
+        "data/equity/details/details.csv",
+        vec![0xff, 0xfe, 0xfd],
+    )
+    .await;
 
     let result = read_equity_details_dataframe_from_s3(&state).await;
 

--- a/applications/ensemble_manager/src/ensemble_manager/server.py
+++ b/applications/ensemble_manager/src/ensemble_manager/server.py
@@ -78,8 +78,6 @@ structlog.contextvars.bind_contextvars(
 
 logger = structlog.get_logger()
 
-AWS_S3_BUCKET_NAME = os.getenv("AWS_S3_BUCKET_NAME", "")
-
 _swap_lock = threading.Lock()
 _CLEANUP_DELAY_SECONDS = 120
 _background_tasks: set[asyncio.Task] = set()
@@ -821,7 +819,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: PLR0915
         app.state.current_artifact_key = None
         logger.info("Loading model from local", directory=model_directory)
 
-    data_bucket = AWS_S3_BUCKET_NAME
+    data_bucket = os.environ.get("AWS_S3_BUCKET_NAME", "")
     if data_bucket:
         app.state.s3_data_client = boto3.client("s3")
         app.state.data_bucket_name = data_bucket

--- a/applications/ensemble_manager/src/ensemble_manager/server.py
+++ b/applications/ensemble_manager/src/ensemble_manager/server.py
@@ -78,7 +78,7 @@ structlog.contextvars.bind_contextvars(
 
 logger = structlog.get_logger()
 
-AWS_S3_DATA_BUCKET_NAME = os.getenv("AWS_S3_DATA_BUCKET_NAME", "")
+AWS_S3_BUCKET_NAME = os.getenv("AWS_S3_BUCKET_NAME", "")
 
 _swap_lock = threading.Lock()
 _CLEANUP_DELAY_SECONDS = 120
@@ -270,7 +270,7 @@ async def _fetch_equity_details(s3_client: "S3Client", bucket: str) -> pl.DataFr
     response = await asyncio.to_thread(
         s3_client.get_object,
         Bucket=bucket,
-        Key="equity/details/details.csv",
+        Key="data/equity/details/details.csv",
     )
     csv_bytes: bytes = response["Body"].read()
     equity_details_data = pl.read_csv(io.BytesIO(csv_bytes))
@@ -704,8 +704,8 @@ async def _sync_run_metadata(
 
 async def _artifact_polling_task(app: FastAPI) -> None:
     """Background task that polls S3 for new model artifacts."""
-    bucket = os.environ.get("AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME")
-    artifact_path = os.environ.get("AWS_S3_MODEL_ARTIFACT_PATH", "artifacts/tide/")
+    bucket = os.environ.get("AWS_S3_BUCKET_NAME")
+    artifact_path = os.environ.get("AWS_S3_MODEL_ARTIFACT_PATH", "models/tide/")
 
     if not bucket:
         logger.info("Artifact polling disabled, no bucket configured")
@@ -787,8 +787,8 @@ async def _artifact_polling_task(app: FastAPI) -> None:
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: PLR0915
     """Load model artifacts from S3 at startup."""
 
-    bucket = os.environ.get("AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME")
-    artifact_path = os.environ.get("AWS_S3_MODEL_ARTIFACT_PATH", "artifacts/tide/")
+    bucket = os.environ.get("AWS_S3_BUCKET_NAME")
+    artifact_path = os.environ.get("AWS_S3_MODEL_ARTIFACT_PATH", "models/tide/")
     model_directory = "."
     s3_client: S3Client | None = None
 
@@ -821,7 +821,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: PLR0915
         app.state.current_artifact_key = None
         logger.info("Loading model from local", directory=model_directory)
 
-    data_bucket = AWS_S3_DATA_BUCKET_NAME
+    data_bucket = AWS_S3_BUCKET_NAME
     if data_bucket:
         app.state.s3_data_client = boto3.client("s3")
         app.state.data_bucket_name = data_bucket

--- a/applications/ensemble_manager/tests/test_server.py
+++ b/applications/ensemble_manager/tests/test_server.py
@@ -330,7 +330,7 @@ def test_artifact_polling_detects_new_key_and_swaps() -> None:
         with (
             patch.dict(
                 "os.environ",
-                {"AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME": "bucket"},
+                {"AWS_S3_BUCKET_NAME": "bucket"},
             ),
             patch("ensemble_manager.server.boto3.client"),
             patch(
@@ -368,7 +368,7 @@ def test_artifact_polling_same_key_no_swap() -> None:
         with (
             patch.dict(
                 "os.environ",
-                {"AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME": "bucket"},
+                {"AWS_S3_BUCKET_NAME": "bucket"},
             ),
             patch("ensemble_manager.server.boto3.client"),
             patch(
@@ -400,7 +400,7 @@ def test_artifact_polling_download_failure_cleans_up() -> None:
         with (
             patch.dict(
                 "os.environ",
-                {"AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME": "bucket"},
+                {"AWS_S3_BUCKET_NAME": "bucket"},
             ),
             patch("ensemble_manager.server.boto3.client"),
             patch(
@@ -439,7 +439,7 @@ def test_artifact_polling_transient_s3_error_continues() -> None:
         with (
             patch.dict(
                 "os.environ",
-                {"AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME": "bucket"},
+                {"AWS_S3_BUCKET_NAME": "bucket"},
             ),
             patch("ensemble_manager.server.boto3.client"),
             patch(
@@ -470,8 +470,8 @@ def test_artifact_polling_no_bucket_returns_immediately() -> None:
         app = MagicMock(spec=FastAPI)
 
         with patch.dict("os.environ", {}, clear=False):
-            if "AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME" in os.environ:
-                del os.environ["AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME"]
+            if "AWS_S3_BUCKET_NAME" in os.environ:
+                del os.environ["AWS_S3_BUCKET_NAME"]
             await _artifact_polling_task(app)
 
     asyncio.run(_run())

--- a/applications/portfolio_manager/src/portfolio_manager/risk_management.py
+++ b/applications/portfolio_manager/src/portfolio_manager/risk_management.py
@@ -11,9 +11,16 @@ from .exceptions import InsufficientPairsError
 
 logger = structlog.get_logger()
 
+# Minimum number of pairs required to construct a diversified portfolio.
 REQUIRED_PAIRS = 10
+# Z-score magnitude below which a pair is held without action (mean-reversion zone).
 Z_SCORE_HOLD_THRESHOLD = 0.5
+# Z-score magnitude at which a pair is force-closed regardless of direction
+# (spread has diverged beyond the expected mean-reversion window).
 Z_SCORE_STOP_LOSS = 4.0
+# Relative bounds applied to each pair's weight by the beta-neutral SLSQP optimizer.
+# A pair can be weighted as low as 0.5x or as high as 2.0x its equal-allocation share,
+# keeping the optimizer anchored near volatility-parity while allowing beta reduction.
 BETA_WEIGHT_LOWER_BOUND = 0.5
 BETA_WEIGHT_UPPER_BOUND = 2.0
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -108,11 +108,8 @@ in {
     # Active profile
     FUND_PROFILE = fundProfile;
 
-    # S3 bucket names derived from FUND_PROFILE
-    AWS_S3_DATA_BUCKET_NAME = "fund-${bucketSlug}-data";
-    AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME = "fund-${bucketSlug}-model-artifacts";
-    AWS_S3_TRAINING_BUCKET_NAME = "fund-${bucketSlug}-training";
-    AWS_S3_COLD_STORAGE_BUCKET_NAME = "fund-${bucketSlug}-cold-storage";
+    # S3 bucket name derived from FUND_PROFILE
+    AWS_S3_BUCKET_NAME = "oscm-fund-${bucketSlug}";
 
     # PostgreSQL
     DATABASE_URL = "postgresql://localhost:5432/fund";
@@ -196,8 +193,7 @@ in {
     set -euo pipefail
     unset AWS_ENDPOINT_URL
     echo "=== Fund S3 Buckets (profile: $FUND_PROFILE) ==="
-    echo "  Data:      $AWS_S3_DATA_BUCKET_NAME"
-    echo "  Artifacts: $AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME"
+    echo "  Bucket: $AWS_S3_BUCKET_NAME"
     echo ""
     buckets=$(aws s3 ls)
     printf '%s\n' "$buckets" | grep fund || echo "No fund buckets found"
@@ -628,9 +624,7 @@ in {
     {
       echo "Fund development environment (profile: $FUND_PROFILE)"
       echo ""
-      echo "  Buckets:"
-      echo "    Data:      $AWS_S3_DATA_BUCKET_NAME"
-      echo "    Artifacts: $AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME"
+      echo "  Bucket: $AWS_S3_BUCKET_NAME"
       echo ""
       echo "  Profiles:"
       echo "    devenv --profile apps up      Start application services"

--- a/devenv.nix
+++ b/devenv.nix
@@ -10,9 +10,9 @@
     if rawFundProfile == ""
     then "development"
     else rawFundProfile;
-  isDeployed = builtins.elem fundProfile ["production" "paper"];
+  isDeployed = fundProfile == "production" || lib.hasPrefix "development/" fundProfile;
 
-  bucketSlug = builtins.replaceStrings ["/"] ["-"] fundProfile;
+  bucketSlug = builtins.replaceStrings ["/" "."] ["-" "-"] fundProfile;
 in {
   cachix.enable = false;
   dotenv.enable = true;

--- a/models/tide/src/tide/register_blocks.py
+++ b/models/tide/src/tide/register_blocks.py
@@ -1,8 +1,8 @@
 """Register Prefect S3Bucket blocks from environment variables.
 
-Reads AWS_S3_DATA_BUCKET_NAME, AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME, and
-AWS_REGION from the environment and creates (or overwrites) the two blocks
-expected by the training workflow.
+Reads AWS_S3_BUCKET_NAME and AWS_REGION from the environment and creates
+(or overwrites) the two blocks expected by the training workflow. Both blocks
+point to the same bucket; path prefixes distinguish data from model artifacts.
 """
 
 import os
@@ -16,33 +16,29 @@ logger = structlog.get_logger()
 
 
 def register_blocks() -> None:
-    data_bucket = os.environ.get("AWS_S3_DATA_BUCKET_NAME", "")
-    artifact_bucket = os.environ.get("AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME", "")
+    bucket = os.environ.get("AWS_S3_BUCKET_NAME", "")
     region = os.environ.get("AWS_REGION", "us-east-1")
 
-    if not data_bucket or not artifact_bucket:
-        message = (
-            "AWS_S3_DATA_BUCKET_NAME and AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME must be set"
-        )
+    if not bucket:
+        message = "AWS_S3_BUCKET_NAME must be set"
         logger.error(message)
         sys.exit(1)
 
     credentials = AwsCredentials(region_name=region)
 
     S3Bucket(
-        bucket_name=data_bucket,
+        bucket_name=bucket,
         credentials=credentials,
     ).save("data-bucket", overwrite=True)
 
     S3Bucket(
-        bucket_name=artifact_bucket,
+        bucket_name=bucket,
         credentials=credentials,
     ).save("artifact-bucket", overwrite=True)
 
     logger.info(
         "Registered Prefect S3 blocks",
-        data_bucket=data_bucket,
-        artifact_bucket=artifact_bucket,
+        bucket=bucket,
     )
 
 

--- a/models/tide/src/tide/tasks.py
+++ b/models/tide/src/tide/tasks.py
@@ -53,7 +53,7 @@ def read_equity_bars_from_s3(
         month = current_date.strftime("%m")
         day = current_date.strftime("%d")
 
-        key = f"equity/bars/daily/year={year}/month={month}/day={day}/data.parquet"
+        key = f"data/equity/bars/year={year}/month={month}/day={day}/data.parquet"
 
         try:
             response = s3_client.get_object(Bucket=bucket_name, Key=key)
@@ -100,7 +100,7 @@ def read_categories_from_s3(
     bucket_name: str,
 ) -> pl.DataFrame:
     """Read categories CSV from S3."""
-    key = "equity/details/details.csv"
+    key = "data/equity/details/details.csv"
 
     logger.info("Reading categories from S3", bucket=bucket_name, key=key)
 
@@ -364,8 +364,8 @@ def write_evaluation_results(
     results: dict[str, float],
     run_id: str,
 ) -> None:
-    """Write evaluation results as JSON to artifacts/tide/{run_id}/evaluation.json."""
-    key = f"artifacts/tide/{run_id}/evaluation.json"
+    """Write evaluation results as JSON to models/tide/{run_id}/evaluation.json."""
+    key = f"models/tide/{run_id}/evaluation.json"
 
     logger.info(
         "Writing evaluation results",

--- a/models/tide/src/tide/workflow.py
+++ b/models/tide/src/tide/workflow.py
@@ -62,7 +62,7 @@ def prepare_data(
         raise ValueError(message) from err
     s3_client = data_block.credentials.get_boto3_session().client("s3")
 
-    output_key = f"data/tide/{artifact_timestamp}/filtered_data.parquet"
+    output_key = f"models/tide/{artifact_timestamp}/filtered_data.parquet"
 
     logger.info(
         "Preparing training data",
@@ -145,7 +145,7 @@ def train_tide_model(
                 checkpoint_directory=checkpoint_directory,
             )
 
-        artifact_folder = f"artifacts/tide/{artifact_timestamp}"
+        artifact_folder = f"models/tide/{artifact_timestamp}"
         artifact_key = f"{artifact_folder}/output/model.tar.gz"
         metadata_key = f"{artifact_folder}/run_metadata.json"
 
@@ -275,7 +275,7 @@ def evaluate_tide_model(
     prior_evaluations = fetch_prior_evaluations(
         s3_client=s3_client,
         bucket_name=artifacts_bucket,
-        artifact_prefix="artifacts/tide/",
+        artifact_prefix="models/tide/",
         run_count=7,
     )
 

--- a/models/tide/tests/test_register_blocks.py
+++ b/models/tide/tests/test_register_blocks.py
@@ -13,8 +13,7 @@ def test_register_blocks_creates_both_buckets(
     mock_s3_bucket_cls: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("AWS_S3_DATA_BUCKET_NAME", "my-data")
-    monkeypatch.setenv("AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME", "my-artifacts")
+    monkeypatch.setenv("AWS_S3_BUCKET_NAME", "my-bucket")
     monkeypatch.setenv("AWS_REGION", "us-west-2")
 
     mock_creds = MagicMock()
@@ -27,10 +26,7 @@ def test_register_blocks_creates_both_buckets(
 
     mock_credentials_cls.assert_called_once_with(region_name="us-west-2")
     assert mock_s3_bucket_cls.call_count == EXPECTED_BUCKET_COUNT
-    mock_s3_bucket_cls.assert_any_call(bucket_name="my-data", credentials=mock_creds)
-    mock_s3_bucket_cls.assert_any_call(
-        bucket_name="my-artifacts", credentials=mock_creds
-    )
+    mock_s3_bucket_cls.assert_any_call(bucket_name="my-bucket", credentials=mock_creds)
     assert mock_block.save.call_count == EXPECTED_BUCKET_COUNT
     mock_block.save.assert_any_call("data-bucket", overwrite=True)
     mock_block.save.assert_any_call("artifact-bucket", overwrite=True)
@@ -43,8 +39,7 @@ def test_register_blocks_defaults_region(
     mock_s3_bucket_cls: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("AWS_S3_DATA_BUCKET_NAME", "data")
-    monkeypatch.setenv("AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME", "artifacts")
+    monkeypatch.setenv("AWS_S3_BUCKET_NAME", "my-bucket")
     monkeypatch.delenv("AWS_REGION", raising=False)
 
     mock_s3_bucket_cls.return_value = MagicMock()
@@ -54,31 +49,10 @@ def test_register_blocks_defaults_region(
     mock_credentials_cls.assert_called_once_with(region_name="us-east-1")
 
 
-def test_register_blocks_exits_when_data_bucket_missing(
+def test_register_blocks_exits_when_bucket_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("AWS_S3_DATA_BUCKET_NAME", raising=False)
-    monkeypatch.setenv("AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME", "artifacts")
-
-    with pytest.raises(SystemExit, match="1"):
-        register_blocks()
-
-
-def test_register_blocks_exits_when_artifact_bucket_missing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("AWS_S3_DATA_BUCKET_NAME", "data")
-    monkeypatch.delenv("AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME", raising=False)
-
-    with pytest.raises(SystemExit, match="1"):
-        register_blocks()
-
-
-def test_register_blocks_exits_when_both_missing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("AWS_S3_DATA_BUCKET_NAME", raising=False)
-    monkeypatch.delenv("AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME", raising=False)
+    monkeypatch.delenv("AWS_S3_BUCKET_NAME", raising=False)
 
     with pytest.raises(SystemExit, match="1"):
         register_blocks()

--- a/models/tide/tests/test_tasks.py
+++ b/models/tide/tests/test_tasks.py
@@ -237,7 +237,7 @@ def test_read_categories_from_s3_returns_dataframe() -> None:
     assert "AAPL" in result["ticker"].to_list()
     mock_s3_client.get_object.assert_called_once_with(
         Bucket="test-bucket",
-        Key="equity/details/details.csv",
+        Key="data/equity/details/details.csv",
     )
 
 

--- a/models/tide/tests/test_workflow.py
+++ b/models/tide/tests/test_workflow.py
@@ -67,7 +67,7 @@ def test_prepare_data_uses_versioned_output_key(
     call_kwargs = mock_prepare.call_args.kwargs
     assert (
         call_kwargs["output_key"]
-        == f"data/tide/{artifact_timestamp}/filtered_data.parquet"
+        == f"models/tide/{artifact_timestamp}/filtered_data.parquet"
     )
 
 
@@ -117,7 +117,7 @@ def test_train_tide_model_downloads_trains_uploads(
         )
 
     assert result.startswith(
-        "s3://artifacts-bucket/artifacts/tide/2024-01-31-00-00-00-000/"
+        "s3://artifacts-bucket/models/tide/2024-01-31-00-00-00-000/"
     )
     mock_s3.get_object.assert_called_once()
     expected_put_object_calls = 2  # model.tar.gz + run_metadata.json

--- a/schema.sql
+++ b/schema.sql
@@ -66,13 +66,13 @@ CREATE INDEX IF NOT EXISTS idx_equity_quotes_ticker_timestamp ON equity_quotes (
 SELECT add_retention_policy('equity_quotes', INTERVAL '1 day', if_not_exists => TRUE);
 
 -- export_equity_quotes: exports the current trading day's quotes to S3 Parquet then purges them.
--- Reads the S3 bucket name from the app.data_bucket_name database GUC (set by data-manager on startup).
+-- Reads the S3 bucket name from the app.bucket_name database GUC (set by data-manager on startup).
 -- pg_parquet must be installed and S3 credentials must be available to the PostgreSQL process.
 -- Returns early with a WARNING if pg_parquet is not installed.
 CREATE OR REPLACE FUNCTION export_equity_quotes() RETURNS void AS $$
 DECLARE
     export_date DATE := CURRENT_DATE;
-    bucket_name  TEXT := current_setting('app.data_bucket_name', true);
+    bucket_name  TEXT := current_setting('app.bucket_name', true);
     s3_path      TEXT;
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_parquet') THEN
@@ -80,10 +80,10 @@ BEGIN
         RETURN;
     END IF;
     IF bucket_name IS NULL OR bucket_name = '' THEN
-        RAISE EXCEPTION 'app.data_bucket_name GUC is not set; cannot export equity quotes';
+        RAISE EXCEPTION 'app.bucket_name GUC is not set; cannot export equity quotes';
     END IF;
     s3_path := format(
-        's3://%s/equity/quotes/daily/year=%s/month=%s/day=%s/data.parquet',
+        's3://%s/data/equity/quotes/year=%s/month=%s/day=%s/data.parquet',
         bucket_name,
         to_char(export_date, 'YYYY'),
         to_char(export_date, 'MM'),
@@ -287,7 +287,7 @@ CREATE TABLE IF NOT EXISTS equity_trades (
 
 -- equity_details: Ticker metadata (sector, industry) seeded from S3 on first startup.
 -- Ongoing updates are owned by data-manager when equity details are refreshed.
--- Source: equity/details/details.csv in the data S3 bucket.
+-- Source: data/equity/details/details.csv in the S3 bucket.
 CREATE TABLE IF NOT EXISTS equity_details (
     ticker    TEXT NOT NULL PRIMARY KEY,
     sector    TEXT NOT NULL DEFAULT 'NOT AVAILABLE',
@@ -504,12 +504,12 @@ END;
 $do$;
 
 -- export_equity_bars: exports equity_bars for the past 120 days to S3 Parquet for model training.
--- Reads the training S3 bucket name from the app.training_bucket_name GUC (set by data-manager on startup).
+-- Reads the S3 bucket name from the app.bucket_name GUC (set by data-manager on startup).
 -- Returns early with a WARNING if pg_parquet is not installed.
 CREATE OR REPLACE FUNCTION export_equity_bars() RETURNS void AS $$
 DECLARE
     export_date  DATE := CURRENT_DATE;
-    bucket_name  TEXT := current_setting('app.training_bucket_name', true);
+    bucket_name  TEXT := current_setting('app.bucket_name', true);
     s3_path      TEXT;
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_parquet') THEN
@@ -517,10 +517,10 @@ BEGIN
         RETURN;
     END IF;
     IF bucket_name IS NULL OR bucket_name = '' THEN
-        RAISE EXCEPTION 'app.training_bucket_name GUC is not set; cannot export equity bars';
+        RAISE EXCEPTION 'app.bucket_name GUC is not set; cannot export equity bars';
     END IF;
     s3_path := format(
-        's3://%s/equity/bars/daily/year=%s/month=%s/day=%s/data.parquet',
+        's3://%s/data/equity/bars/year=%s/month=%s/day=%s/data.parquet',
         bucket_name,
         to_char(export_date, 'YYYY'),
         to_char(export_date, 'MM'),
@@ -560,38 +560,45 @@ END;
 $do$;
 
 -- export_trading_history: exports irreplaceable trading tables to S3 Parquet cold storage.
--- Reads the cold storage bucket name from the app.cold_storage_bucket_name GUC (set by data-manager on startup).
+-- Reads the S3 bucket name from the app.bucket_name GUC (set by data-manager on startup).
 -- Returns early with a WARNING if pg_parquet is not installed.
 CREATE OR REPLACE FUNCTION export_trading_history() RETURNS void AS $$
 DECLARE
     export_date  DATE := CURRENT_DATE;
-    bucket_name  TEXT := current_setting('app.cold_storage_bucket_name', true);
-    base_path    TEXT;
+    bucket_name  TEXT := current_setting('app.bucket_name', true);
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_parquet') THEN
         RAISE WARNING 'pg_parquet is not installed; skipping trading history export';
         RETURN;
     END IF;
     IF bucket_name IS NULL OR bucket_name = '' THEN
-        RAISE EXCEPTION 'app.cold_storage_bucket_name GUC is not set; cannot export trading history';
+        RAISE EXCEPTION 'app.bucket_name GUC is not set; cannot export trading history';
     END IF;
-    base_path := format(
-        's3://%s/trading-history/year=%s/month=%s/day=%s',
-        bucket_name,
-        to_char(export_date, 'YYYY'),
-        to_char(export_date, 'MM'),
-        to_char(export_date, 'DD')
+    EXECUTE format(
+        'COPY (SELECT * FROM equity_rebalance_sessions) TO %L',
+        format('s3://%s/exports/equity/rebalance-sessions/year=%s/month=%s/day=%s/data.parquet',
+               bucket_name, to_char(export_date, 'YYYY'), to_char(export_date, 'MM'), to_char(export_date, 'DD'))
     );
-    EXECUTE format('COPY (SELECT * FROM equity_rebalance_sessions) TO %L',
-        base_path || '/rebalance_sessions.parquet');
-    EXECUTE format('COPY (SELECT * FROM equity_pairs) TO %L',
-        base_path || '/pairs.parquet');
-    EXECUTE format('COPY (SELECT * FROM equity_allocations) TO %L',
-        base_path || '/allocations.parquet');
-    EXECUTE format('COPY (SELECT * FROM equity_orders) TO %L',
-        base_path || '/orders.parquet');
-    EXECUTE format('COPY (SELECT * FROM equity_portfolio_snapshots) TO %L',
-        base_path || '/portfolio_snapshots.parquet');
+    EXECUTE format(
+        'COPY (SELECT * FROM equity_pairs) TO %L',
+        format('s3://%s/exports/equity/pairs/year=%s/month=%s/day=%s/data.parquet',
+               bucket_name, to_char(export_date, 'YYYY'), to_char(export_date, 'MM'), to_char(export_date, 'DD'))
+    );
+    EXECUTE format(
+        'COPY (SELECT * FROM equity_allocations) TO %L',
+        format('s3://%s/exports/equity/allocations/year=%s/month=%s/day=%s/data.parquet',
+               bucket_name, to_char(export_date, 'YYYY'), to_char(export_date, 'MM'), to_char(export_date, 'DD'))
+    );
+    EXECUTE format(
+        'COPY (SELECT * FROM equity_orders) TO %L',
+        format('s3://%s/exports/equity/orders/year=%s/month=%s/day=%s/data.parquet',
+               bucket_name, to_char(export_date, 'YYYY'), to_char(export_date, 'MM'), to_char(export_date, 'DD'))
+    );
+    EXECUTE format(
+        'COPY (SELECT * FROM equity_portfolio_snapshots) TO %L',
+        format('s3://%s/exports/equity/portfolio-snapshots/year=%s/month=%s/day=%s/data.parquet',
+               bucket_name, to_char(export_date, 'YYYY'), to_char(export_date, 'MM'), to_char(export_date, 'DD'))
+    );
 END;
 $$ LANGUAGE plpgsql;
 

--- a/secretspec.toml
+++ b/secretspec.toml
@@ -9,26 +9,19 @@ ALPACA_API_KEY_ID = { description = "Alpaca trading API key ID", required = true
 ALPACA_API_SECRET = { description = "Alpaca trading API secret", required = true }
 ALPACA_IS_PAPER = { description = "Alpaca paper trading flag", required = false, default = "false" }
 
-[profiles.paper]
+[profiles."development/john.forstmeier"]
 MASSIVE_BASE_URL = { description = "Massive API base URL", required = true }
 MASSIVE_API_KEY = { description = "Massive API key for equity data", required = true }
 ALPACA_API_KEY_ID = { description = "Alpaca trading API key ID", required = true }
 ALPACA_API_SECRET = { description = "Alpaca trading API secret", required = true }
 ALPACA_IS_PAPER = { description = "Alpaca paper trading flag", required = false, default = "true" }
 
-[profiles."dev/chris"]
-MASSIVE_BASE_URL = { description = "Massive API base URL", required = false, default = "" }
-MASSIVE_API_KEY = { description = "Massive API key", required = false, default = "" }
-ALPACA_API_KEY_ID = { description = "Alpaca API key ID", required = false, default = "" }
-ALPACA_API_SECRET = { description = "Alpaca API secret", required = false, default = "" }
-ALPACA_IS_PAPER = { description = "Alpaca paper flag", required = false, default = "true" }
-
-[profiles."dev/john"]
-MASSIVE_BASE_URL = { description = "Massive API base URL", required = false, default = "" }
-MASSIVE_API_KEY = { description = "Massive API key", required = false, default = "" }
-ALPACA_API_KEY_ID = { description = "Alpaca API key ID", required = false, default = "" }
-ALPACA_API_SECRET = { description = "Alpaca API secret", required = false, default = "" }
-ALPACA_IS_PAPER = { description = "Alpaca paper flag", required = false, default = "true" }
+[profiles."development/chris.addy"]
+MASSIVE_BASE_URL = { description = "Massive API base URL", required = true }
+MASSIVE_API_KEY = { description = "Massive API key for equity data", required = true }
+ALPACA_API_KEY_ID = { description = "Alpaca trading API key ID", required = true }
+ALPACA_API_SECRET = { description = "Alpaca trading API secret", required = true }
+ALPACA_IS_PAPER = { description = "Alpaca paper trading flag", required = false, default = "true" }
 
 [profiles.development]
 MASSIVE_BASE_URL = { description = "Massive API base URL", required = false, default = "" }

--- a/tools/bootstrap-machine
+++ b/tools/bootstrap-machine
@@ -244,18 +244,30 @@ else
 fi
 
 # --------------------------------------------------------------------------- #
+# 6b. Validate secretspec profile is defined
+# --------------------------------------------------------------------------- #
+if [[ "$PROFILE" != "production" ]]; then
+  if ! grep -qF "[profiles.\"${PROFILE}\"]" "$REPO_ROOT/secretspec.toml"; then
+    echo "Error: Profile '${PROFILE}' is not defined in secretspec.toml."
+    echo "  Add a [profiles.\"${PROFILE}\"] section to secretspec.toml, commit it,"
+    echo "  then re-run bootstrap."
+    exit 1
+  fi
+fi
+
+# --------------------------------------------------------------------------- #
 # 7. Generate .env from .env.example
 # --------------------------------------------------------------------------- #
 DOTENV="$REPO_ROOT/.env"
 
 if [[ ! -f "$DOTENV" ]]; then
   step "Creating .env (profile: $PROFILE)"
-  sed "s|dev/yourname|$PROFILE|g" "$REPO_ROOT/.env.example" > "$DOTENV"
+  sed "s|development/your.name|$PROFILE|g" "$REPO_ROOT/.env.example" > "$DOTENV"
 
   # Production needs extra vars
   if [[ "$PRODUCTION" == true ]]; then
     cat >> "$DOTENV" << 'EOF'
-AWS_S3_MODEL_ARTIFACT_PATH=artifacts/tide/
+AWS_S3_MODEL_ARTIFACT_PATH=models/tide/
 MASSIVE_BASE_URL=https://api.massive.com
 EOF
   fi

--- a/tools/bootstrap-machine
+++ b/tools/bootstrap-machine
@@ -4,19 +4,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-PROD=false
+PRODUCTION=false
 NONINTERACTIVE=false
 PROFILE=""
 OS="$(uname -s)"
 
 usage() {
-  echo "Usage: $(basename "$0") --profile <name> [--prod] [--noninteractive]"
+  echo "Usage: $(basename "$0") --profile <name> [--production] [--noninteractive]"
   echo ""
   echo "Bootstrap a fresh machine for the fund development environment."
   echo ""
   echo "Options:"
-  echo "  --profile <name>    Fund profile (e.g., dev/chris, production) [required]"
-  echo "  --prod              Configure production environment and validate secrets"
+  echo "  --profile <name>    Fund profile (e.g., development/chris.addy, production) [required]"
+  echo "  --production        Configure production environment and validate secrets"
   echo "  --noninteractive    Skip the final exec \$SHELL (for use from automation)"
   echo "  -h, --help          Show this help message"
   exit "${1:-0}"
@@ -32,8 +32,8 @@ while [[ $# -gt 0 ]]; do
       PROFILE="$2"
       shift 2
       ;;
-    --prod)
-      PROD=true
+    --production)
+      PRODUCTION=true
       shift
       ;;
     --noninteractive)
@@ -51,7 +51,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -z "$PROFILE" ]]; then
-  echo "Error: --profile is required (e.g., --profile dev/chris or --profile production)"
+  echo "Error: --profile is required (e.g., --profile development/chris.addy or --profile production)"
   usage 1
 fi
 
@@ -253,7 +253,7 @@ if [[ ! -f "$DOTENV" ]]; then
   sed "s|dev/yourname|$PROFILE|g" "$REPO_ROOT/.env.example" > "$DOTENV"
 
   # Production needs extra vars
-  if [[ "$PROD" == true ]]; then
+  if [[ "$PRODUCTION" == true ]]; then
     cat >> "$DOTENV" << 'EOF'
 AWS_S3_MODEL_ARTIFACT_PATH=artifacts/tide/
 MASSIVE_BASE_URL=https://api.massive.com
@@ -270,7 +270,7 @@ else
   echo ".env already exists, skipping creation"
 fi
 
-if [[ "$PROD" != true && "$PROFILE" != "production" && "$PROFILE" != "paper" ]]; then
+if [[ "$PRODUCTION" != true && "$PROFILE" != "production" ]]; then
   step "Ensuring dev S3 buckets exist"
   set -a
   # shellcheck disable=SC1090
@@ -309,7 +309,7 @@ devenv shell -- echo "devenv environment built successfully"
 # --------------------------------------------------------------------------- #
 # 10. Prod mode: validate secrets
 # --------------------------------------------------------------------------- #
-if [[ "$PROD" == true ]]; then
+if [[ "$PRODUCTION" == true ]]; then
   echo "Validating secrets via secretspec..."
   devenv shell -- secretspec check || echo "Run 'secretspec set <KEY>' to populate missing secrets"
 fi
@@ -322,7 +322,7 @@ step "Bootstrap complete"
 echo ""
 echo "Next steps:"
 echo "  cd $REPO_ROOT"
-if [[ "$PROD" == true ]]; then
+if [[ "$PRODUCTION" == true ]]; then
   echo "  tmux new-session -d -s fund 'devenv --profile apps up'"
   echo "  tmux attach -t fund        # attach to services session"
 else
@@ -330,7 +330,7 @@ else
   echo "  devenv --profile apps up  # start application services"
   echo ""
   echo "For production setup, re-run with:"
-  echo "  $(basename "$0") --profile production --prod"
+  echo "  $(basename "$0") --profile production --production"
 fi
 
 # Replace current shell so Nix paths are on PATH

--- a/tools/create-development-buckets
+++ b/tools/create-development-buckets
@@ -9,8 +9,7 @@ if [[ -z "$PROFILE" ]]; then
 fi
 
 SLUG="${PROFILE//[\/.]/-}"
-DATA_BUCKET="fund-${SLUG}-data"
-ARTIFACTS_BUCKET="fund-${SLUG}-model-artifacts"
+BUCKET="oscm-fund-${SLUG}"
 
 create_bucket() {
   local bucket="$1"
@@ -22,7 +21,6 @@ create_bucket() {
   fi
 }
 
-create_bucket "$DATA_BUCKET"
-create_bucket "$ARTIFACTS_BUCKET"
+create_bucket "$BUCKET"
 
-echo "Development buckets ready for profile $PROFILE"
+echo "Development bucket ready for profile $PROFILE"

--- a/tools/create-development-buckets
+++ b/tools/create-development-buckets
@@ -4,11 +4,11 @@ set -euo pipefail
 PROFILE="${1:-}"
 if [[ -z "$PROFILE" ]]; then
   echo "Usage: $(basename "$0") <profile>"
-  echo "  e.g. $(basename "$0") dev/chris"
+  echo "  e.g. $(basename "$0") development/chris.addy"
   exit 1
 fi
 
-SLUG="${PROFILE//\//-}"
+SLUG="${PROFILE//[\/.]/-}"
 DATA_BUCKET="fund-${SLUG}-data"
 ARTIFACTS_BUCKET="fund-${SLUG}-model-artifacts"
 

--- a/uv.lock
+++ b/uv.lock
@@ -156,7 +156,7 @@ wheels = [
 
 [[package]]
 name = "apprise"
-version = "1.10.0"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -167,9 +167,9 @@ dependencies = [
     { name = "requests-oauthlib" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/74/9c16829d3e7e45ce7daf1b704687fa4fde7ea00d72eafe8de18c72bf5995/apprise-1.10.0.tar.gz", hash = "sha256:b768f32d99e45ed5f4c3eef1f67903e803c97f97ba61a531a5d0a45d40df90a8", size = 2188611, upload-time = "2026-04-26T14:23:51.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/f8/83f4e2aaaa0342dc67f783bf84427d9ff5cfa4ecde3a52d9b587740a91ee/apprise-1.11.0.tar.gz", hash = "sha256:3b1e6f5365b302d1fae270c0c8007958e54224b9b7808acec69006ea27f5b8a2", size = 2337248, upload-time = "2026-05-29T17:52:29.198Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/f9/177a73589d34e676d10bc4c6a8328710e28af5907234e9f25bb149a04eec/apprise-1.10.0-py3-none-any.whl", hash = "sha256:e685303d3568bb7a057d6ddeafd27ee12fff183ca36483ad4bacc0b9b4efa82c", size = 1632292, upload-time = "2026-04-26T14:23:49.28Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/79/1483693160917522703708e45b4045946d86be634b8af2c2ac9f361f8fa3/apprise-1.11.0-py3-none-any.whl", hash = "sha256:6abc6d9f8dddedfe14b2918c3553146894ac6e3dad401deaf854b20b4c455d38", size = 1712975, upload-time = "2026-05-29T17:52:26.645Z" },
 ]
 
 [[package]]
@@ -229,29 +229,29 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.16"
+version = "1.43.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/4f/f13d80d377b54dd2973e243e4eb7ce748706cd53876361cc72506006fd8b/boto3-1.43.16.tar.gz", hash = "sha256:6c337bbe608aacc7d335c79e671f0c893870293b74d652f7a7af22ccd0dfef16", size = 113152, upload-time = "2026-05-27T19:31:39.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/37/2ae45d06423182b4561c03bc33494fafa21a0d1e847f0554f590e3cbbc62/boto3-1.43.18.tar.gz", hash = "sha256:33138883e984eb1937d1553da699182c8ad2099138091e885b65c9accbccea16", size = 113154, upload-time = "2026-05-29T19:33:30.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/c0/7d687e40f4b7046ede66026ecd1b0a93d47afe26d9170f5926a1605c8641/boto3-1.43.16-py3-none-any.whl", hash = "sha256:dffc8a3cd3edbc0ad95b9c6b983e873b76ede46d3aa0709f94db253f2ff2388f", size = 140537, upload-time = "2026-05-27T19:31:36.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/75/fcb2c10d516496536c50e397248de42a673d8ea8137caf5b578a72b11293/boto3-1.43.18-py3-none-any.whl", hash = "sha256:7b62ce5c0a51428d692aa4f2adc9dc2a4a4c2989bf65a0a12834eeffa99b0b84", size = 140538, upload-time = "2026-05-29T19:33:27.131Z" },
 ]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.43.16"
+version = "1.43.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/f9/ca125c335ef0803837c70fd58b7a271e46ef75cf2af422f09833416358c9/boto3_stubs-1.43.16.tar.gz", hash = "sha256:33e8d6e0e28c4596c5ea9afa484370f8b84cf02bcf211a3c082fdad7edb4aa54", size = 102671, upload-time = "2026-05-27T19:38:22.35Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/9d/1c492f6f1b52c977516401a6ab6782e619431b2925e049d8d3327af7d1f5/boto3_stubs-1.43.18.tar.gz", hash = "sha256:09bf480c62bc54cf59bd0ad13b3db0ed9a00592675fd01248bcba4f93eaa7660", size = 102838, upload-time = "2026-05-29T20:08:23.628Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/7b/e611ba7e90804794f57ba6f3325679ea650056e4d800cc0fcb67522557bc/boto3_stubs-1.43.16-py3-none-any.whl", hash = "sha256:3d58c43bc59e32de9952ff51e7e8326941bd484b626277cec6e34aadde058356", size = 70669, upload-time = "2026-05-27T19:38:18.468Z" },
+    { url = "https://files.pythonhosted.org/packages/83/fd/981298cc78006bb1e396bff3a78afff8d9f1ae0cfeb376179c9d03873e7c/boto3_stubs-1.43.18-py3-none-any.whl", hash = "sha256:c4215090a2945339d0f32065520fb2df54fec25fc5cbc8b266779984c2c5540d", size = 70719, upload-time = "2026-05-29T20:08:19.08Z" },
 ]
 
 [package.optional-dependencies]
@@ -264,16 +264,16 @@ ssm = [
 
 [[package]]
 name = "botocore"
-version = "1.43.16"
+version = "1.43.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/74/140451a1fe027cb5e387cc7b1ec56224616ca742c330f1492f71c5cba3fb/botocore-1.43.16.tar.gz", hash = "sha256:813dae233d8b365c19aaf7865b32070e34d7e793654881bf86ecbbef3f4ad5c6", size = 15388648, upload-time = "2026-05-27T19:31:25.172Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/6d/436d69ec484ffc43635b38d7fb7d717d38824671f10e12e77924019ca929/botocore-1.43.18.tar.gz", hash = "sha256:dc8c105351b49688c667065cd5a45fc5b9db982657cefc9e3fbfb9417a55c7df", size = 15424886, upload-time = "2026-05-29T19:33:16.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/8f/25933240485c0662bb3fa430ed0c6b8b8124ab3bc136154c07ce12644cb0/botocore-1.43.16-py3-none-any.whl", hash = "sha256:8ab05b1346d26a3c6d69c7338051f07bd4739a090f414d2cff43c0dbc1e18ca7", size = 15067437, upload-time = "2026-05-27T19:31:19.212Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5a/35c92c0af1514581031fe66c398b622176b3c928a6d5cf8133c7207e3bd7/botocore-1.43.18-py3-none-any.whl", hash = "sha256:e2610fce16df9f89deab5f3c163430a814e6804034eb95bef8957c8db60b7dbc", size = 15106258, upload-time = "2026-05-29T19:33:11.18Z" },
 ]
 
 [[package]]
@@ -1601,30 +1601,30 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.41.1"
+version = "1.41.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "polars-runtime-32" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/af/5fd97632f49ffe46b887b9931e19ec38ae1e3d9198be86dccd465dc6f1b3/polars-1.41.1.tar.gz", hash = "sha256:4a8df19475a68c3b4a65466b2683fc3a9a76053a591cde1748d84b690aff9338", size = 737807, upload-time = "2026-05-27T19:54:41.937Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/f9/aeda46259b0669247a160315d2d51269de9504b9dd2f70acadbcb22f46b7/polars-1.41.2.tar.gz", hash = "sha256:256d6731162371b77f3f29a55eacb8c0fc740ddb1a293a01d2ef5b5393c5c708", size = 737996, upload-time = "2026-05-29T17:39:15.604Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/ef/cdd8bf7e46e94c4cb8f7c092c9c2c731a734a2dc3076516a85e457845b92/polars-1.41.1-py3-none-any.whl", hash = "sha256:b758df44b0d5dc3f19b2d81eaa3c617d53196226163d41e7ccd240ab494274da", size = 833213, upload-time = "2026-05-27T19:53:28.752Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/22/28f62d24f7db56ac4343588f9362d49b7b4177e55ac47a466fe696b0099b/polars-1.41.2-py3-none-any.whl", hash = "sha256:23ce9a2910b6e3e8d4258770bf44aa17170958df7af6e85feedf4458a04d8d29", size = 833445, upload-time = "2026-05-29T17:37:05.576Z" },
 ]
 
 [[package]]
 name = "polars-runtime-32"
-version = "1.41.1"
+version = "1.41.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/96/cd099e525716cc8549096e3cc1c1f13b9d97d00588d40781f42a09243b4c/polars_runtime_32-1.41.1.tar.gz", hash = "sha256:84cb75c70bf48fd27a9c2c83b9ade7eadd647eee6c3df3ed2dcc7dccfd5ad56e", size = 2989104, upload-time = "2026-05-27T19:54:43.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/56/54e3ea0e9b64f327179049e4742241cc6b1d3e8fa414b05a057dd26df367/polars_runtime_32-1.41.2.tar.gz", hash = "sha256:7af09ec1ab053da2c9669e8d15f809a4083a29be05db57111688b8051062af56", size = 2989474, upload-time = "2026-05-29T17:39:17.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/be/d3777241935a5ba3a54b1bc89e81f9a640d13c30f38b37f8e677a5683288/polars_runtime_32-1.41.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:3791802e0665ab66e72cdacf94966fd409f408acd7d16c1a31ecc74ea06aa6e8", size = 52210540, upload-time = "2026-05-27T19:53:31.669Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/47/846140d1fbdada68b467116c65845935eb82f5ac92884573b0906ae8fcb2/polars_runtime_32-1.41.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:df0de10d152ebd2fb3cccd0a2a26db68138440bc44164e831a7c9a50f73adf8b", size = 46504153, upload-time = "2026-05-27T19:53:34.593Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/a7/873f38f71e20e747ec4d4aea8b5c510e279b3447efc5bac725a954923f8e/polars_runtime_32-1.41.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b544fcf95219857d698f5b61583309dcc5469443fbcb688356d5913169cf37df", size = 50393809, upload-time = "2026-05-27T19:53:37.64Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/6b/6e9f6818e2b8258be5127a3455a6e09d99770f14098e9d5bfd85c2b3aa71/polars_runtime_32-1.41.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d279ad9036293592396988a46046d73cc340a3bd51fa82fa6993822632ed11f9", size = 56368917, upload-time = "2026-05-27T19:53:40.857Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ec/33fd93f4d6f251c3a4125668d8e4b6fc25b7abdb3cd13aecb4cda2252d56/polars_runtime_32-1.41.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d25e6e99a85488943b6377194e1dd6391281027d355e5da3f607705434b9756f", size = 50564909, upload-time = "2026-05-27T19:53:44.096Z" },
-    { url = "https://files.pythonhosted.org/packages/11/5f/0c893aacc1aa4f78b15c0eeab44fce69487ff659fb2145e894bd3f5df451/polars_runtime_32-1.41.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1fec5be999825a1956392c682d0c04426b4fc40c4e16bc166807f36b5056d10e", size = 54289924, upload-time = "2026-05-27T19:53:47.067Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/98/996c48e2f94b8c81d6ac9e513fdd75a612015c40a367ab885ef7d053f08a/polars_runtime_32-1.41.1-cp310-abi3-win_amd64.whl", hash = "sha256:dfb9eff25fca1b67d6381895313d05a3510f3c0cdba0bd0cf24cba9071aa190b", size = 51946331, upload-time = "2026-05-27T19:53:50.066Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/67/c053610d3609263d4d4412390ced8db8e45322c1358ec6ef5359457a6ae5/polars_runtime_32-1.41.1-cp310-abi3-win_arm64.whl", hash = "sha256:348f4fe9ebacf904b71ecc7c293314292117a78c6464aa0b5781db7ffc425c56", size = 45957732, upload-time = "2026-05-27T19:53:52.816Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/9b/fe72a3811c0357cdb06c67bdc7695fa1623ad47948fc523195f5ac31037f/polars_runtime_32-1.41.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:95a08346dac337357cdb825c8076df7d36da54c4caa59a5cb41d0a30691c5edd", size = 52265283, upload-time = "2026-05-29T17:37:09.407Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/93/fab9da803fd80d9e83ef88c20932f637a10bc611b20415fc322eec84bc44/polars_runtime_32-1.41.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:dedfaeec2c7f995298da7319dd9431d662e5dd1d0ec51b1459df4a0234ceff52", size = 46571222, upload-time = "2026-05-29T17:37:13.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2a/8843f34a8ac57acd058a39b87b03b580dd352a490e9dae0415e02033bdd4/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18eea22c5cc34e27f8a60950458ad81e6a9ea75e89363ca1367e14e7e7f781fc", size = 50409372, upload-time = "2026-05-29T17:37:17.875Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c6/92b352fe88cf51bd0a19fb99e1c0cbe46aa26c14dcf7995b89869cd932ae/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2630540dfdfb0f36f9b04a07c7c2e3f50bf2ad384113263c1c812007ee9141e0", size = 56405484, upload-time = "2026-05-29T17:37:22.684Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c4/bae3174c3b02f6b441d2e58594387abcd509f67a098f682a83b195f08966/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:20e969e08f9b137e233c04cc04de73d9795f89eb77d34854e40a025965a43763", size = 50603512, upload-time = "2026-05-29T17:37:27.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ed/f2d26ae02d92c2689056838ed59e2a626326ad23c2831d58637d25f6c82a/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e7016a3deb641b64a31447abbbee0f34bd020a6a9ae34ee6b743837def15e2a4", size = 54328561, upload-time = "2026-05-29T17:37:32.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c4/9c3831cc885dc7769e59abf8f583821a5fb4403fd0e4eba0ccc6d47a3d4b/polars_runtime_32-1.41.2-cp310-abi3-win_amd64.whl", hash = "sha256:1e5e5377c315e0dcafdfb2a31adc546abbaeb3f9cb1864e6536523d2af473265", size = 51978643, upload-time = "2026-05-29T17:37:37.443Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c6/79e9f3f270270d7ed5575d92b7bfef49f01abd9275447161275b23b553a8/polars_runtime_32-1.41.2-cp310-abi3-win_arm64.whl", hash = "sha256:843d96f69d18eca53429c1198e58891db7f18111f83b9c419bb45ad9d73eaed5", size = 46006901, upload-time = "2026-05-29T17:37:42.522Z" },
 ]
 
 [[package]]
@@ -1997,7 +1997,7 @@ wheels = [
 
 [[package]]
 name = "pydocket"
-version = "0.21.0"
+version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "burner-redis" },
@@ -2014,9 +2014,9 @@ dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "uncalled-for" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/71/e267ddae6fa3524bfbc00fd409fe2157cc8814751ebf3e2cf22879c1732e/pydocket-0.21.0.tar.gz", hash = "sha256:2fcfc67f05a98689505e6af127af7f71b9612c08a139cfe1a690706c43810968", size = 398122, upload-time = "2026-05-26T15:28:51.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/5f/2f68c38ac3fdbff3cdec3ccfe31303ae5972f3e3f1c365d0ec71573dfd2e/pydocket-0.21.1.tar.gz", hash = "sha256:79d19d5f3be29caa23eba95226a516f8b2aed3ba1ad7830095fdce59f49b51f7", size = 399652, upload-time = "2026-05-29T21:04:10.855Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/d1/fcfa26ced70c37714b5b4c5da9bb2ea9c28116367e8db8994de7b91d0b5f/pydocket-0.21.0-py3-none-any.whl", hash = "sha256:b98f8fcd48fbd5258f6ab0be9080fbc36dcab52a73a9acc0509652de0b445df0", size = 116953, upload-time = "2026-05-26T15:28:50.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ca/6bd186338cf4abb318825d9e8d2d2cf069432f9217d17f78f61204eaba70/pydocket-0.21.1-py3-none-any.whl", hash = "sha256:7f3b12c307488efbfde96f76dac533babf5dff4ce72dc0a108a49de03ab39564", size = 117222, upload-time = "2026-05-29T21:04:09.375Z" },
 ]
 
 [[package]]
@@ -2306,14 +2306,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.17.1"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/b3/bcdc2f58fa92592db511beda154c2c08d28f21f6c4637f06a42a24b10c21/s3transfer-0.17.1.tar.gz", hash = "sha256:042dd5e3b1b512355e35a23f0223e426b7042e80b97830ea2680ddce327fc45e", size = 159439, upload-time = "2026-05-26T19:45:01.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/dd/904873250a6554fbae40cddbf9198e3cc37a2f1319d5e1a5ce82fe269c17/s3transfer-0.17.1-py3-none-any.whl", hash = "sha256:5b9827d1044159bbb01b86ef8902760ea39281927f5de31de75e1d657177bf4c", size = 88264, upload-time = "2026-05-26T19:45:00.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
 ]
 
 [[package]]
@@ -2611,7 +2611,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.26.2"
+version = "0.26.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -2619,9 +2619,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/a5/756f2e6bc81a7dd79aa3c625dd01b74cabc4516628cace2caaec09ca6ff2/typer-0.26.2.tar.gz", hash = "sha256:9b4f19e08fcc9427a822d1ef467b1fe76737a2f65c7926bdeba2337d73569b68", size = 198991, upload-time = "2026-05-27T10:41:39.166Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/15/f5fc7be23b7196bc065b282d9589a372392fb10860c80f9c1dd7eb008662/typer-0.26.3.tar.gz", hash = "sha256:3e2b9352f535e5303ef27806dadc2c8647687bdca5c902f03fec3fb88f46a46a", size = 198326, upload-time = "2026-05-28T20:30:50.984Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/a5/6ffd702beda8798b2b82ff70805ed4a66d963557e43a5d1823ab456251a4/typer-0.26.2-py3-none-any.whl", hash = "sha256:39beff72ffbb31978a5b545f677d57edb97c6f980f433b38556deb0af25f094d", size = 123123, upload-time = "2026-05-27T10:41:40.504Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/cc/c6c5dea061e2740355bfeef22ac6a41751bd2f3903e83921295569bdcec4/typer-0.26.3-py3-none-any.whl", hash = "sha256:e70549ec5a403ca8a0bf0802ddd9f3c6ff7a14ccbb859b01b697baa943636f33", size = 122338, upload-time = "2026-05-28T20:30:49.816Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Overview

## Changes

- Rename `FUND_PROFILE` values to `development/first.last` pattern; bare `development` remains as the credential-free local default; remove `paper` profile (Alpaca paper trading is now an `ALPACA_IS_PAPER` flag per named dev profile)
- Update `isDeployed` in `devenv.nix` to `lib.hasPrefix "development/"` and derive bucket slug using both `/` and `.` as separators
- Rename `--prod` flag to `--production` in `tools/bootstrap-machine`
- Consolidate four S3 buckets (data, training, cold-storage, model artifacts) into a single `oscm-fund-{profile-slug}` bucket per environment; path prefixes distinguish data from model artifacts:
  - `data/equity/bars/year=.../month=.../day=.../data.parquet`
  - `data/equity/details/details.csv`
  - `models/tide/{timestamp}/filtered_data.parquet`
  - `models/tide/{timestamp}/output/model.tar.gz`
  - `exports/equity/{table}/year=.../...`
- Replace `AWS_S3_DATA/TRAINING/COLD_STORAGE/MODEL_ARTIFACTS_BUCKET_NAME` env vars with single `AWS_S3_BUCKET_NAME` across all services and Prefect blocks
- Collapse `set_data/training/cold_storage_bucket_guc` into single `set_bucket_guc` updating `app.bucket_name` GUC in PostgreSQL
- Replace `state.pool.as_ref().unwrap()` in `equity_quotes.rs` with `ok_or()` to propagate the error through the existing `Result` return type
- Replace `unwrap()` on timestamp conversion and Option price fields inside `push_values` closure in `database.rs` with `expect()` messages (closure is `FnMut` and cannot return `Result`)
- Add inline comments for `REQUIRED_PAIRS`, `Z_SCORE_HOLD_THRESHOLD`, `Z_SCORE_STOP_LOSS`, `BETA_WEIGHT_LOWER_BOUND`, and `BETA_WEIGHT_UPPER_BOUND` in `risk_management.py`

## Context

This is another batch of some cleanup stuff. Spur of the moment add is the S3 bucket stuff - I had the thought we can probably just stick everything into a single bucket and then just update the paths different files are being written to. Simplifies things especially since we aren't using lifecycle configurations on the buckets.

Addresses a batch of deferred cleanup items. The S3 consolidation simplifies infrastructure: one bucket per environment with Hive-partitioned paths replaces four separately named buckets. Profile naming now follows a consistent `development/first.last` convention that enables `isDeployed` detection via prefix match rather than an explicit allowlist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Consolidates multiple S3 bucket environment variables into a single `AWS_S3_BUCKET_NAME` variable.
  * Updates development profile naming convention from `dev/yourname` to `development/your.name`.

* **Storage & Data**
  * Reorganizes S3 object paths for equity data and model artifacts under a unified bucket structure.
  * Streamlines data manager to use a single S3 bucket for all data types instead of separate data, training, and cold storage buckets.

* **Documentation**
  * Adds clarifying comments for portfolio risk management constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->