### PR TITLE
[Wave 1, Part 1] Python critical fixes: prediction staleness gate, fill confirmation, dangling long alert

### DIFF
--- a/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
@@ -118,6 +118,50 @@ class AlpacaClient:
             equity=float(cast("str", account.equity)),
         )
 
+    def _confirm_order_status(
+        self,
+        ticker: str,
+        alpaca_order_id: str,
+        order: object,
+    ) -> None:
+        """Check submitted order status and raise if rejected or stuck pending_new."""
+        order_status = str(getattr(order, "status", ""))
+
+        if order_status == "rejected":
+            logger.error(
+                "Order rejected by Alpaca",
+                ticker=ticker,
+                alpaca_order_id=alpaca_order_id,
+            )
+            message = (
+                f"Order for {ticker} was rejected by Alpaca"
+                f" (order_id={alpaca_order_id})"
+            )
+            raise RuntimeError(message)
+
+        if order_status == "pending_new":
+            time.sleep(1)
+            try:
+                polled_order = self.trading_client.get_order_by_id(alpaca_order_id)
+                order_status = str(getattr(polled_order, "status", ""))
+            except Exception:
+                logger.exception(
+                    "Failed to poll order status after pending_new",
+                    ticker=ticker,
+                    alpaca_order_id=alpaca_order_id,
+                )
+            if order_status == "pending_new":
+                logger.error(
+                    "Order remains pending_new after poll",
+                    ticker=ticker,
+                    alpaca_order_id=alpaca_order_id,
+                )
+                message = (
+                    f"Order for {ticker} remains pending_new after poll"
+                    f" (order_id={alpaca_order_id})"
+                )
+                raise RuntimeError(message)
+
     def open_position(
         self,
         ticker: str,
@@ -172,6 +216,7 @@ class AlpacaClient:
         try:
             order = self.trading_client.submit_order(order_data=order_request)
             alpaca_order_id = str(getattr(order, "id", ""))
+            self._confirm_order_status(ticker, alpaca_order_id, order)
         except APIError as e:
             error_str = str(e).lower()
             if "insufficient buying power" in error_str or "buying_power" in error_str:

--- a/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
@@ -150,6 +150,19 @@ class AlpacaClient:
                     ticker=ticker,
                     alpaca_order_id=alpaca_order_id,
                 )
+                # Cannot confirm status; treat as submitted rather than failing.
+                return
+            if order_status == "rejected":
+                logger.error(
+                    "Order rejected by Alpaca after poll",
+                    ticker=ticker,
+                    alpaca_order_id=alpaca_order_id,
+                )
+                message = (
+                    f"Order for {ticker} was rejected by Alpaca"
+                    f" (order_id={alpaca_order_id})"
+                )
+                raise RuntimeError(message)
             if order_status == "pending_new":
                 logger.error(
                     "Order remains pending_new after poll",

--- a/applications/portfolio_manager/src/portfolio_manager/rebalance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/rebalance.py
@@ -367,11 +367,15 @@ async def run_rebalance(  # noqa: PLR0911, PLR0912, PLR0915, C901
 
 
 async def get_latest_predictions_correlation_id() -> str | None:
-    """Return the correlation_id of the most recently inserted predictions row."""
+    """Return the correlation_id of today's most recently inserted predictions row.
+
+    Returns None if no predictions were generated today.
+    """
     pool = await get_pool()
     async with pool.connection() as connection:
         result = await connection.execute(
             "SELECT correlation_id FROM equity_predictions"
+            " WHERE created_at::date = CURRENT_DATE"
             " ORDER BY created_at DESC LIMIT 1"
         )
         row = await result.fetchone()
@@ -383,7 +387,8 @@ async def get_raw_predictions(
 ) -> tuple[pl.DataFrame, str | None]:
     """Query predictions from PostgreSQL for the given correlation_id.
 
-    If correlation_id is None, uses the most recently inserted set of predictions.
+    If correlation_id is None, uses the most recently inserted set of predictions
+    generated today. Stale predictions from a prior trading day return empty results.
     Returns (predictions_dataframe, model_run_id).
     """
     pool = await get_pool()
@@ -406,6 +411,7 @@ async def get_raw_predictions(
                    FROM equity_predictions
                    WHERE correlation_id = (
                        SELECT correlation_id FROM equity_predictions
+                       WHERE created_at::date = CURRENT_DATE
                        ORDER BY created_at DESC LIMIT 1
                    )
                    ORDER BY ticker, timestamp"""

--- a/applications/portfolio_manager/src/portfolio_manager/trade_execution.py
+++ b/applications/portfolio_manager/src/portfolio_manager/trade_execution.py
@@ -342,12 +342,12 @@ def execute_open_positions(  # noqa: C901, PLR0912, PLR0915
             opened_count += 1
         else:
             logger.warning(
-                "Short leg failed after long leg filled, dangling long exposure",
+                "Short leg failed after long leg succeeded, dangling long exposure",
                 pair_id=pair_id,
                 long_ticker=long_leg["ticker"],
                 short_ticker=short_leg["ticker"],
                 short_status=short_result.get("status"),
-                short_reason=short_result.get("reason"),
+                short_reason=short_result.get("reason") or short_result.get("error"),
             )
             reason = short_result.get("reason", "")
             if reason == "insufficient_buying_power":

--- a/applications/portfolio_manager/src/portfolio_manager/trade_execution.py
+++ b/applications/portfolio_manager/src/portfolio_manager/trade_execution.py
@@ -341,6 +341,14 @@ def execute_open_positions(  # noqa: C901, PLR0912, PLR0915
         if short_succeeded:
             opened_count += 1
         else:
+            logger.warning(
+                "Short leg failed after long leg filled, dangling long exposure",
+                pair_id=pair_id,
+                long_ticker=long_leg["ticker"],
+                short_ticker=short_leg["ticker"],
+                short_status=short_result.get("status"),
+                short_reason=short_result.get("reason"),
+            )
             reason = short_result.get("reason", "")
             if reason == "insufficient_buying_power":
                 skipped_insufficient_buying_power += 1

--- a/applications/portfolio_manager/tests/test_alpaca_client.py
+++ b/applications/portfolio_manager/tests/test_alpaca_client.py
@@ -375,6 +375,66 @@ def test_open_position_reraises_other_api_errors() -> None:
 
 
 @patch("portfolio_manager.alpaca_client.time.sleep")
+def test_open_position_raises_when_order_is_rejected(
+    mock_sleep: MagicMock,  # noqa: ARG001
+) -> None:
+    client, mock_trading = _make_client()
+    mock_order = MagicMock()
+    mock_order.id = "order-123"
+    mock_order.status = "rejected"
+    mock_trading.submit_order.return_value = mock_order
+
+    with pytest.raises(RuntimeError, match="rejected by Alpaca"):
+        client.open_position(
+            ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0, entry_price=50.0
+        )
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_open_position_raises_when_order_remains_pending_new_after_poll(
+    mock_sleep: MagicMock,  # noqa: ARG001
+) -> None:
+    client, mock_trading = _make_client()
+    mock_order = MagicMock()
+    mock_order.id = "order-456"
+    mock_order.status = "pending_new"
+    mock_trading.submit_order.return_value = mock_order
+
+    mock_polled_order = MagicMock()
+    mock_polled_order.status = "pending_new"
+    mock_trading.get_order_by_id.return_value = mock_polled_order
+
+    with pytest.raises(RuntimeError, match="remains pending_new"):
+        client.open_position(
+            ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0, entry_price=50.0
+        )
+
+    mock_trading.get_order_by_id.assert_called_once_with("order-456")
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_open_position_succeeds_when_order_transitions_from_pending_new(
+    mock_sleep: MagicMock,  # noqa: ARG001
+) -> None:
+    client, mock_trading = _make_client()
+    mock_order = MagicMock()
+    mock_order.id = "order-789"
+    mock_order.status = "pending_new"
+    mock_trading.submit_order.return_value = mock_order
+
+    mock_polled_order = MagicMock()
+    mock_polled_order.status = "new"
+    mock_trading.get_order_by_id.return_value = mock_polled_order
+
+    result = client.open_position(
+        ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0, entry_price=50.0
+    )
+
+    assert result == "order-789"
+    mock_trading.get_order_by_id.assert_called_once_with("order-789")
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
 def test_close_position_returns_true_on_success(mock_sleep: MagicMock) -> None:
     client, mock_trading = _make_client()
 

--- a/applications/portfolio_manager/tests/test_alpaca_client.py
+++ b/applications/portfolio_manager/tests/test_alpaca_client.py
@@ -435,6 +435,47 @@ def test_open_position_succeeds_when_order_transitions_from_pending_new(
 
 
 @patch("portfolio_manager.alpaca_client.time.sleep")
+def test_open_position_raises_when_polled_order_is_rejected(
+    mock_sleep: MagicMock,  # noqa: ARG001
+) -> None:
+    client, mock_trading = _make_client()
+    mock_order = MagicMock()
+    mock_order.id = "order-abc"
+    mock_order.status = "pending_new"
+    mock_trading.submit_order.return_value = mock_order
+
+    mock_polled_order = MagicMock()
+    mock_polled_order.status = "rejected"
+    mock_trading.get_order_by_id.return_value = mock_polled_order
+
+    with pytest.raises(RuntimeError, match="rejected by Alpaca"):
+        client.open_position(
+            ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0, entry_price=50.0
+        )
+
+    mock_trading.get_order_by_id.assert_called_once_with("order-abc")
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_open_position_succeeds_when_poll_raises_exception(
+    mock_sleep: MagicMock,  # noqa: ARG001
+) -> None:
+    client, mock_trading = _make_client()
+    mock_order = MagicMock()
+    mock_order.id = "order-def"
+    mock_order.status = "pending_new"
+    mock_trading.submit_order.return_value = mock_order
+    mock_trading.get_order_by_id.side_effect = OSError("network error")
+
+    result = client.open_position(
+        ticker="AAPL", side=TradeSide.BUY, dollar_amount=500.0, entry_price=50.0
+    )
+
+    assert result == "order-def"
+    mock_trading.get_order_by_id.assert_called_once_with("order-def")
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
 def test_close_position_returns_true_on_success(mock_sleep: MagicMock) -> None:
     client, mock_trading = _make_client()
 

--- a/applications/portfolio_manager/tests/test_rebalance.py
+++ b/applications/portfolio_manager/tests/test_rebalance.py
@@ -934,6 +934,19 @@ def test_get_latest_predictions_correlation_id_returns_none_when_no_rows() -> No
     assert result is None
 
 
+def test_get_latest_predictions_correlation_id_filters_to_current_date() -> None:
+    mock_pool = _make_mock_pool(None)
+
+    with patch(
+        "portfolio_manager.rebalance.get_pool", AsyncMock(return_value=mock_pool)
+    ) as _:
+        mock_connection = mock_pool.connection.return_value.__aenter__.return_value
+        asyncio.run(get_latest_predictions_correlation_id())
+
+    sql = mock_connection.execute.call_args[0][0]
+    assert "CURRENT_DATE" in sql
+
+
 # --- get_raw_predictions ---
 
 
@@ -991,6 +1004,33 @@ def test_get_raw_predictions_returns_empty_dataframe_when_no_rows() -> None:
     assert len(result) == 0
     assert "ticker" in result.columns
     assert "quantile_10" in result.columns
+    assert model_run_id is None
+
+
+def test_get_raw_predictions_without_correlation_id_filters_to_current_date() -> None:
+    mock_pool = _make_mock_pool_with_fetchall([])
+
+    with patch(
+        "portfolio_manager.rebalance.get_pool", AsyncMock(return_value=mock_pool)
+    ):
+        mock_connection = mock_pool.connection.return_value.__aenter__.return_value
+        asyncio.run(get_raw_predictions())
+
+    sql = mock_connection.execute.call_args[0][0]
+    assert "CURRENT_DATE" in sql
+
+
+def test_get_raw_predictions_returns_empty_when_predictions_are_stale() -> None:
+    # Simulate the CURRENT_DATE filter excluding yesterday's predictions by
+    # returning no rows from the database.
+    mock_pool = _make_mock_pool_with_fetchall([])
+
+    with patch(
+        "portfolio_manager.rebalance.get_pool", AsyncMock(return_value=mock_pool)
+    ):
+        result, model_run_id = asyncio.run(get_raw_predictions())
+
+    assert result.is_empty()
     assert model_run_id is None
 
 

--- a/applications/portfolio_manager/tests/test_trade_execution.py
+++ b/applications/portfolio_manager/tests/test_trade_execution.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from portfolio_manager.alpaca_client import AlpacaAccount, AlpacaClient
 from portfolio_manager.configuration import Configuration
@@ -379,6 +379,44 @@ def test_execute_open_positions_returns_empty_for_no_positions() -> None:
     )
     assert results == []
     assert count == 0
+
+
+def test_execute_open_positions_logs_dangling_long_when_short_fails() -> None:
+    client = _make_mock_client()
+    client.open_position.side_effect = [None, RuntimeError("short failed")]
+
+    positions = [_long(ticker="AAPL"), _short(ticker="MSFT", quantity=10)]
+    with patch("portfolio_manager.trade_execution.logger") as mock_logger:
+        results, count = execute_open_positions(
+            client, positions, 10000.0, 50000.0, _DEFAULT_CONFIG
+        )
+
+    assert count == 1
+    assert results[0]["status"] == "success"
+    assert results[1]["status"] == "failed"
+    mock_logger.warning.assert_called_once()
+    warning_kwargs = mock_logger.warning.call_args[1]
+    assert warning_kwargs["long_ticker"] == "AAPL"
+    assert warning_kwargs["short_ticker"] == "MSFT"
+
+
+def test_execute_open_positions_logs_dangling_long_when_short_skipped() -> None:
+    config = Configuration(minimum_short_equity=2000.0)
+    client = _make_mock_client()
+
+    positions = [_long(ticker="AAPL"), _short(ticker="MSFT")]
+    with patch("portfolio_manager.trade_execution.logger") as mock_logger:
+        results, _ = execute_open_positions(client, positions, 10000.0, 500.0, config)
+
+    assert results[0]["status"] == "success"
+    assert results[1]["status"] == "skipped"
+    mock_logger.warning.assert_called()
+    dangling_calls = [
+        warning_call
+        for warning_call in mock_logger.warning.call_args_list
+        if "dangling" in warning_call[0][0]
+    ]
+    assert len(dangling_calls) == 1
 
 
 def test_execute_open_positions_uses_computed_short_qty_when_quantity_is_none() -> None:

--- a/applications/portfolio_manager/tests/test_trade_execution.py
+++ b/applications/portfolio_manager/tests/test_trade_execution.py
@@ -396,8 +396,11 @@ def test_execute_open_positions_logs_dangling_long_when_short_fails() -> None:
     assert results[1]["status"] == "failed"
     mock_logger.warning.assert_called_once()
     warning_kwargs = mock_logger.warning.call_args[1]
+    assert warning_kwargs["pair_id"] == "pair-1"
     assert warning_kwargs["long_ticker"] == "AAPL"
     assert warning_kwargs["short_ticker"] == "MSFT"
+    assert warning_kwargs["short_status"] == "failed"
+    assert warning_kwargs["short_reason"] == "short failed"
 
 
 def test_execute_open_positions_logs_dangling_long_when_short_skipped() -> None:
@@ -417,6 +420,12 @@ def test_execute_open_positions_logs_dangling_long_when_short_skipped() -> None:
         if "dangling" in warning_call[0][0]
     ]
     assert len(dangling_calls) == 1
+    warning_kwargs = dangling_calls[0][1]
+    assert warning_kwargs["pair_id"] == "pair-1"
+    assert warning_kwargs["long_ticker"] == "AAPL"
+    assert warning_kwargs["short_ticker"] == "MSFT"
+    assert warning_kwargs["short_status"] == "skipped"
+    assert warning_kwargs["short_reason"] == "insufficient_equity_for_short"
 
 
 def test_execute_open_positions_uses_computed_short_qty_when_quantity_is_none() -> None:


### PR DESCRIPTION
# Overview

## Changes

- Fixes #900
- Adds `WHERE created_at::date = CURRENT_DATE` staleness gate to `get_raw_predictions` and `get_latest_predictions_correlation_id` in `portfolio_manager`; stale predictions from a prior trading day now return empty results, triggering the existing rebalance-skip path
- Adds `_confirm_order_status` to `AlpacaClient` to check submitted order status: raises `RuntimeError` on `rejected` orders and on orders that remain `pending_new` after a single poll
- Adds a `logger.warning` in `execute_open_positions` whenever the long leg succeeds but the short leg does not, surfacing dangling directional exposure in structured logs

## Context

Three high-risk gaps carrying real financial risk, addressed before the Rust migration reaches them. Low-effort changes with immediate risk reduction; no new dependencies introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced order validation to detect and report rejected or stuck orders immediately after submission
  * Predictions now restricted to current-date data, eliminating potential use of stale predictions
  * Added warning visibility for incomplete trade executions when a long position opens but the short leg fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->