### PR TITLE
[Wave 1, Part 2] `schema.sql`: explicit column exports, missing indexes, `equity_predictions.id` cleanup

### DIFF
--- a/.github/label_configuration.yaml
+++ b/.github/label_configuration.yaml
@@ -23,3 +23,13 @@ yaml:
       - any-glob-to-any-file:
           - "**/*.yml"
           - "**/*.yaml"
+
+postgresql:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.sql"
+
+toml:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.toml"

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -14,6 +14,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Detect changed file types
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+            python:
+              - '**/*.py'
+              - '**/pyproject.toml'
+              - '**/uv.lock'
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
@@ -26,24 +39,44 @@ jobs:
       - name: Install devenv
         run: nix profile install nixpkgs#devenv
       - name: Cache Rust dependencies
+        if: steps.changes.outputs.rust == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: .
           cache-on-failure: false
           shared-key: rust-continuous-integration
           save-if: true
+      - name: Cache llvm-cov artifacts
+        if: steps.changes.outputs.rust == 'true'
+        uses: actions/cache@v4
+        with:
+          path: target/llvm-cov-target
+          key: llvm-cov-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            llvm-cov-${{ runner.os }}-
       - name: Cache Python dependencies
+        if: steps.changes.outputs.python == 'true'
         uses: actions/cache@v4
         with:
           path: ~/.cache/uv
           key: uv-${{ hashFiles('**/pyproject.toml', 'uv.lock') }}
           restore-keys: uv-
-      - name: Run all continuous integration checks
+      - name: Run base checks
         run: >-
           devenv --secretspec-provider env --secretspec-profile development
-          tasks run --mode before checks:continuous-integration
+          tasks run checks:base
+      - name: Run Rust checks
+        if: steps.changes.outputs.rust == 'true'
+        run: >-
+          devenv --secretspec-provider env --secretspec-profile development
+          tasks run checks:rust
+      - name: Run Python checks
+        if: steps.changes.outputs.python == 'true'
+        run: >-
+          devenv --secretspec-provider env --secretspec-profile development
+          tasks run checks:python
       - name: Show Python coverage report
-        if: always()
+        if: always() && steps.changes.outputs.python == 'true'
         run: |
           if [ -f .coverage_output/python_report.txt ]; then
             cat .coverage_output/python_report.txt

--- a/devenv.nix
+++ b/devenv.nix
@@ -480,9 +480,9 @@ in {
 
     "data:backfill-bars".exec = "backfill-bars";
 
-    "checks:continuous-integration" = {
+    "checks:base" = {
       exec = ''
-        echo "All continuous integration checks passed"
+        echo "All base checks passed"
       '';
       after = [
         "checks:nix"
@@ -490,6 +490,15 @@ in {
         "checks:yaml"
         "checks:toml"
         "checks:sql"
+      ];
+    };
+
+    "checks:continuous-integration" = {
+      exec = ''
+        echo "All continuous integration checks passed"
+      '';
+      after = [
+        "checks:base"
         "checks:python:format"
         "checks:python:lint"
         "checks:python:type-check"
@@ -651,6 +660,7 @@ in {
       echo "    aws-secrets       List fund secrets"
       echo ""
       echo "  Tasks (devenv tasks run):"
+      echo "    checks:base         Non-language checks (nix, markdown, yaml, toml, sql)"
       echo "    checks:python       All Python checks (parallel after install)"
       echo "    checks:rust         All Rust checks (sequential: format, lint, test)"
       echo "    checks:markdown     Markdown lint"

--- a/schema.sql
+++ b/schema.sql
@@ -90,7 +90,7 @@ BEGIN
         to_char(export_date, 'DD')
     );
     EXECUTE format(
-        'COPY (SELECT * FROM equity_quotes WHERE timestamp >= %L AND timestamp < %L) TO %L',
+        'COPY (SELECT timestamp, ticker, bid_price, ask_price, bid_size, ask_size FROM equity_quotes WHERE timestamp >= %L AND timestamp < %L) TO %L',
         export_date::timestamptz,
         (export_date + 1)::timestamptz,
         s3_path
@@ -195,6 +195,8 @@ CREATE TABLE IF NOT EXISTS equity_allocations (
         CHECK (quantity IS NOT NULL OR notional IS NOT NULL)
 );
 
+CREATE INDEX IF NOT EXISTS idx_equity_allocations_rebalance_id ON equity_allocations (rebalance_id);
+
 -- Add quantity and notional columns with CHECK if running against an older schema.
 DO $do$
 BEGIN
@@ -223,6 +225,8 @@ CREATE TABLE IF NOT EXISTS equity_orders (
     limit_price      NUMERIC,
     alpaca_order_id  TEXT        NOT NULL
 );
+
+CREATE INDEX IF NOT EXISTS idx_equity_orders_allocation_id ON equity_orders (allocation_id);
 
 -- Add FK from equity_orders.allocation_id to equity_allocations if running against a pre-migration schema
 -- that had allocation_id as a plain UUID with no constraint.
@@ -423,8 +427,8 @@ $do$;
 -- Columns match the Prediction struct in data_manager/src/data.rs and
 -- the predictions_schema pandera definition in ensemble_manager.
 -- timestamp is TIMESTAMPTZ; callers convert from Unix milliseconds at write time.
+-- Identity is (ticker, timestamp) — the TimescaleDB primary key; no surrogate id column.
 CREATE TABLE IF NOT EXISTS equity_predictions (
-    id              BIGSERIAL        NOT NULL,
     correlation_id  UUID             NOT NULL,
     model_run_id    TEXT             NOT NULL,
     ticker          TEXT             NOT NULL,
@@ -527,7 +531,7 @@ BEGIN
         to_char(export_date, 'DD')
     );
     EXECUTE format(
-        'COPY (SELECT * FROM equity_bars WHERE timestamp >= %L AND timestamp < %L) TO %L',
+        'COPY (SELECT ticker, timestamp, open_price, high_price, low_price, close_price, volume, volume_weighted_average_price, transactions, inserted_at FROM equity_bars WHERE timestamp >= %L AND timestamp < %L) TO %L',
         export_date::timestamptz,
         (export_date + INTERVAL '1 day')::timestamptz,
         s3_path
@@ -582,15 +586,15 @@ BEGIN
         to_char(export_date, 'MM'),
         to_char(export_date, 'DD')
     );
-    EXECUTE format('COPY (SELECT * FROM equity_rebalance_sessions) TO %L',
+    EXECUTE format('COPY (SELECT id, triggered_at, trigger_reason, model_run_id, completed_at, status FROM equity_rebalance_sessions) TO %L',
         base_path || '/rebalance_sessions.parquet');
-    EXECUTE format('COPY (SELECT * FROM equity_pairs) TO %L',
+    EXECUTE format('COPY (SELECT id, rebalance_id, pair_id, long_ticker, short_ticker, z_score, hedge_ratio, signal_strength, status, opened_at, closed_at, realized_profit_and_loss, return_percent, holding_days FROM equity_pairs) TO %L',
         base_path || '/pairs.parquet');
-    EXECUTE format('COPY (SELECT * FROM equity_allocations) TO %L',
+    EXECUTE format('COPY (SELECT id, rebalance_id, equity_pair_id, generated_at, model_run_id, ticker, side, action, dollar_amount, entry_price, quantity, notional FROM equity_allocations) TO %L',
         base_path || '/allocations.parquet');
-    EXECUTE format('COPY (SELECT * FROM equity_orders) TO %L',
+    EXECUTE format('COPY (SELECT id, allocation_id, submitted_at, ticker, side, quantity, order_type, limit_price, alpaca_order_id FROM equity_orders) TO %L',
         base_path || '/orders.parquet');
-    EXECUTE format('COPY (SELECT * FROM equity_portfolio_snapshots) TO %L',
+    EXECUTE format('COPY (SELECT id, snapshot_timestamp, snapshot_type, net_asset_value, gross_return, net_return, total_slippage_cost, created_at FROM equity_portfolio_snapshots) TO %L',
         base_path || '/portfolio_snapshots.parquet');
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
# Overview

## Changes

- update continuous integration checks with cache logic and changed file checks to improve Rust performance during runs
- Replace `SELECT *` with explicit named column lists in `export_equity_bars`, `export_equity_quotes`, and `export_trading_history` so schema drift fails loudly at export time rather than silently at restore time
- Add `idx_equity_allocations_rebalance_id` index on `equity_allocations(rebalance_id)` — used in the `get_active_tickers` join path, previously unindexed
- Add `idx_equity_orders_allocation_id` index on `equity_orders(allocation_id)` — FK column with no supporting index
- Remove the unused `BIGSERIAL id` column from the `equity_predictions` `CREATE TABLE` definition; `(ticker, timestamp)` is the struct identity and TimescaleDB primary key
- fixes #901

## Context

Part of the Wave 1 work tracked in #898. No dependencies on other in-flight PRs. The inline `DO $do$` migration guards are intentionally left in place — they are scheduled for removal in PR 7 (Wave 3) once all deployments have run past them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Database query performance improved through index optimization

* **Chores**
  * Data export configurations refined for deterministic output
  * Core data structure adjustments for system reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->