### PR TITLE
[Wave 1, Part 3] Create `libraries/rust/` (internal crate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,3 +64,5 @@ This is a collection of guidelines and references.
 - Guard against division by zero when computing ratios or percentages from DataFrame aggregations
 - When Polars `Series.sum()` is used on a potentially empty or all-null series, handle the `None` return case
 - `devenv tasks run` supports prefix group execution: `checks:python` runs all `checks:python:*` subtasks
+- Prefer validated constructors with private fields over public struct literals — a value in scope should be proof of its
+  own validity, not a candidate for re-checking downstream

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,6 +2724,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "internal"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "num-traits",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "uuid",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5329,6 +5342,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rust_decimal",
  "rustls 0.23.40",
  "serde",
  "serde_json",
@@ -5339,6 +5353,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "uuid",
  "webpki-roots 0.26.11",
 ]
 
@@ -5412,6 +5427,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.6",
  "rsa",
+ "rust_decimal",
  "serde",
  "sha1 0.10.6",
  "sha2 0.10.9",
@@ -5420,6 +5436,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -5450,6 +5467,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "rand 0.8.6",
+ "rust_decimal",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -5458,6 +5476,7 @@ dependencies = [
  "stringprep",
  "thiserror",
  "tracing",
+ "uuid",
  "whoami",
 ]
 
@@ -5484,6 +5503,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["applications/data_manager"]
+members = ["applications/data_manager", "libraries/rust"]

--- a/libraries/rust/Cargo.toml
+++ b/libraries/rust/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "internal"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "internal"
+path = "src/lib.rs"
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+num-traits = "0.2"
+rust_decimal = { version = "1", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sqlx = { version = "0.8", default-features = false, features = [
+  "postgres",
+  "macros",
+  "uuid",
+  "chrono",
+  "rust_decimal",
+  "json",
+] }
+uuid = { version = "1", features = ["serde", "v4"] }

--- a/libraries/rust/src/freshness.rs
+++ b/libraries/rust/src/freshness.rs
@@ -1,0 +1,155 @@
+//! Data freshness wrapper enforcing staleness checks at the type level.
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Named staleness window for equity predictions.
+///
+/// Twenty hours covers the full trading day without gating valid same-day
+/// afternoon rebalances. The window is measured from the prediction batch's
+/// `created_at` timestamp.
+pub const PREDICTIONS_STALENESS_WINDOW_HOURS: i64 = 20;
+
+/// Error returned when constructing a `StalenessWindow` with a zero duration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ZeroDurationError;
+
+impl std::fmt::Display for ZeroDurationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "Staleness window duration must not be zero.")
+    }
+}
+
+impl std::error::Error for ZeroDurationError {}
+
+/// A validated non-zero duration representing the maximum age for fresh data.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct StalenessWindow(pub Duration);
+
+impl StalenessWindow {
+    /// Creates a new `StalenessWindow`, returning an error if `duration` is zero.
+    pub fn new(duration: Duration) -> Result<Self, ZeroDurationError> {
+        if duration.is_zero() {
+            return Err(ZeroDurationError);
+        }
+        Ok(StalenessWindow(duration))
+    }
+
+    /// Returns the staleness window for equity predictions (20 hours).
+    pub fn predictions() -> Self {
+        StalenessWindow(Duration::hours(PREDICTIONS_STALENESS_WINDOW_HOURS))
+    }
+}
+
+/// A timestamped data wrapper that enforces a staleness check on access.
+///
+/// `get()` returns `None` if the data is older than `maximum_age`, forcing
+/// callers to handle the stale-data case explicitly rather than silently
+/// trading on yesterday's predictions.
+#[derive(Debug, Clone)]
+pub struct Fresh<T> {
+    pub data: T,
+    pub fetched_at: DateTime<Utc>,
+    pub maximum_age: StalenessWindow,
+}
+
+impl<T> Fresh<T> {
+    /// Creates a new `Fresh` wrapper with the current time as `fetched_at`.
+    pub fn new(data: T, maximum_age: StalenessWindow) -> Self {
+        Fresh {
+            data,
+            fetched_at: Utc::now(),
+            maximum_age,
+        }
+    }
+
+    /// Returns a reference to the wrapped data if it is still within the
+    /// staleness window, or `None` if the data has expired.
+    pub fn get(&self) -> Option<&T> {
+        let age = Utc::now().signed_duration_since(self.fetched_at);
+        if age <= self.maximum_age.0 {
+            Some(&self.data)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    #[test]
+    fn test_staleness_window_new_rejects_zero() {
+        let error = StalenessWindow::new(Duration::zero()).unwrap_err();
+        assert_eq!(error, ZeroDurationError);
+    }
+
+    #[test]
+    fn test_staleness_window_new_accepts_positive() {
+        let window = StalenessWindow::new(Duration::hours(1)).unwrap();
+        assert_eq!(window.0, Duration::hours(1));
+    }
+
+    #[test]
+    fn test_staleness_window_predictions_returns_twenty_hours() {
+        let window = StalenessWindow::predictions();
+        assert_eq!(
+            window.0,
+            Duration::hours(PREDICTIONS_STALENESS_WINDOW_HOURS)
+        );
+        assert_eq!(window.0, Duration::hours(20));
+    }
+
+    #[test]
+    fn test_staleness_window_copy() {
+        let window = StalenessWindow::predictions();
+        let copy = window;
+        assert_eq!(window, copy);
+    }
+
+    #[test]
+    fn test_zero_duration_error_display() {
+        let error = ZeroDurationError;
+        let message = format!("{}", error);
+        assert!(message.contains("zero"));
+    }
+
+    #[test]
+    fn test_fresh_get_returns_data_when_within_window() {
+        let window = StalenessWindow::new(Duration::hours(1)).unwrap();
+        let fresh = Fresh::new("live data".to_string(), window);
+        assert_eq!(fresh.get(), Some(&"live data".to_string()));
+    }
+
+    #[test]
+    fn test_fresh_get_returns_none_when_stale() {
+        let window = StalenessWindow::new(Duration::hours(1)).unwrap();
+        let stale = Fresh {
+            data: "stale predictions".to_string(),
+            fetched_at: Utc::now() - Duration::hours(25),
+            maximum_age: window,
+        };
+        assert!(stale.get().is_none());
+    }
+
+    #[test]
+    fn test_fresh_get_returns_data_just_inside_window() {
+        let window = StalenessWindow::new(Duration::hours(20)).unwrap();
+        let fresh = Fresh {
+            data: 42_u32,
+            fetched_at: Utc::now() - Duration::hours(19),
+            maximum_age: window,
+        };
+        assert_eq!(fresh.get(), Some(&42_u32));
+    }
+
+    #[test]
+    fn test_fresh_clone() {
+        let window = StalenessWindow::new(Duration::hours(1)).unwrap();
+        let fresh = Fresh::new(100_u32, window);
+        let cloned = fresh.clone();
+        assert_eq!(cloned.data, 100_u32);
+    }
+}

--- a/libraries/rust/src/freshness.rs
+++ b/libraries/rust/src/freshness.rs
@@ -10,26 +10,26 @@ use serde::{Deserialize, Serialize};
 /// `created_at` timestamp.
 pub const PREDICTIONS_STALENESS_WINDOW_HOURS: i64 = 20;
 
-/// Error returned when constructing a `StalenessWindow` with a zero duration.
+/// Error returned when constructing a `StalenessWindow` with a non-positive duration.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ZeroDurationError;
 
 impl std::fmt::Display for ZeroDurationError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(formatter, "Staleness window duration must not be zero.")
+        write!(formatter, "Staleness window duration must be positive.")
     }
 }
 
 impl std::error::Error for ZeroDurationError {}
 
-/// A validated non-zero duration representing the maximum age for fresh data.
+/// A validated positive duration representing the maximum age for fresh data.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct StalenessWindow(pub Duration);
 
 impl StalenessWindow {
-    /// Creates a new `StalenessWindow`, returning an error if `duration` is zero.
+    /// Creates a new `StalenessWindow`, returning an error if `duration` is non-positive.
     pub fn new(duration: Duration) -> Result<Self, ZeroDurationError> {
-        if duration.is_zero() {
+        if duration <= Duration::zero() {
             return Err(ZeroDurationError);
         }
         Ok(StalenessWindow(duration))
@@ -37,7 +37,8 @@ impl StalenessWindow {
 
     /// Returns the staleness window for equity predictions (20 hours).
     pub fn predictions() -> Self {
-        StalenessWindow(Duration::hours(PREDICTIONS_STALENESS_WINDOW_HOURS))
+        StalenessWindow::new(Duration::hours(PREDICTIONS_STALENESS_WINDOW_HOURS))
+            .expect("PREDICTIONS_STALENESS_WINDOW_HOURS must be positive")
     }
 }
 
@@ -110,10 +111,16 @@ mod tests {
     }
 
     #[test]
+    fn test_staleness_window_new_rejects_negative() {
+        let error = StalenessWindow::new(Duration::hours(-1)).unwrap_err();
+        assert_eq!(error, ZeroDurationError);
+    }
+
+    #[test]
     fn test_zero_duration_error_display() {
         let error = ZeroDurationError;
         let message = format!("{}", error);
-        assert!(message.contains("zero"));
+        assert!(message.contains("positive"));
     }
 
     #[test]

--- a/libraries/rust/src/lib.rs
+++ b/libraries/rust/src/lib.rs
@@ -1,0 +1,14 @@
+//! Internal domain types shared across fund platform services.
+//!
+//! This crate is the schema authority: struct definitions are the single source
+//! of truth for what a data record looks like across PostgreSQL, S3, and
+//! application code.
+
+pub mod freshness;
+pub mod market;
+pub mod orders;
+pub mod portfolio;
+pub mod predictions;
+pub mod primitives;
+pub mod signals;
+pub mod trading;

--- a/libraries/rust/src/market.rs
+++ b/libraries/rust/src/market.rs
@@ -1,0 +1,165 @@
+//! Raw ingest record types from market data providers (Alpaca, Massive).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+/// Daily OHLCV equity bar record.
+///
+/// Timestamps are stored as `TIMESTAMPTZ` in PostgreSQL. The `inserted_at` field
+/// is set by the database on insert.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct EquityBar {
+    pub ticker: String,
+    /// UTC timestamp for the trading day this bar covers.
+    pub timestamp: DateTime<Utc>,
+    pub open_price: Option<f64>,
+    pub high_price: Option<f64>,
+    pub low_price: Option<f64>,
+    pub close_price: Option<f64>,
+    /// Whole share units. Fractional values from the source API are rounded on ingest.
+    pub volume: Option<i64>,
+    pub volume_weighted_average_price: Option<f64>,
+    pub transactions: Option<i64>,
+    /// Set by the database at insert time.
+    pub inserted_at: DateTime<Utc>,
+}
+
+/// Intraday bid/ask quote record from the Alpaca WebSocket stream.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct EquityQuote {
+    pub timestamp: DateTime<Utc>,
+    pub ticker: String,
+    pub bid_price: f64,
+    pub ask_price: f64,
+    pub bid_size: i32,
+    pub ask_size: i32,
+}
+
+/// Ticker metadata record seeded from the S3 details CSV.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct EquityDetails {
+    pub ticker: String,
+    pub sector: String,
+    pub industry: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    #[test]
+    fn test_equity_bar_construction_with_all_fields() {
+        let now = Utc::now();
+        let bar = EquityBar {
+            ticker: "AAPL".to_string(),
+            timestamp: now,
+            open_price: Some(150.0),
+            high_price: Some(155.0),
+            low_price: Some(149.0),
+            close_price: Some(153.0),
+            volume: Some(1_000_000),
+            volume_weighted_average_price: Some(152.0),
+            transactions: Some(50_000),
+            inserted_at: now,
+        };
+        assert_eq!(bar.ticker, "AAPL");
+        assert_eq!(bar.open_price, Some(150.0));
+        assert_eq!(bar.volume, Some(1_000_000));
+    }
+
+    #[test]
+    fn test_equity_bar_construction_with_nullable_fields() {
+        let now = Utc::now();
+        let bar = EquityBar {
+            ticker: "MSFT".to_string(),
+            timestamp: now,
+            open_price: None,
+            high_price: None,
+            low_price: None,
+            close_price: None,
+            volume: None,
+            volume_weighted_average_price: None,
+            transactions: None,
+            inserted_at: now,
+        };
+        assert_eq!(bar.ticker, "MSFT");
+        assert!(bar.open_price.is_none());
+    }
+
+    #[test]
+    fn test_equity_bar_clone() {
+        let now = Utc::now();
+        let bar = EquityBar {
+            ticker: "GOOG".to_string(),
+            timestamp: now,
+            open_price: Some(100.0),
+            high_price: Some(105.0),
+            low_price: Some(99.0),
+            close_price: Some(103.0),
+            volume: Some(500_000),
+            volume_weighted_average_price: Some(102.0),
+            transactions: Some(25_000),
+            inserted_at: now,
+        };
+        let cloned = bar.clone();
+        assert_eq!(cloned.ticker, "GOOG");
+        assert_eq!(cloned.close_price, Some(103.0));
+    }
+
+    #[test]
+    fn test_equity_quote_construction() {
+        let quote = EquityQuote {
+            timestamp: Utc::now(),
+            ticker: "AAPL".to_string(),
+            bid_price: 150.50,
+            ask_price: 150.55,
+            bid_size: 10,
+            ask_size: 5,
+        };
+        assert_eq!(quote.ticker, "AAPL");
+        assert_eq!(quote.bid_price, 150.50);
+        assert_eq!(quote.ask_price, 150.55);
+        assert_eq!(quote.bid_size, 10);
+        assert_eq!(quote.ask_size, 5);
+    }
+
+    #[test]
+    fn test_equity_quote_clone() {
+        let quote = EquityQuote {
+            timestamp: Utc::now(),
+            ticker: "MSFT".to_string(),
+            bid_price: 420.10,
+            ask_price: 420.20,
+            bid_size: 2,
+            ask_size: 4,
+        };
+        let cloned = quote.clone();
+        assert_eq!(cloned.ticker, "MSFT");
+        assert_eq!(cloned.bid_price, 420.10);
+    }
+
+    #[test]
+    fn test_equity_details_construction() {
+        let details = EquityDetails {
+            ticker: "AAPL".to_string(),
+            sector: "TECHNOLOGY".to_string(),
+            industry: "SOFTWARE".to_string(),
+        };
+        assert_eq!(details.ticker, "AAPL");
+        assert_eq!(details.sector, "TECHNOLOGY");
+        assert_eq!(details.industry, "SOFTWARE");
+    }
+
+    #[test]
+    fn test_equity_details_clone() {
+        let details = EquityDetails {
+            ticker: "NVDA".to_string(),
+            sector: "TECHNOLOGY".to_string(),
+            industry: "SEMICONDUCTORS".to_string(),
+        };
+        let cloned = details.clone();
+        assert_eq!(cloned.ticker, "NVDA");
+    }
+}

--- a/libraries/rust/src/orders.rs
+++ b/libraries/rust/src/orders.rs
@@ -182,7 +182,7 @@ impl PendingPair {
             quantity: long_fill.filled_quantity,
             order_type: self.long.order_type,
             limit_price: self.long.limit_price,
-            alpaca_order_id: long_fill.alpaca_order_id,
+            alpaca_order_id: self.long.alpaca_order_id,
             submitted_at: self.long.submitted_at,
             fill_price: Some(long_fill.fill_price),
             _state: PhantomData::<Filled>,
@@ -195,7 +195,7 @@ impl PendingPair {
             quantity: short_fill.filled_quantity,
             order_type: self.short.order_type,
             limit_price: self.short.limit_price,
-            alpaca_order_id: short_fill.alpaca_order_id,
+            alpaca_order_id: self.short.alpaca_order_id,
             submitted_at: self.short.submitted_at,
             fill_price: Some(short_fill.fill_price),
             _state: PhantomData::<Filled>,
@@ -303,6 +303,8 @@ mod tests {
         let pair = make_pending_pair("AAPL", "MSFT");
         let long_ticker = pair.long.ticker.clone();
         let short_ticker = pair.short.ticker.clone();
+        let long_alpaca_id = pair.long.alpaca_order_id.clone();
+        let short_alpaca_id = pair.short.alpaca_order_id.clone();
 
         let filled = pair
             .confirm(
@@ -319,6 +321,9 @@ mod tests {
         assert_eq!(filled.short_notional.0, Decimal::from(10_000));
         assert_eq!(filled.long_beta, 1.1);
         assert_eq!(filled.short_beta, 0.9);
+        // Broker order ID is preserved from the submitted order, not taken from the fill payload.
+        assert_eq!(filled.long.alpaca_order_id, long_alpaca_id);
+        assert_eq!(filled.short.alpaca_order_id, short_alpaca_id);
     }
 
     #[test]

--- a/libraries/rust/src/orders.rs
+++ b/libraries/rust/src/orders.rs
@@ -1,0 +1,382 @@
+//! Order lifecycle typestate machine.
+//!
+//! The typestate pattern encodes the order lifecycle as type parameters, making
+//! invalid state transitions compile errors. A `PendingPair` is consumed by
+//! `confirm()`, making a dangling long (short fails after long fills)
+//! unrepresentable at the type level.
+
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
+use uuid::Uuid;
+
+use crate::primitives::{Dollars, Shares};
+
+/// Sealing module: prevents external crates from implementing `OrderState`.
+mod private {
+    pub trait Sealed {}
+}
+
+/// Marker trait for valid order lifecycle states.
+///
+/// Sealed to prevent external state implementations.
+pub trait OrderState: private::Sealed {}
+
+/// Order has been submitted to the broker and is awaiting fill confirmation.
+#[derive(Debug, Clone)]
+pub struct Pending;
+
+/// Order has been confirmed as filled by the broker.
+#[derive(Debug, Clone)]
+pub struct Filled;
+
+/// Order was rejected by the broker.
+#[derive(Debug, Clone)]
+pub struct Rejected;
+
+/// Order was cancelled.
+#[derive(Debug, Clone)]
+pub struct Cancelled;
+
+impl private::Sealed for Pending {}
+impl private::Sealed for Filled {}
+impl private::Sealed for Rejected {}
+impl private::Sealed for Cancelled {}
+
+impl OrderState for Pending {}
+impl OrderState for Filled {}
+impl OrderState for Rejected {}
+impl OrderState for Cancelled {}
+
+/// A typed order at lifecycle state `S`.
+///
+/// The `fill_price` field is `None` for `Order<Pending>` and `Some` only after
+/// fill confirmation.
+#[derive(Debug, Clone)]
+pub struct Order<S: OrderState> {
+    pub id: Uuid,
+    pub ticker: String,
+    pub side: String,
+    pub quantity: Decimal,
+    pub order_type: String,
+    pub limit_price: Option<Decimal>,
+    pub alpaca_order_id: String,
+    pub submitted_at: DateTime<Utc>,
+    /// Set on fill confirmation; `None` for pending orders.
+    pub fill_price: Option<Decimal>,
+    _state: PhantomData<S>,
+}
+
+impl Order<Pending> {
+    /// Creates a new pending order after it has been submitted to the broker.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: Uuid,
+        ticker: String,
+        side: String,
+        quantity: Decimal,
+        order_type: String,
+        limit_price: Option<Decimal>,
+        alpaca_order_id: String,
+        submitted_at: DateTime<Utc>,
+    ) -> Self {
+        Order {
+            id,
+            ticker,
+            side,
+            quantity,
+            order_type,
+            limit_price,
+            alpaca_order_id,
+            submitted_at,
+            fill_price: None,
+            _state: PhantomData,
+        }
+    }
+}
+
+/// Represents a request to place an order with the broker, before submission.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrderRequest {
+    pub ticker: String,
+    pub side: String,
+    pub quantity: Shares,
+    pub order_type: String,
+    pub limit_price: Option<Dollars>,
+}
+
+/// Fill confirmation data returned by the broker for a specific order.
+#[derive(Debug, Clone)]
+pub struct FilledOrder {
+    pub alpaca_order_id: String,
+    pub fill_price: Decimal,
+    pub filled_quantity: Decimal,
+}
+
+/// Error returned when `PendingPair::confirm()` cannot produce a `FilledPair`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PairFillError {
+    /// The long leg did not fill.
+    LongNotFilled,
+    /// The short leg did not fill.
+    ShortNotFilled,
+}
+
+impl std::fmt::Display for PairFillError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PairFillError::LongNotFilled => write!(formatter, "Long order did not fill."),
+            PairFillError::ShortNotFilled => write!(formatter, "Short order did not fill."),
+        }
+    }
+}
+
+impl std::error::Error for PairFillError {}
+
+/// A pair of pending orders (long + short) awaiting fill confirmation.
+///
+/// Consuming this type via `confirm()` is the only way to obtain a `FilledPair`.
+/// If either leg fails to fill, the entire `PendingPair` is consumed and dropped,
+/// making a dangling long position unrepresentable.
+#[derive(Debug)]
+pub struct PendingPair {
+    pub long: Order<Pending>,
+    pub short: Order<Pending>,
+    pub long_beta: f64,
+    pub short_beta: f64,
+}
+
+/// A pair where both the long and short legs have been confirmed as filled.
+#[derive(Debug, Clone)]
+pub struct FilledPair {
+    pub long: Order<Filled>,
+    pub short: Order<Filled>,
+    pub long_beta: f64,
+    pub short_beta: f64,
+    pub long_notional: Dollars,
+    pub short_notional: Dollars,
+}
+
+impl PendingPair {
+    /// Confirms both legs of the pair as filled, consuming the `PendingPair`.
+    ///
+    /// Pass `Some(FilledOrder)` for each leg that filled. Pass `None` for a leg
+    /// that did not fill (rejected, cancelled, or timed out). If either leg is
+    /// `None`, the entire pair is dropped — a dangling long is unrepresentable.
+    pub fn confirm(
+        self,
+        long_fill: Option<FilledOrder>,
+        short_fill: Option<FilledOrder>,
+    ) -> Result<FilledPair, PairFillError> {
+        let long_fill = long_fill.ok_or(PairFillError::LongNotFilled)?;
+        let short_fill = short_fill.ok_or(PairFillError::ShortNotFilled)?;
+
+        let long_notional = Dollars(long_fill.fill_price * long_fill.filled_quantity);
+        let short_notional = Dollars(short_fill.fill_price * short_fill.filled_quantity);
+
+        let long = Order {
+            id: self.long.id,
+            ticker: self.long.ticker,
+            side: self.long.side,
+            quantity: long_fill.filled_quantity,
+            order_type: self.long.order_type,
+            limit_price: self.long.limit_price,
+            alpaca_order_id: long_fill.alpaca_order_id,
+            submitted_at: self.long.submitted_at,
+            fill_price: Some(long_fill.fill_price),
+            _state: PhantomData::<Filled>,
+        };
+
+        let short = Order {
+            id: self.short.id,
+            ticker: self.short.ticker,
+            side: self.short.side,
+            quantity: short_fill.filled_quantity,
+            order_type: self.short.order_type,
+            limit_price: self.short.limit_price,
+            alpaca_order_id: short_fill.alpaca_order_id,
+            submitted_at: self.short.submitted_at,
+            fill_price: Some(short_fill.fill_price),
+            _state: PhantomData::<Filled>,
+        };
+
+        Ok(FilledPair {
+            long,
+            short,
+            long_beta: self.long_beta,
+            short_beta: self.short_beta,
+            long_notional,
+            short_notional,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use rust_decimal::Decimal;
+    use uuid::Uuid;
+
+    fn make_pending_order(ticker: &str, side: &str) -> Order<Pending> {
+        Order::<Pending>::new(
+            Uuid::new_v4(),
+            ticker.to_string(),
+            side.to_string(),
+            Decimal::from(100),
+            "market".to_string(),
+            None,
+            format!("alpaca-{}-id", ticker.to_lowercase()),
+            Utc::now(),
+        )
+    }
+
+    fn make_filled_order(ticker: &str) -> FilledOrder {
+        FilledOrder {
+            alpaca_order_id: format!("fill-{}", ticker.to_lowercase()),
+            fill_price: Decimal::from(100),
+            filled_quantity: Decimal::from(100),
+        }
+    }
+
+    fn make_pending_pair(long_ticker: &str, short_ticker: &str) -> PendingPair {
+        PendingPair {
+            long: make_pending_order(long_ticker, "LONG"),
+            short: make_pending_order(short_ticker, "SHORT"),
+            long_beta: 1.1,
+            short_beta: 0.9,
+        }
+    }
+
+    #[test]
+    fn test_order_pending_new() {
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let order = Order::<Pending>::new(
+            id,
+            "AAPL".to_string(),
+            "LONG".to_string(),
+            Decimal::from(50),
+            "market".to_string(),
+            None,
+            "alpaca-order-1".to_string(),
+            now,
+        );
+        assert_eq!(order.ticker, "AAPL");
+        assert_eq!(order.side, "LONG");
+        assert_eq!(order.quantity, Decimal::from(50));
+        assert!(order.fill_price.is_none());
+        assert!(order.limit_price.is_none());
+    }
+
+    #[test]
+    fn test_order_pending_with_limit_price() {
+        let order = Order::<Pending>::new(
+            Uuid::new_v4(),
+            "MSFT".to_string(),
+            "SHORT".to_string(),
+            Decimal::from(25),
+            "limit".to_string(),
+            Some(Decimal::from(420)),
+            "alpaca-limit-1".to_string(),
+            Utc::now(),
+        );
+        assert_eq!(order.limit_price, Some(Decimal::from(420)));
+    }
+
+    #[test]
+    fn test_order_request_construction() {
+        let request = OrderRequest {
+            ticker: "NVDA".to_string(),
+            side: "LONG".to_string(),
+            quantity: Shares(Decimal::from(10)),
+            order_type: "market".to_string(),
+            limit_price: None,
+        };
+        assert_eq!(request.ticker, "NVDA");
+        assert_eq!(request.quantity.0, Decimal::from(10));
+    }
+
+    #[test]
+    fn test_pending_pair_confirm_both_filled() {
+        let pair = make_pending_pair("AAPL", "MSFT");
+        let long_ticker = pair.long.ticker.clone();
+        let short_ticker = pair.short.ticker.clone();
+
+        let filled = pair
+            .confirm(
+                Some(make_filled_order("AAPL")),
+                Some(make_filled_order("MSFT")),
+            )
+            .unwrap();
+
+        assert_eq!(filled.long.ticker, long_ticker);
+        assert_eq!(filled.short.ticker, short_ticker);
+        assert_eq!(filled.long.fill_price, Some(Decimal::from(100)));
+        assert_eq!(filled.short.fill_price, Some(Decimal::from(100)));
+        assert_eq!(filled.long_notional.0, Decimal::from(10_000));
+        assert_eq!(filled.short_notional.0, Decimal::from(10_000));
+        assert_eq!(filled.long_beta, 1.1);
+        assert_eq!(filled.short_beta, 0.9);
+    }
+
+    #[test]
+    fn test_pending_pair_confirm_long_not_filled() {
+        let pair = make_pending_pair("AAPL", "MSFT");
+        let error = pair
+            .confirm(None, Some(make_filled_order("MSFT")))
+            .unwrap_err();
+        assert_eq!(error, PairFillError::LongNotFilled);
+    }
+
+    #[test]
+    fn test_pending_pair_confirm_short_not_filled() {
+        let pair = make_pending_pair("AAPL", "MSFT");
+        let error = pair
+            .confirm(Some(make_filled_order("AAPL")), None)
+            .unwrap_err();
+        assert_eq!(error, PairFillError::ShortNotFilled);
+    }
+
+    #[test]
+    fn test_pending_pair_confirm_neither_filled() {
+        let pair = make_pending_pair("AAPL", "MSFT");
+        let error = pair.confirm(None, None).unwrap_err();
+        // Long is checked first
+        assert_eq!(error, PairFillError::LongNotFilled);
+    }
+
+    #[test]
+    fn test_pair_fill_error_display() {
+        assert!(format!("{}", PairFillError::LongNotFilled).contains("Long"));
+        assert!(format!("{}", PairFillError::ShortNotFilled).contains("Short"));
+    }
+
+    #[test]
+    fn test_filled_pair_clone() {
+        let pair = make_pending_pair("GOOG", "META");
+        let filled = pair
+            .confirm(
+                Some(make_filled_order("GOOG")),
+                Some(make_filled_order("META")),
+            )
+            .unwrap();
+        let cloned = filled.clone();
+        assert_eq!(cloned.long.ticker, "GOOG");
+        assert_eq!(cloned.short.ticker, "META");
+    }
+
+    #[test]
+    fn test_order_states_exist() {
+        // Verify all state types compile and have the expected Debug output
+        let _pending = Pending;
+        let _filled = Filled;
+        let _rejected = Rejected;
+        let _cancelled = Cancelled;
+        assert_eq!(format!("{:?}", Pending), "Pending");
+        assert_eq!(format!("{:?}", Filled), "Filled");
+        assert_eq!(format!("{:?}", Rejected), "Rejected");
+        assert_eq!(format!("{:?}", Cancelled), "Cancelled");
+    }
+}

--- a/libraries/rust/src/orders.rs
+++ b/libraries/rust/src/orders.rs
@@ -13,6 +13,26 @@ use uuid::Uuid;
 
 use crate::primitives::{Dollars, Shares};
 
+/// The side of an order: long (buy) or short (sell/borrow).
+///
+/// Serializes as `"LONG"` or `"SHORT"` to match the database `CHECK` constraint on
+/// `equity_allocations.side` and `equity_orders.side`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum OrderSide {
+    Long,
+    Short,
+}
+
+impl std::fmt::Display for OrderSide {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OrderSide::Long => write!(formatter, "LONG"),
+            OrderSide::Short => write!(formatter, "SHORT"),
+        }
+    }
+}
+
 /// Sealing module: prevents external crates from implementing `OrderState`.
 mod private {
     pub trait Sealed {}
@@ -57,7 +77,7 @@ impl OrderState for Cancelled {}
 pub struct Order<S: OrderState> {
     pub id: Uuid,
     pub ticker: String,
-    pub side: String,
+    pub side: OrderSide,
     pub quantity: Decimal,
     pub order_type: String,
     pub limit_price: Option<Decimal>,
@@ -74,7 +94,7 @@ impl Order<Pending> {
     pub fn new(
         id: Uuid,
         ticker: String,
-        side: String,
+        side: OrderSide,
         quantity: Decimal,
         order_type: String,
         limit_price: Option<Decimal>,
@@ -100,7 +120,7 @@ impl Order<Pending> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrderRequest {
     pub ticker: String,
-    pub side: String,
+    pub side: OrderSide,
     pub quantity: Shares,
     pub order_type: String,
     pub limit_price: Option<Dollars>,
@@ -219,11 +239,11 @@ mod tests {
     use rust_decimal::Decimal;
     use uuid::Uuid;
 
-    fn make_pending_order(ticker: &str, side: &str) -> Order<Pending> {
+    fn make_pending_order(ticker: &str, side: OrderSide) -> Order<Pending> {
         Order::<Pending>::new(
             Uuid::new_v4(),
             ticker.to_string(),
-            side.to_string(),
+            side,
             Decimal::from(100),
             "market".to_string(),
             None,
@@ -242,8 +262,8 @@ mod tests {
 
     fn make_pending_pair(long_ticker: &str, short_ticker: &str) -> PendingPair {
         PendingPair {
-            long: make_pending_order(long_ticker, "LONG"),
-            short: make_pending_order(short_ticker, "SHORT"),
+            long: make_pending_order(long_ticker, OrderSide::Long),
+            short: make_pending_order(short_ticker, OrderSide::Short),
             long_beta: 1.1,
             short_beta: 0.9,
         }
@@ -256,7 +276,7 @@ mod tests {
         let order = Order::<Pending>::new(
             id,
             "AAPL".to_string(),
-            "LONG".to_string(),
+            OrderSide::Long,
             Decimal::from(50),
             "market".to_string(),
             None,
@@ -264,7 +284,7 @@ mod tests {
             now,
         );
         assert_eq!(order.ticker, "AAPL");
-        assert_eq!(order.side, "LONG");
+        assert_eq!(order.side, OrderSide::Long);
         assert_eq!(order.quantity, Decimal::from(50));
         assert!(order.fill_price.is_none());
         assert!(order.limit_price.is_none());
@@ -275,7 +295,7 @@ mod tests {
         let order = Order::<Pending>::new(
             Uuid::new_v4(),
             "MSFT".to_string(),
-            "SHORT".to_string(),
+            OrderSide::Short,
             Decimal::from(25),
             "limit".to_string(),
             Some(Decimal::from(420)),
@@ -289,13 +309,13 @@ mod tests {
     fn test_order_request_construction() {
         let request = OrderRequest {
             ticker: "NVDA".to_string(),
-            side: "LONG".to_string(),
-            quantity: Shares(Decimal::from(10)),
+            side: OrderSide::Long,
+            quantity: Shares::new(Decimal::from(10)).unwrap(),
             order_type: "market".to_string(),
             limit_price: None,
         };
         assert_eq!(request.ticker, "NVDA");
-        assert_eq!(request.quantity.0, Decimal::from(10));
+        assert_eq!(request.quantity.value(), Decimal::from(10));
     }
 
     #[test]

--- a/libraries/rust/src/portfolio.rs
+++ b/libraries/rust/src/portfolio.rs
@@ -1,0 +1,415 @@
+//! Portfolio construction with validated invariants.
+//!
+//! The only way to obtain a `Portfolio` value is through `Portfolio::new()`.
+//! A `Portfolio` in scope is proof that all structural constraints passed at
+//! construction time, eliminating the need for defensive re-checks downstream.
+
+use std::collections::HashMap;
+use std::num::NonZeroU8;
+
+use num_traits::ToPrimitive;
+
+use crate::orders::FilledPair;
+use crate::primitives::Percent;
+
+/// Required minimum number of pairs in a valid portfolio.
+pub const REQUIRED_PAIRS: usize = 10;
+
+/// Maximum allowed fractional imbalance between long and short notional per pair.
+const DOLLAR_NEUTRAL_TOLERANCE: f64 = 0.05;
+
+/// Drawdown threshold as a percentage of capital; triggers a trading halt when breached.
+#[derive(Debug, Clone, Copy)]
+pub struct DrawdownThreshold(pub Percent);
+
+/// Maximum allowed notional fraction for any single ticker across the portfolio.
+#[derive(Debug, Clone, Copy)]
+pub struct ConcentrationCap(pub Percent);
+
+/// Minimum number of pairs required for a valid portfolio.
+#[derive(Debug, Clone, Copy)]
+pub struct MinimumPairs(pub NonZeroU8);
+
+/// Maximum allowed absolute deviation of net portfolio beta from zero.
+#[derive(Debug, Clone, Copy)]
+pub struct BetaTolerance(pub f64);
+
+/// Portfolio construction constraints.
+#[derive(Debug, Clone)]
+pub struct Constraints {
+    pub drawdown_threshold: DrawdownThreshold,
+    pub concentration_cap: ConcentrationCap,
+    pub minimum_pairs: MinimumPairs,
+    pub beta_tolerance: BetaTolerance,
+}
+
+/// Error returned when `Portfolio::new()` rejects the candidate pairs.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PortfolioError {
+    /// Fewer pairs than the minimum floor.
+    InsufficientPairs { required: usize, found: usize },
+    /// A single ticker's notional fraction exceeds the concentration cap.
+    ConcentrationCapExceeded { ticker: String },
+    /// A pair's long and short notionals deviate beyond the dollar-neutral tolerance.
+    DollarNeutralityViolation { pair_index: usize },
+    /// Net portfolio beta exceeds the configured tolerance.
+    BetaNeutralityViolation { net_beta: f64, tolerance: f64 },
+}
+
+impl std::fmt::Display for PortfolioError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PortfolioError::InsufficientPairs { required, found } => write!(
+                formatter,
+                "Portfolio has {found} pairs but requires {required}."
+            ),
+            PortfolioError::ConcentrationCapExceeded { ticker } => {
+                write!(formatter, "Ticker {ticker} exceeds the concentration cap.")
+            }
+            PortfolioError::DollarNeutralityViolation { pair_index } => write!(
+                formatter,
+                "Pair at index {pair_index} violates dollar neutrality."
+            ),
+            PortfolioError::BetaNeutralityViolation {
+                net_beta,
+                tolerance,
+            } => write!(
+                formatter,
+                "Net portfolio beta {net_beta:.4} exceeds tolerance {tolerance:.4}."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PortfolioError {}
+
+/// A validated portfolio of filled long-short pairs.
+///
+/// Constructed only via `::new()`. A value of this type is proof that:
+/// - the pair count meets or exceeds `minimum_pairs`
+/// - no single ticker exceeds `concentration_cap` of total gross notional
+/// - each pair is dollar-neutral within `DOLLAR_NEUTRAL_TOLERANCE`
+/// - net portfolio beta is within `beta_tolerance` of zero
+#[derive(Debug)]
+pub struct Portfolio(pub Vec<FilledPair>);
+
+impl Portfolio {
+    /// Constructs a `Portfolio`, enforcing all invariants from `constraints`.
+    ///
+    /// Returns `Err` with the first violated constraint.
+    pub fn new(pairs: Vec<FilledPair>, constraints: &Constraints) -> Result<Self, PortfolioError> {
+        let minimum = constraints.minimum_pairs.0.get() as usize;
+        if pairs.len() < minimum {
+            return Err(PortfolioError::InsufficientPairs {
+                required: minimum,
+                found: pairs.len(),
+            });
+        }
+
+        // Compute total gross notional as f64 for ratio checks.
+        let total_gross_notional: f64 = pairs
+            .iter()
+            .flat_map(|pair| [pair.long_notional.0, pair.short_notional.0])
+            .filter_map(|decimal| decimal.to_f64())
+            .sum();
+
+        if total_gross_notional > 0.0 {
+            // Concentration cap: no single ticker may exceed the cap fraction of total gross notional.
+            let mut ticker_notionals: HashMap<String, f64> = HashMap::new();
+            for pair in &pairs {
+                let long_notional = pair.long_notional.0.to_f64().unwrap_or(0.0);
+                let short_notional = pair.short_notional.0.to_f64().unwrap_or(0.0);
+                *ticker_notionals
+                    .entry(pair.long.ticker.clone())
+                    .or_insert(0.0) += long_notional;
+                *ticker_notionals
+                    .entry(pair.short.ticker.clone())
+                    .or_insert(0.0) += short_notional;
+            }
+
+            let cap = constraints.concentration_cap.0 .0;
+            for (ticker, notional) in &ticker_notionals {
+                let fraction = notional / total_gross_notional;
+                if fraction > cap {
+                    return Err(PortfolioError::ConcentrationCapExceeded {
+                        ticker: ticker.clone(),
+                    });
+                }
+            }
+        }
+
+        // Dollar-neutral pairing: each pair's long and short notionals must be within tolerance.
+        for (index, pair) in pairs.iter().enumerate() {
+            let long_notional = pair.long_notional.0.to_f64().unwrap_or(0.0);
+            let short_notional = pair.short_notional.0.to_f64().unwrap_or(0.0);
+            let average = (long_notional + short_notional) / 2.0;
+            if average > 0.0 {
+                let imbalance = (long_notional - short_notional).abs() / average;
+                if imbalance > DOLLAR_NEUTRAL_TOLERANCE {
+                    return Err(PortfolioError::DollarNeutralityViolation { pair_index: index });
+                }
+            }
+        }
+
+        // Beta neutrality: net portfolio beta must be within the configured tolerance.
+        let net_beta: f64 = pairs
+            .iter()
+            .map(|pair| pair.long_beta - pair.short_beta)
+            .sum();
+        let tolerance = constraints.beta_tolerance.0;
+        if net_beta.abs() > tolerance {
+            return Err(PortfolioError::BetaNeutralityViolation {
+                net_beta,
+                tolerance,
+            });
+        }
+
+        Ok(Portfolio(pairs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::orders::{FilledOrder, Order, PendingPair};
+    use chrono::Utc;
+    use rust_decimal::Decimal;
+    use uuid::Uuid;
+
+    fn make_constraints() -> Constraints {
+        Constraints {
+            drawdown_threshold: DrawdownThreshold(Percent::new(0.10).unwrap()),
+            concentration_cap: ConcentrationCap(Percent::new(0.20).unwrap()),
+            minimum_pairs: MinimumPairs(NonZeroU8::new(10).unwrap()),
+            beta_tolerance: BetaTolerance(0.1),
+        }
+    }
+
+    fn make_filled_pair(
+        long_ticker: &str,
+        short_ticker: &str,
+        long_beta: f64,
+        short_beta: f64,
+    ) -> FilledPair {
+        let long_order = Order::<crate::orders::Pending>::new(
+            Uuid::new_v4(),
+            long_ticker.to_string(),
+            "LONG".to_string(),
+            Decimal::from(100),
+            "market".to_string(),
+            None,
+            format!("alpaca-long-{}", long_ticker.to_lowercase()),
+            Utc::now(),
+        );
+        let short_order = Order::<crate::orders::Pending>::new(
+            Uuid::new_v4(),
+            short_ticker.to_string(),
+            "SHORT".to_string(),
+            Decimal::from(100),
+            "market".to_string(),
+            None,
+            format!("alpaca-short-{}", short_ticker.to_lowercase()),
+            Utc::now(),
+        );
+        let pending_pair = PendingPair {
+            long: long_order,
+            short: short_order,
+            long_beta,
+            short_beta,
+        };
+        // price=100, qty=100 → notional=10,000 per leg
+        pending_pair
+            .confirm(
+                Some(FilledOrder {
+                    alpaca_order_id: "fill-long".to_string(),
+                    fill_price: Decimal::from(100),
+                    filled_quantity: Decimal::from(100),
+                }),
+                Some(FilledOrder {
+                    alpaca_order_id: "fill-short".to_string(),
+                    fill_price: Decimal::from(100),
+                    filled_quantity: Decimal::from(100),
+                }),
+            )
+            .unwrap()
+    }
+
+    fn make_balanced_pairs(count: usize) -> Vec<FilledPair> {
+        let long_tickers = [
+            "AAPL", "MSFT", "GOOG", "AMZN", "NVDA", "META", "TSLA", "NFLX", "AMD", "INTC", "CRM",
+            "ORCL", "IBM", "QCOM", "TXN",
+        ];
+        let short_tickers = [
+            "WMT", "TGT", "KO", "PEP", "JNJ", "PFE", "MRK", "ABT", "UNH", "CVS", "WBA", "RAD",
+            "DG", "DLTR", "COST",
+        ];
+        (0..count)
+            .map(|index| {
+                make_filled_pair(
+                    long_tickers[index % long_tickers.len()],
+                    short_tickers[index % short_tickers.len()],
+                    1.0,
+                    1.0,
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_portfolio_new_accepts_valid_pairs() {
+        let pairs = make_balanced_pairs(10);
+        let constraints = make_constraints();
+        assert!(Portfolio::new(pairs, &constraints).is_ok());
+    }
+
+    #[test]
+    fn test_portfolio_new_rejects_insufficient_pairs() {
+        let pairs = make_balanced_pairs(9);
+        let constraints = make_constraints();
+        let error = Portfolio::new(pairs, &constraints).unwrap_err();
+        assert_eq!(
+            error,
+            PortfolioError::InsufficientPairs {
+                required: 10,
+                found: 9
+            }
+        );
+    }
+
+    #[test]
+    fn test_portfolio_new_rejects_empty_pairs() {
+        let constraints = make_constraints();
+        let error = Portfolio::new(vec![], &constraints).unwrap_err();
+        assert!(matches!(error, PortfolioError::InsufficientPairs { .. }));
+    }
+
+    #[test]
+    fn test_portfolio_new_rejects_concentration_cap_exceeded() {
+        // 10 pairs all with the same long ticker → exceeds 20% cap on a 20-ticker portfolio
+        let long_tickers = ["AAPL"; 10];
+        let short_tickers = [
+            "WMT", "TGT", "KO", "PEP", "JNJ", "PFE", "MRK", "ABT", "UNH", "CVS",
+        ];
+        let pairs: Vec<FilledPair> = (0..10)
+            .map(|index| make_filled_pair(long_tickers[index], short_tickers[index], 1.0, 1.0))
+            .collect();
+        let constraints = make_constraints();
+        let error = Portfolio::new(pairs, &constraints).unwrap_err();
+        assert!(matches!(
+            error,
+            PortfolioError::ConcentrationCapExceeded { ticker } if ticker == "AAPL"
+        ));
+    }
+
+    #[test]
+    fn test_portfolio_new_rejects_dollar_neutrality_violation() {
+        let long_order = Order::<crate::orders::Pending>::new(
+            Uuid::new_v4(),
+            "AAPL".to_string(),
+            "LONG".to_string(),
+            Decimal::from(100),
+            "market".to_string(),
+            None,
+            "alpaca-long-aapl".to_string(),
+            Utc::now(),
+        );
+        let short_order = Order::<crate::orders::Pending>::new(
+            Uuid::new_v4(),
+            "WMT".to_string(),
+            "SHORT".to_string(),
+            Decimal::from(100),
+            "market".to_string(),
+            None,
+            "alpaca-short-wmt".to_string(),
+            Utc::now(),
+        );
+        let pending = PendingPair {
+            long: long_order,
+            short: short_order,
+            long_beta: 1.0,
+            short_beta: 1.0,
+        };
+        // long: 100*100=10,000; short: 50*100=5,000 → imbalance ≫ 5%
+        let imbalanced = pending
+            .confirm(
+                Some(FilledOrder {
+                    alpaca_order_id: "fill-long".to_string(),
+                    fill_price: Decimal::from(100),
+                    filled_quantity: Decimal::from(100),
+                }),
+                Some(FilledOrder {
+                    alpaca_order_id: "fill-short".to_string(),
+                    fill_price: Decimal::from(50),
+                    filled_quantity: Decimal::from(100),
+                }),
+            )
+            .unwrap();
+
+        // Build 10 valid pairs plus the one imbalanced pair (which becomes index 0 after replacing)
+        let mut pairs = make_balanced_pairs(9);
+        pairs.insert(0, imbalanced);
+
+        let constraints = make_constraints();
+        let error = Portfolio::new(pairs, &constraints).unwrap_err();
+        assert!(matches!(
+            error,
+            PortfolioError::DollarNeutralityViolation { .. }
+        ));
+    }
+
+    #[test]
+    fn test_portfolio_new_rejects_beta_neutrality_violation() {
+        // All pairs have long_beta=2.0 and short_beta=1.0 → net_beta = 10*1.0 = 10.0 >> 0.1
+        let pairs: Vec<FilledPair> = (0..10)
+            .map(|index| {
+                let long_tickers = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"];
+                let short_tickers = ["K", "L", "M", "N", "O", "P", "Q", "R", "S", "T"];
+                make_filled_pair(long_tickers[index], short_tickers[index], 2.0, 1.0)
+            })
+            .collect();
+        let constraints = make_constraints();
+        let error = Portfolio::new(pairs, &constraints).unwrap_err();
+        assert!(matches!(
+            error,
+            PortfolioError::BetaNeutralityViolation { .. }
+        ));
+    }
+
+    #[test]
+    fn test_portfolio_error_display() {
+        let error = PortfolioError::InsufficientPairs {
+            required: 10,
+            found: 5,
+        };
+        assert!(format!("{}", error).contains("10"));
+        assert!(format!("{}", error).contains("5"));
+
+        let error = PortfolioError::ConcentrationCapExceeded {
+            ticker: "AAPL".to_string(),
+        };
+        assert!(format!("{}", error).contains("AAPL"));
+
+        let error = PortfolioError::DollarNeutralityViolation { pair_index: 3 };
+        assert!(format!("{}", error).contains("3"));
+
+        let error = PortfolioError::BetaNeutralityViolation {
+            net_beta: 0.5,
+            tolerance: 0.1,
+        };
+        assert!(format!("{}", error).contains("0.5000"));
+    }
+
+    #[test]
+    fn test_required_pairs_constant() {
+        assert_eq!(REQUIRED_PAIRS, 10);
+    }
+
+    #[test]
+    fn test_constraints_construction() {
+        let constraints = make_constraints();
+        assert_eq!(constraints.drawdown_threshold.0 .0, 0.10);
+        assert_eq!(constraints.concentration_cap.0 .0, 0.20);
+        assert_eq!(constraints.minimum_pairs.0.get(), 10);
+        assert_eq!(constraints.beta_tolerance.0, 0.1);
+    }
+}

--- a/libraries/rust/src/portfolio.rs
+++ b/libraries/rust/src/portfolio.rs
@@ -178,7 +178,7 @@ impl Portfolio {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::orders::{FilledOrder, Order, PendingPair};
+    use crate::orders::{FilledOrder, Order, OrderSide, PendingPair};
     use chrono::Utc;
     use rust_decimal::Decimal;
     use uuid::Uuid;
@@ -201,7 +201,7 @@ mod tests {
         let long_order = Order::<crate::orders::Pending>::new(
             Uuid::new_v4(),
             long_ticker.to_string(),
-            "LONG".to_string(),
+            OrderSide::Long,
             Decimal::from(100),
             "market".to_string(),
             None,
@@ -211,7 +211,7 @@ mod tests {
         let short_order = Order::<crate::orders::Pending>::new(
             Uuid::new_v4(),
             short_ticker.to_string(),
-            "SHORT".to_string(),
+            OrderSide::Short,
             Decimal::from(100),
             "market".to_string(),
             None,
@@ -313,7 +313,7 @@ mod tests {
         let long_order = Order::<crate::orders::Pending>::new(
             Uuid::new_v4(),
             "AAPL".to_string(),
-            "LONG".to_string(),
+            OrderSide::Long,
             Decimal::from(100),
             "market".to_string(),
             None,
@@ -323,7 +323,7 @@ mod tests {
         let short_order = Order::<crate::orders::Pending>::new(
             Uuid::new_v4(),
             "WMT".to_string(),
-            "SHORT".to_string(),
+            OrderSide::Short,
             Decimal::from(100),
             "market".to_string(),
             None,

--- a/libraries/rust/src/portfolio.rs
+++ b/libraries/rust/src/portfolio.rs
@@ -90,10 +90,17 @@ impl std::error::Error for PortfolioError {}
 /// - no single ticker exceeds `concentration_cap` of total gross notional
 /// - each pair is dollar-neutral within `DOLLAR_NEUTRAL_TOLERANCE`
 /// - net portfolio beta is within `beta_tolerance` of zero
+///
+/// The inner field is private; use `pairs()` to access the validated pairs.
 #[derive(Debug)]
-pub struct Portfolio(pub Vec<FilledPair>);
+pub struct Portfolio(Vec<FilledPair>);
 
 impl Portfolio {
+    /// Returns the validated pairs in this portfolio.
+    pub fn pairs(&self) -> &[FilledPair] {
+        &self.0
+    }
+
     /// Constructs a `Portfolio`, enforcing all invariants from `constraints`.
     ///
     /// Returns `Err` with the first violated constraint.
@@ -110,7 +117,7 @@ impl Portfolio {
         let total_gross_notional: f64 = pairs
             .iter()
             .flat_map(|pair| [pair.long_notional.0, pair.short_notional.0])
-            .filter_map(|decimal| decimal.to_f64())
+            .map(|decimal| decimal.to_f64().unwrap_or(0.0))
             .sum();
 
         if total_gross_notional > 0.0 {
@@ -127,7 +134,7 @@ impl Portfolio {
                     .or_insert(0.0) += short_notional;
             }
 
-            let cap = constraints.concentration_cap.0 .0;
+            let cap = constraints.concentration_cap.0.value();
             for (ticker, notional) in &ticker_notionals {
                 let fraction = notional / total_gross_notional;
                 if fraction > cap {
@@ -407,8 +414,8 @@ mod tests {
     #[test]
     fn test_constraints_construction() {
         let constraints = make_constraints();
-        assert_eq!(constraints.drawdown_threshold.0 .0, 0.10);
-        assert_eq!(constraints.concentration_cap.0 .0, 0.20);
+        assert_eq!(constraints.drawdown_threshold.0.value(), 0.10);
+        assert_eq!(constraints.concentration_cap.0.value(), 0.20);
         assert_eq!(constraints.minimum_pairs.0.get(), 10);
         assert_eq!(constraints.beta_tolerance.0, 0.1);
     }

--- a/libraries/rust/src/predictions.rs
+++ b/libraries/rust/src/predictions.rs
@@ -1,0 +1,163 @@
+//! Model output and training run record types.
+
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::FromRow;
+use uuid::Uuid;
+
+/// A single model prediction row for one ticker at one timestamp.
+///
+/// Identity is `(ticker, timestamp)` — matches the TimescaleDB primary key.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct EquityPrediction {
+    pub correlation_id: Uuid,
+    pub model_run_id: String,
+    pub ticker: String,
+    /// UTC timestamp for the day this prediction targets.
+    pub timestamp: DateTime<Utc>,
+    pub quantile_10: f64,
+    pub quantile_50: f64,
+    pub quantile_90: f64,
+    /// Set by the database at insert time.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Training run metadata and evaluation metrics.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct ModelRun {
+    pub id: i64,
+    pub run_id: String,
+    pub model_name: String,
+    pub artifact_key: Option<String>,
+    pub training_data_key: Option<String>,
+    pub start_date: Option<NaiveDate>,
+    pub end_date: Option<NaiveDate>,
+    pub lookback_days: Option<i32>,
+    pub status: String,
+    pub continuous_ranked_probability_score: Option<f64>,
+    pub directional_accuracy: Option<f64>,
+    pub quantile_coverage: Option<f64>,
+    pub drift_status: Option<String>,
+    /// Per-stage prediction counts as a JSON object.
+    pub stage_counts: Option<Value>,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{NaiveDate, Utc};
+    use uuid::Uuid;
+
+    #[test]
+    fn test_equity_prediction_construction() {
+        let prediction = EquityPrediction {
+            correlation_id: Uuid::new_v4(),
+            model_run_id: "run-abc123".to_string(),
+            ticker: "AAPL".to_string(),
+            timestamp: Utc::now(),
+            quantile_10: -0.02,
+            quantile_50: 0.01,
+            quantile_90: 0.04,
+            created_at: Utc::now(),
+        };
+        assert_eq!(prediction.ticker, "AAPL");
+        assert_eq!(prediction.model_run_id, "run-abc123");
+        assert!(prediction.quantile_10 < prediction.quantile_50);
+        assert!(prediction.quantile_50 < prediction.quantile_90);
+    }
+
+    #[test]
+    fn test_equity_prediction_clone() {
+        let prediction = EquityPrediction {
+            correlation_id: Uuid::new_v4(),
+            model_run_id: "run-def456".to_string(),
+            ticker: "MSFT".to_string(),
+            timestamp: Utc::now(),
+            quantile_10: -0.01,
+            quantile_50: 0.005,
+            quantile_90: 0.02,
+            created_at: Utc::now(),
+        };
+        let cloned = prediction.clone();
+        assert_eq!(cloned.ticker, "MSFT");
+        assert_eq!(cloned.quantile_50, 0.005);
+    }
+
+    #[test]
+    fn test_model_run_construction_minimal() {
+        let model_run = ModelRun {
+            id: 1,
+            run_id: "run-tide-001".to_string(),
+            model_name: "tide".to_string(),
+            artifact_key: None,
+            training_data_key: None,
+            start_date: None,
+            end_date: None,
+            lookback_days: None,
+            status: "started".to_string(),
+            continuous_ranked_probability_score: None,
+            directional_accuracy: None,
+            quantile_coverage: None,
+            drift_status: None,
+            stage_counts: None,
+            started_at: Utc::now(),
+            completed_at: None,
+        };
+        assert_eq!(model_run.model_name, "tide");
+        assert_eq!(model_run.status, "started");
+    }
+
+    #[test]
+    fn test_model_run_construction_completed() {
+        let model_run = ModelRun {
+            id: 2,
+            run_id: "run-tide-002".to_string(),
+            model_name: "tide".to_string(),
+            artifact_key: Some("models/tide/weights.safetensors".to_string()),
+            training_data_key: Some("data/equity/bars/training.parquet".to_string()),
+            start_date: Some(NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()),
+            end_date: Some(NaiveDate::from_ymd_opt(2026, 5, 1).unwrap()),
+            lookback_days: Some(70),
+            status: "completed".to_string(),
+            continuous_ranked_probability_score: Some(0.42),
+            directional_accuracy: Some(0.55),
+            quantile_coverage: Some(0.88),
+            drift_status: Some("stable".to_string()),
+            stage_counts: Some(serde_json::json!({"stage_1": 100, "stage_2": 200})),
+            started_at: Utc::now(),
+            completed_at: Some(Utc::now()),
+        };
+        assert_eq!(model_run.status, "completed");
+        assert_eq!(model_run.lookback_days, Some(70));
+        assert!(model_run.continuous_ranked_probability_score.is_some());
+        assert!(model_run.stage_counts.is_some());
+    }
+
+    #[test]
+    fn test_model_run_clone() {
+        let model_run = ModelRun {
+            id: 3,
+            run_id: "run-tide-003".to_string(),
+            model_name: "tide".to_string(),
+            artifact_key: None,
+            training_data_key: None,
+            start_date: None,
+            end_date: None,
+            lookback_days: Some(70),
+            status: "failed".to_string(),
+            continuous_ranked_probability_score: None,
+            directional_accuracy: None,
+            quantile_coverage: None,
+            drift_status: None,
+            stage_counts: None,
+            started_at: Utc::now(),
+            completed_at: None,
+        };
+        let cloned = model_run.clone();
+        assert_eq!(cloned.run_id, "run-tide-003");
+        assert_eq!(cloned.status, "failed");
+    }
+}

--- a/libraries/rust/src/primitives.rs
+++ b/libraries/rust/src/primitives.rs
@@ -26,9 +26,46 @@ impl std::fmt::Display for RangeError {
 
 impl std::error::Error for RangeError {}
 
-/// Whole share count.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Shares(pub Decimal);
+/// Error returned when constructing a `Shares` with a non-positive quantity.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SharesError;
+
+impl std::fmt::Display for SharesError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "Share quantity must be positive.")
+    }
+}
+
+impl std::error::Error for SharesError {}
+
+/// Whole share count (always positive).
+///
+/// The inner field is private; use `Shares::new()` to construct and `value()` to read.
+/// Deserialization validates positivity, preventing zero or negative quantities from serde.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Shares(Decimal);
+
+impl Shares {
+    /// Creates a new `Shares`, returning an error if `quantity` is not positive.
+    pub fn new(quantity: Decimal) -> Result<Self, SharesError> {
+        if quantity <= Decimal::ZERO {
+            return Err(SharesError);
+        }
+        Ok(Shares(quantity))
+    }
+
+    /// Returns the inner `Decimal` value.
+    pub fn value(self) -> Decimal {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for Shares {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = <Decimal as Deserialize<'de>>::deserialize(deserializer)?;
+        Shares::new(raw).map_err(de::Error::custom)
+    }
+}
 
 /// Dollar amount.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -148,9 +185,26 @@ mod tests {
     }
 
     #[test]
-    fn test_shares_construction() {
-        let shares = Shares(Decimal::from(100));
-        assert_eq!(shares.0, Decimal::from(100));
+    fn test_shares_new_accepts_positive() {
+        let shares = Shares::new(Decimal::from(100)).unwrap();
+        assert_eq!(shares.value(), Decimal::from(100));
+    }
+
+    #[test]
+    fn test_shares_new_rejects_zero() {
+        let error = Shares::new(Decimal::ZERO).unwrap_err();
+        assert_eq!(error, SharesError);
+    }
+
+    #[test]
+    fn test_shares_new_rejects_negative() {
+        let error = Shares::new(Decimal::from(-1)).unwrap_err();
+        assert_eq!(error, SharesError);
+    }
+
+    #[test]
+    fn test_shares_error_display() {
+        assert!(format!("{}", SharesError).contains("positive"));
     }
 
     #[test]

--- a/libraries/rust/src/primitives.rs
+++ b/libraries/rust/src/primitives.rs
@@ -1,0 +1,170 @@
+//! Zero-cost financial primitive newtypes.
+//!
+//! These types wrap standard Rust primitives to make unit-mismatch bugs compile
+//! errors rather than silent runtime surprises.
+
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+/// Error returned when constructing a validated primitive with an out-of-range value.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RangeError {
+    pub value: f64,
+    pub minimum: f64,
+    pub maximum: f64,
+}
+
+impl std::fmt::Display for RangeError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Value {} is not in range [{}, {}].",
+            self.value, self.minimum, self.maximum
+        )
+    }
+}
+
+impl std::error::Error for RangeError {}
+
+/// Whole share count.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Shares(pub Decimal);
+
+/// Dollar amount.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Dollars(pub Decimal);
+
+/// Percentage in the range `[0.0, 1.0]`.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct Percent(pub f64);
+
+impl Percent {
+    /// Creates a new `Percent`, returning an error if `value` is outside `[0.0, 1.0]`.
+    pub fn new(value: f64) -> Result<Self, RangeError> {
+        if !(0.0..=1.0).contains(&value) {
+            return Err(RangeError {
+                value,
+                minimum: 0.0,
+                maximum: 1.0,
+            });
+        }
+        Ok(Percent(value))
+    }
+}
+
+/// Long position size (always a positive magnitude).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Long(pub Decimal);
+
+/// Short position size (stored as a positive magnitude).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Short(pub Decimal);
+
+/// Notional dollar amount.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Notional(pub Dollars);
+
+/// Portfolio allocation expressed as a fraction of total capital.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Allocation(pub Percent);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_percent_new_accepts_zero() {
+        let percent = Percent::new(0.0).unwrap();
+        assert_eq!(percent.0, 0.0);
+    }
+
+    #[test]
+    fn test_percent_new_accepts_one() {
+        let percent = Percent::new(1.0).unwrap();
+        assert_eq!(percent.0, 1.0);
+    }
+
+    #[test]
+    fn test_percent_new_accepts_midpoint() {
+        let percent = Percent::new(0.5).unwrap();
+        assert_eq!(percent.0, 0.5);
+    }
+
+    #[test]
+    fn test_percent_new_rejects_negative() {
+        let error = Percent::new(-0.1).unwrap_err();
+        assert_eq!(error.value, -0.1);
+        assert_eq!(error.minimum, 0.0);
+        assert_eq!(error.maximum, 1.0);
+    }
+
+    #[test]
+    fn test_percent_new_rejects_above_one() {
+        let error = Percent::new(1.1).unwrap_err();
+        assert_eq!(error.value, 1.1);
+    }
+
+    #[test]
+    fn test_range_error_display() {
+        let error = RangeError {
+            value: 1.5,
+            minimum: 0.0,
+            maximum: 1.0,
+        };
+        let message = format!("{}", error);
+        assert!(message.contains("1.5"));
+        assert!(message.contains("0"));
+        assert!(message.contains("1"));
+    }
+
+    #[test]
+    fn test_percent_ordering() {
+        let low = Percent::new(0.2).unwrap();
+        let high = Percent::new(0.8).unwrap();
+        assert!(low < high);
+        assert!(high > low);
+    }
+
+    #[test]
+    fn test_percent_copy() {
+        let original = Percent::new(0.5).unwrap();
+        let copy = original;
+        assert_eq!(original, copy);
+    }
+
+    #[test]
+    fn test_shares_construction() {
+        let shares = Shares(Decimal::from(100));
+        assert_eq!(shares.0, Decimal::from(100));
+    }
+
+    #[test]
+    fn test_dollars_construction() {
+        let dollars = Dollars(Decimal::from(5000));
+        assert_eq!(dollars.0, Decimal::from(5000));
+    }
+
+    #[test]
+    fn test_long_construction() {
+        let long = Long(Decimal::from(50));
+        assert_eq!(long.0, Decimal::from(50));
+    }
+
+    #[test]
+    fn test_short_construction() {
+        let short = Short(Decimal::from(50));
+        assert_eq!(short.0, Decimal::from(50));
+    }
+
+    #[test]
+    fn test_notional_construction() {
+        let notional = Notional(Dollars(Decimal::from(10_000)));
+        assert_eq!(notional.0 .0, Decimal::from(10_000));
+    }
+
+    #[test]
+    fn test_allocation_construction() {
+        let allocation = Allocation(Percent::new(0.25).unwrap());
+        assert_eq!(allocation.0 .0, 0.25);
+    }
+}

--- a/libraries/rust/src/primitives.rs
+++ b/libraries/rust/src/primitives.rs
@@ -4,7 +4,7 @@
 //! errors rather than silent runtime surprises.
 
 use rust_decimal::Decimal;
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
 
 /// Error returned when constructing a validated primitive with an out-of-range value.
 #[derive(Debug, Clone, PartialEq)]
@@ -35,8 +35,11 @@ pub struct Shares(pub Decimal);
 pub struct Dollars(pub Decimal);
 
 /// Percentage in the range `[0.0, 1.0]`.
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
-pub struct Percent(pub f64);
+///
+/// The inner field is private; use `Percent::new()` to construct and `value()` to read.
+/// Deserialization validates the range, preventing out-of-range values from serde.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize)]
+pub struct Percent(f64);
 
 impl Percent {
     /// Creates a new `Percent`, returning an error if `value` is outside `[0.0, 1.0]`.
@@ -49,6 +52,18 @@ impl Percent {
             });
         }
         Ok(Percent(value))
+    }
+
+    /// Returns the inner `f64` value.
+    pub fn value(self) -> f64 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for Percent {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = f64::deserialize(deserializer)?;
+        Percent::new(raw).map_err(de::Error::custom)
     }
 }
 
@@ -75,7 +90,7 @@ mod tests {
     #[test]
     fn test_percent_new_accepts_zero() {
         let percent = Percent::new(0.0).unwrap();
-        assert_eq!(percent.0, 0.0);
+        assert_eq!(percent.value(), 0.0);
     }
 
     #[test]
@@ -165,6 +180,6 @@ mod tests {
     #[test]
     fn test_allocation_construction() {
         let allocation = Allocation(Percent::new(0.25).unwrap());
-        assert_eq!(allocation.0 .0, 0.25);
+        assert_eq!(allocation.0.value(), 0.25);
     }
 }

--- a/libraries/rust/src/signals.rs
+++ b/libraries/rust/src/signals.rs
@@ -1,0 +1,287 @@
+//! Regime classification and signal gating types.
+
+use crate::primitives::Percent;
+use serde::{Deserialize, Serialize};
+
+/// Regime state controlling position exposure scaling.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum Regime {
+    /// Momentum-driven market. Position exposure is scaled to 0.5x.
+    Trending,
+    /// Mean-reverting market. Position exposure is scaled to 1.0x.
+    MeanReversion,
+}
+
+impl Regime {
+    /// Returns the position size exposure multiplier for this regime.
+    ///
+    /// `Trending` halves exposure to reduce risk during momentum markets.
+    /// `MeanReversion` uses full exposure when the stat-arb signal is strong.
+    pub fn exposure_factor(&self) -> f64 {
+        match self {
+            Regime::Trending => 0.5,
+            Regime::MeanReversion => 1.0,
+        }
+    }
+}
+
+/// Output of the regime classifier.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegimeResult {
+    pub state: Regime,
+    /// Classifier confidence in the regime state, in `[0.0, 1.0]`.
+    pub confidence: Percent,
+}
+
+/// Minimum regime confidence required for signal processing to proceed.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ConfidenceFloor(pub Percent);
+
+/// A single equity signal from the ensemble model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Signal {
+    pub ticker: String,
+    /// Ensemble confidence in this signal, in `[0.0, 1.0]`.
+    pub confidence: Percent,
+    /// Predicted price return for the next period.
+    pub predicted_return: f64,
+}
+
+/// Error returned when `GatedSignals::new()` rejects the input.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SignalGateError {
+    /// Signals vector was empty.
+    EmptySignals,
+    /// Regime confidence is below the configured floor.
+    BelowConfidenceFloor { confidence: f64, floor: f64 },
+    /// All signals have identical predicted returns, producing a degenerate
+    /// quantile spread where normalization would assign uniform confidence.
+    DegenerateQuantileSpread,
+}
+
+impl std::fmt::Display for SignalGateError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SignalGateError::EmptySignals => write!(formatter, "Signals vector is empty."),
+            SignalGateError::BelowConfidenceFloor { confidence, floor } => write!(
+                formatter,
+                "Regime confidence {:.4} is below floor {:.4}.",
+                confidence, floor
+            ),
+            SignalGateError::DegenerateQuantileSpread => write!(
+                formatter,
+                "All predicted returns are identical; quantile spread is degenerate."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SignalGateError {}
+
+/// Signals that have passed all gate checks.
+///
+/// Constructed only via `::new()`, which enforces:
+/// - non-empty signal list
+/// - regime confidence above the configured floor
+/// - non-degenerate quantile spread across predicted returns
+#[derive(Debug)]
+pub struct GatedSignals {
+    pub signals: Vec<Signal>,
+    pub regime: Regime,
+    pub confidence: Percent,
+}
+
+impl GatedSignals {
+    /// Constructs `GatedSignals` after validating all gate invariants.
+    ///
+    /// Returns `Err` if signals is empty, regime confidence is below `floor`,
+    /// or all signals have identical `predicted_return` values.
+    pub fn new(
+        signals: Vec<Signal>,
+        regime_result: RegimeResult,
+        floor: ConfidenceFloor,
+    ) -> Result<Self, SignalGateError> {
+        if signals.is_empty() {
+            return Err(SignalGateError::EmptySignals);
+        }
+
+        if regime_result.confidence.0 < floor.0 .0 {
+            return Err(SignalGateError::BelowConfidenceFloor {
+                confidence: regime_result.confidence.0,
+                floor: floor.0 .0,
+            });
+        }
+
+        let maximum_return = signals
+            .iter()
+            .map(|signal| signal.predicted_return)
+            .fold(f64::NEG_INFINITY, f64::max);
+        let minimum_return = signals
+            .iter()
+            .map(|signal| signal.predicted_return)
+            .fold(f64::INFINITY, f64::min);
+
+        if (maximum_return - minimum_return).abs() <= f64::EPSILON {
+            return Err(SignalGateError::DegenerateQuantileSpread);
+        }
+
+        Ok(GatedSignals {
+            signals,
+            regime: regime_result.state,
+            confidence: regime_result.confidence,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::Percent;
+
+    fn make_regime_result(confidence: f64) -> RegimeResult {
+        RegimeResult {
+            state: Regime::MeanReversion,
+            confidence: Percent::new(confidence).unwrap(),
+        }
+    }
+
+    fn make_signals(returns: &[f64]) -> Vec<Signal> {
+        returns
+            .iter()
+            .enumerate()
+            .map(|(index, &predicted_return)| Signal {
+                ticker: format!("TICK{}", index),
+                confidence: Percent::new(0.8).unwrap(),
+                predicted_return,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_regime_trending_exposure_factor() {
+        assert_eq!(Regime::Trending.exposure_factor(), 0.5);
+    }
+
+    #[test]
+    fn test_regime_mean_reversion_exposure_factor() {
+        assert_eq!(Regime::MeanReversion.exposure_factor(), 1.0);
+    }
+
+    #[test]
+    fn test_regime_clone_and_eq() {
+        let regime = Regime::Trending;
+        let cloned = regime.clone();
+        assert_eq!(regime, cloned);
+    }
+
+    #[test]
+    fn test_gated_signals_new_rejects_empty_signals() {
+        let error = GatedSignals::new(
+            vec![],
+            make_regime_result(0.8),
+            ConfidenceFloor(Percent::new(0.5).unwrap()),
+        )
+        .unwrap_err();
+        assert_eq!(error, SignalGateError::EmptySignals);
+    }
+
+    #[test]
+    fn test_gated_signals_new_rejects_below_confidence_floor() {
+        let signals = make_signals(&[0.01, 0.02, 0.03]);
+        let error = GatedSignals::new(
+            signals,
+            make_regime_result(0.3),
+            ConfidenceFloor(Percent::new(0.5).unwrap()),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            SignalGateError::BelowConfidenceFloor {
+                confidence: 0.3,
+                floor: 0.5
+            }
+        );
+    }
+
+    #[test]
+    fn test_gated_signals_new_rejects_degenerate_spread() {
+        let signals = make_signals(&[0.01, 0.01, 0.01]);
+        let error = GatedSignals::new(
+            signals,
+            make_regime_result(0.8),
+            ConfidenceFloor(Percent::new(0.5).unwrap()),
+        )
+        .unwrap_err();
+        assert_eq!(error, SignalGateError::DegenerateQuantileSpread);
+    }
+
+    #[test]
+    fn test_gated_signals_new_rejects_all_zero_returns() {
+        let signals = make_signals(&[0.0, 0.0, 0.0, 0.0, 0.0]);
+        let error = GatedSignals::new(
+            signals,
+            make_regime_result(0.9),
+            ConfidenceFloor(Percent::new(0.5).unwrap()),
+        )
+        .unwrap_err();
+        assert_eq!(error, SignalGateError::DegenerateQuantileSpread);
+    }
+
+    #[test]
+    fn test_gated_signals_new_accepts_valid_input() {
+        let signals = make_signals(&[-0.02, 0.0, 0.01, 0.03, 0.05]);
+        let gated = GatedSignals::new(
+            signals,
+            make_regime_result(0.8),
+            ConfidenceFloor(Percent::new(0.5).unwrap()),
+        )
+        .unwrap();
+        assert_eq!(gated.signals.len(), 5);
+        assert_eq!(gated.regime, Regime::MeanReversion);
+        assert_eq!(gated.confidence.0, 0.8);
+    }
+
+    #[test]
+    fn test_gated_signals_accepts_confidence_equal_to_floor() {
+        let signals = make_signals(&[0.01, 0.02, 0.03]);
+        let gated = GatedSignals::new(
+            signals,
+            make_regime_result(0.5),
+            ConfidenceFloor(Percent::new(0.5).unwrap()),
+        )
+        .unwrap();
+        assert_eq!(gated.confidence.0, 0.5);
+    }
+
+    #[test]
+    fn test_signal_gate_error_display() {
+        let error = SignalGateError::EmptySignals;
+        assert!(format!("{}", error).contains("empty"));
+
+        let error = SignalGateError::BelowConfidenceFloor {
+            confidence: 0.3,
+            floor: 0.5,
+        };
+        assert!(format!("{}", error).contains("0.3000"));
+
+        let error = SignalGateError::DegenerateQuantileSpread;
+        assert!(format!("{}", error).contains("degenerate"));
+    }
+
+    #[test]
+    fn test_confidence_floor_construction() {
+        let floor = ConfidenceFloor(Percent::new(0.6).unwrap());
+        assert_eq!(floor.0 .0, 0.6);
+    }
+
+    #[test]
+    fn test_regime_result_construction() {
+        let result = RegimeResult {
+            state: Regime::Trending,
+            confidence: Percent::new(0.75).unwrap(),
+        };
+        assert_eq!(result.state, Regime::Trending);
+        assert_eq!(result.confidence.0, 0.75);
+    }
+}

--- a/libraries/rust/src/signals.rs
+++ b/libraries/rust/src/signals.rs
@@ -57,6 +57,8 @@ pub enum SignalGateError {
     /// All signals have identical predicted returns, producing a degenerate
     /// quantile spread where normalization would assign uniform confidence.
     DegenerateQuantileSpread,
+    /// At least one signal has a non-finite (`NaN` or `±inf`) predicted return.
+    NonFiniteReturn,
 }
 
 impl std::fmt::Display for SignalGateError {
@@ -72,6 +74,10 @@ impl std::fmt::Display for SignalGateError {
                 formatter,
                 "All predicted returns are identical; quantile spread is degenerate."
             ),
+            SignalGateError::NonFiniteReturn => write!(
+                formatter,
+                "One or more signals contain a non-finite predicted return."
+            ),
         }
     }
 }
@@ -83,19 +89,23 @@ impl std::error::Error for SignalGateError {}
 /// Constructed only via `::new()`, which enforces:
 /// - non-empty signal list
 /// - regime confidence above the configured floor
+/// - all `predicted_return` values are finite (no `NaN` or `±inf`)
 /// - non-degenerate quantile spread across predicted returns
+///
+/// Fields are private; use the provided accessors to read values.
 #[derive(Debug)]
 pub struct GatedSignals {
-    pub signals: Vec<Signal>,
-    pub regime: Regime,
-    pub confidence: Percent,
+    signals: Vec<Signal>,
+    regime: Regime,
+    confidence: Percent,
 }
 
 impl GatedSignals {
     /// Constructs `GatedSignals` after validating all gate invariants.
     ///
     /// Returns `Err` if signals is empty, regime confidence is below `floor`,
-    /// or all signals have identical `predicted_return` values.
+    /// any signal has a non-finite `predicted_return`, or all signals have
+    /// identical `predicted_return` values.
     pub fn new(
         signals: Vec<Signal>,
         regime_result: RegimeResult,
@@ -105,11 +115,20 @@ impl GatedSignals {
             return Err(SignalGateError::EmptySignals);
         }
 
-        if regime_result.confidence.0 < floor.0 .0 {
+        let regime_confidence = regime_result.confidence.value();
+        let confidence_floor = floor.0.value();
+        if regime_confidence < confidence_floor {
             return Err(SignalGateError::BelowConfidenceFloor {
-                confidence: regime_result.confidence.0,
-                floor: floor.0 .0,
+                confidence: regime_confidence,
+                floor: confidence_floor,
             });
+        }
+
+        if signals
+            .iter()
+            .any(|signal| !signal.predicted_return.is_finite())
+        {
+            return Err(SignalGateError::NonFiniteReturn);
         }
 
         let maximum_return = signals
@@ -130,6 +149,21 @@ impl GatedSignals {
             regime: regime_result.state,
             confidence: regime_result.confidence,
         })
+    }
+
+    /// Returns a slice of the validated signals.
+    pub fn signals(&self) -> &[Signal] {
+        &self.signals
+    }
+
+    /// Returns a reference to the regime state.
+    pub fn regime(&self) -> &Regime {
+        &self.regime
+    }
+
+    /// Returns the regime confidence.
+    pub fn confidence(&self) -> Percent {
+        self.confidence
     }
 }
 
@@ -237,9 +271,9 @@ mod tests {
             ConfidenceFloor(Percent::new(0.5).unwrap()),
         )
         .unwrap();
-        assert_eq!(gated.signals.len(), 5);
-        assert_eq!(gated.regime, Regime::MeanReversion);
-        assert_eq!(gated.confidence.0, 0.8);
+        assert_eq!(gated.signals().len(), 5);
+        assert_eq!(*gated.regime(), Regime::MeanReversion);
+        assert_eq!(gated.confidence().value(), 0.8);
     }
 
     #[test]
@@ -251,7 +285,31 @@ mod tests {
             ConfidenceFloor(Percent::new(0.5).unwrap()),
         )
         .unwrap();
-        assert_eq!(gated.confidence.0, 0.5);
+        assert_eq!(gated.confidence().value(), 0.5);
+    }
+
+    #[test]
+    fn test_gated_signals_new_rejects_nan_return() {
+        let signals = make_signals(&[0.01, f64::NAN, 0.03]);
+        let error = GatedSignals::new(
+            signals,
+            make_regime_result(0.8),
+            ConfidenceFloor(Percent::new(0.5).unwrap()),
+        )
+        .unwrap_err();
+        assert_eq!(error, SignalGateError::NonFiniteReturn);
+    }
+
+    #[test]
+    fn test_gated_signals_new_rejects_inf_return() {
+        let signals = make_signals(&[0.01, f64::INFINITY, 0.03]);
+        let error = GatedSignals::new(
+            signals,
+            make_regime_result(0.8),
+            ConfidenceFloor(Percent::new(0.5).unwrap()),
+        )
+        .unwrap_err();
+        assert_eq!(error, SignalGateError::NonFiniteReturn);
     }
 
     #[test]
@@ -267,12 +325,15 @@ mod tests {
 
         let error = SignalGateError::DegenerateQuantileSpread;
         assert!(format!("{}", error).contains("degenerate"));
+
+        let error = SignalGateError::NonFiniteReturn;
+        assert!(format!("{}", error).contains("non-finite"));
     }
 
     #[test]
     fn test_confidence_floor_construction() {
         let floor = ConfidenceFloor(Percent::new(0.6).unwrap());
-        assert_eq!(floor.0 .0, 0.6);
+        assert_eq!(floor.0.value(), 0.6);
     }
 
     #[test]
@@ -282,6 +343,6 @@ mod tests {
             confidence: Percent::new(0.75).unwrap(),
         };
         assert_eq!(result.state, Regime::Trending);
-        assert_eq!(result.confidence.0, 0.75);
+        assert_eq!(result.confidence.value(), 0.75);
     }
 }

--- a/libraries/rust/src/trading.rs
+++ b/libraries/rust/src/trading.rs
@@ -1,0 +1,228 @@
+//! Trading lifecycle record types mirroring the PostgreSQL trading tables.
+
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+/// Groups one full rebalance cycle from allocation through order submission.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct EquityRebalanceSession {
+    pub id: Uuid,
+    pub triggered_at: DateTime<Utc>,
+    pub trigger_reason: String,
+    /// References `model_runs.run_id`; nullable when the model run is unavailable.
+    pub model_run_id: Option<String>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub status: String,
+}
+
+/// One cointegrated long-short pair within a rebalance session.
+///
+/// Entry signal fields (`z_score`, `hedge_ratio`, `signal_strength`) are recorded
+/// at the time the pair is opened.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct EquityPair {
+    pub id: Uuid,
+    pub rebalance_id: Uuid,
+    pub pair_id: String,
+    pub long_ticker: String,
+    pub short_ticker: String,
+    pub z_score: Decimal,
+    pub hedge_ratio: Decimal,
+    pub signal_strength: Decimal,
+    /// Either `"open"` or `"closed"`.
+    pub status: String,
+    pub opened_at: DateTime<Utc>,
+    pub closed_at: Option<DateTime<Utc>>,
+    pub realized_profit_and_loss: Option<Decimal>,
+    pub return_percent: Option<Decimal>,
+    pub holding_days: Option<i32>,
+}
+
+/// One ticker leg of an allocation within a rebalance session.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct EquityAllocation {
+    pub id: Uuid,
+    pub rebalance_id: Uuid,
+    pub equity_pair_id: Uuid,
+    pub generated_at: DateTime<Utc>,
+    /// References `model_runs.run_id`; nullable when unavailable.
+    pub model_run_id: Option<String>,
+    pub ticker: String,
+    /// Either `"LONG"` or `"SHORT"`.
+    pub side: String,
+    /// Either `"OPEN_POSITION"`, `"CLOSE_POSITION"`, or `"UNSPECIFIED"`.
+    pub action: String,
+    pub dollar_amount: Decimal,
+    pub entry_price: Option<Decimal>,
+    /// Non-null for `SHORT` legs (whole-share count for Alpaca SELL).
+    pub quantity: Option<Decimal>,
+    /// Non-null for `LONG` legs (dollar amount for Alpaca BUY).
+    pub notional: Option<Decimal>,
+}
+
+/// An order submitted to Alpaca, linked to an allocation.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct EquityOrder {
+    pub id: Uuid,
+    pub allocation_id: Uuid,
+    pub submitted_at: DateTime<Utc>,
+    pub ticker: String,
+    pub side: String,
+    pub quantity: Decimal,
+    pub order_type: String,
+    pub limit_price: Option<Decimal>,
+    pub alpaca_order_id: String,
+}
+
+/// Per-rebalance portfolio state snapshot.
+///
+/// `"intraday"` rows are recorded after each live rebalance; `gross_return` and
+/// `net_return` are `None`. `"eod"` rows are recorded once per trading day at
+/// market close; all columns are populated.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct EquityPortfolioSnapshot {
+    pub id: i64,
+    pub snapshot_timestamp: DateTime<Utc>,
+    /// Either `"intraday"` or `"eod"`.
+    pub snapshot_type: String,
+    pub net_asset_value: Decimal,
+    pub gross_return: Option<Decimal>,
+    pub net_return: Option<Decimal>,
+    pub total_slippage_cost: Decimal,
+    pub created_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use rust_decimal::Decimal;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_equity_rebalance_session_construction() {
+        let session = EquityRebalanceSession {
+            id: Uuid::new_v4(),
+            triggered_at: Utc::now(),
+            trigger_reason: "intraday_check".to_string(),
+            model_run_id: Some("run-abc123".to_string()),
+            completed_at: None,
+            status: "completed".to_string(),
+        };
+        assert_eq!(session.trigger_reason, "intraday_check");
+        assert_eq!(session.status, "completed");
+        assert!(session.completed_at.is_none());
+    }
+
+    #[test]
+    fn test_equity_rebalance_session_clone() {
+        let session = EquityRebalanceSession {
+            id: Uuid::new_v4(),
+            triggered_at: Utc::now(),
+            trigger_reason: "eod_snapshot_requested".to_string(),
+            model_run_id: None,
+            completed_at: Some(Utc::now()),
+            status: "completed".to_string(),
+        };
+        let cloned = session.clone();
+        assert_eq!(cloned.trigger_reason, "eod_snapshot_requested");
+    }
+
+    #[test]
+    fn test_equity_pair_construction() {
+        let pair = EquityPair {
+            id: Uuid::new_v4(),
+            rebalance_id: Uuid::new_v4(),
+            pair_id: "AAPL-MSFT".to_string(),
+            long_ticker: "AAPL".to_string(),
+            short_ticker: "MSFT".to_string(),
+            z_score: Decimal::from(2),
+            hedge_ratio: Decimal::from(1),
+            signal_strength: Decimal::new(75, 2),
+            status: "open".to_string(),
+            opened_at: Utc::now(),
+            closed_at: None,
+            realized_profit_and_loss: None,
+            return_percent: None,
+            holding_days: None,
+        };
+        assert_eq!(pair.long_ticker, "AAPL");
+        assert_eq!(pair.short_ticker, "MSFT");
+        assert_eq!(pair.status, "open");
+    }
+
+    #[test]
+    fn test_equity_allocation_construction() {
+        let allocation = EquityAllocation {
+            id: Uuid::new_v4(),
+            rebalance_id: Uuid::new_v4(),
+            equity_pair_id: Uuid::new_v4(),
+            generated_at: Utc::now(),
+            model_run_id: None,
+            ticker: "AAPL".to_string(),
+            side: "LONG".to_string(),
+            action: "OPEN_POSITION".to_string(),
+            dollar_amount: Decimal::from(10_000),
+            entry_price: Some(Decimal::from(150)),
+            quantity: None,
+            notional: Some(Decimal::from(10_000)),
+        };
+        assert_eq!(allocation.ticker, "AAPL");
+        assert_eq!(allocation.side, "LONG");
+        assert_eq!(allocation.dollar_amount, Decimal::from(10_000));
+    }
+
+    #[test]
+    fn test_equity_order_construction() {
+        let order = EquityOrder {
+            id: Uuid::new_v4(),
+            allocation_id: Uuid::new_v4(),
+            submitted_at: Utc::now(),
+            ticker: "MSFT".to_string(),
+            side: "SHORT".to_string(),
+            quantity: Decimal::from(25),
+            order_type: "market".to_string(),
+            limit_price: None,
+            alpaca_order_id: "alpaca-order-xyz".to_string(),
+        };
+        assert_eq!(order.ticker, "MSFT");
+        assert_eq!(order.side, "SHORT");
+        assert_eq!(order.quantity, Decimal::from(25));
+    }
+
+    #[test]
+    fn test_equity_portfolio_snapshot_construction() {
+        let snapshot = EquityPortfolioSnapshot {
+            id: 1,
+            snapshot_timestamp: Utc::now(),
+            snapshot_type: "intraday".to_string(),
+            net_asset_value: Decimal::from(100_000),
+            gross_return: None,
+            net_return: None,
+            total_slippage_cost: Decimal::from(50),
+            created_at: Utc::now(),
+        };
+        assert_eq!(snapshot.snapshot_type, "intraday");
+        assert_eq!(snapshot.net_asset_value, Decimal::from(100_000));
+        assert!(snapshot.gross_return.is_none());
+    }
+
+    #[test]
+    fn test_equity_portfolio_snapshot_eod() {
+        let snapshot = EquityPortfolioSnapshot {
+            id: 2,
+            snapshot_timestamp: Utc::now(),
+            snapshot_type: "eod".to_string(),
+            net_asset_value: Decimal::from(102_000),
+            gross_return: Some(Decimal::new(2, 2)),
+            net_return: Some(Decimal::new(18, 3)),
+            total_slippage_cost: Decimal::from(75),
+            created_at: Utc::now(),
+        };
+        assert_eq!(snapshot.snapshot_type, "eod");
+        assert!(snapshot.gross_return.is_some());
+    }
+}


### PR DESCRIPTION
# Overview

## Changes

- Adds `libraries/rust/` as a new Cargo workspace member (package name `internal`) — fixes #902
- Adds `"libraries/rust"` to the workspace `members` list in the root `Cargo.toml`
- Implements all eight source modules under `libraries/rust/src/`:
  - `primitives.rs` — zero-cost newtypes: `Shares(Decimal)`, `Dollars(Decimal)`, `Percent(f64)` validated `[0.0, 1.0]`, `Long`, `Short`, `Notional`, `Allocation`
  - `market.rs` — `EquityBar`, `EquityQuote`, `EquityDetails` with `FromRow` + serde derives
  - `trading.rs` — `EquityRebalanceSession`, `EquityPair`, `EquityAllocation`, `EquityOrder`, `EquityPortfolioSnapshot`
  - `predictions.rs` — `EquityPrediction`, `ModelRun` (JSONB `stage_counts` as `serde_json::Value`)
  - `orders.rs` — typestate machine `Order<S: OrderState>` with sealed trait; `PendingPair::confirm()` consumes both legs atomically, making a dangling long unrepresentable at the type level
  - `portfolio.rs` — `Portfolio::new()` enforcing minimum pairs (10), per-ticker concentration cap, dollar neutrality (5% tolerance per pair), and net beta neutrality
  - `signals.rs` — `GatedSignals::new()` rejecting empty signals, below-floor regime confidence, and degenerate quantile spreads
  - `freshness.rs` — `Fresh<T>::get()` returning `None` when data age exceeds the staleness window; predictions window is 20 hours
- 73 tests; 99.8% line coverage on the `internal` crate
- Purely additive — no changes to existing application code

## Context

This crate is the schema authority: its struct definitions are the single source of truth for what a data record looks like across PostgreSQL, S3, and application code. Unblocks #903 and #904.

Part of the Wave 1 refactor tracked in #898. No dependencies on other Wave 1 PRs (parallel).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Rust library for shared domain types across fund platform services
  * Portfolio validation with concentration caps, beta/dollar neutrality checks, and minimum pair requirements
  * Order lifecycle management with fill confirmation and pair validation
  * Prediction and market data record types
  * Signal gating with regime detection and confidence thresholds
  * Data freshness tracking for model predictions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->