### PR TITLE
[Wave 3, Part 7] data_manager: replace pg_parquet exports with Rust tasks

### DIFF
--- a/applications/data_manager/src/database.rs
+++ b/applications/data_manager/src/database.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDate;
+use chrono::{DateTime, NaiveDate, Utc};
 use internal::market::{EquityBar, EquityDetails, EquityQuote};
 use internal::trading::{
     EquityAllocation, EquityOrder, EquityPair, EquityPortfolioSnapshot, EquityRebalanceSession,
@@ -52,8 +52,11 @@ pub async fn insert_equity_bars(pool: &PgPool, bars: &[EquityBar]) -> Result<u64
     Ok(rows_affected)
 }
 
-pub async fn claim_pending_job(pool: &PgPool, job_name: &str) -> Result<Option<i64>, sqlx::Error> {
-    let row: Option<(i64,)> = sqlx::query_as(
+pub async fn claim_pending_job(
+    pool: &PgPool,
+    job_name: &str,
+) -> Result<Option<(i64, DateTime<Utc>)>, sqlx::Error> {
+    let row: Option<(i64, DateTime<Utc>)> = sqlx::query_as(
         r#"UPDATE scheduled_jobs
            SET claimed_at = now(), status = 'claimed'
            WHERE id = (
@@ -63,17 +66,16 @@ pub async fn claim_pending_job(pool: &PgPool, job_name: &str) -> Result<Option<i
                LIMIT 1
                FOR UPDATE SKIP LOCKED
            )
-           RETURNING id"#,
+           RETURNING id, scheduled_at"#,
     )
     .bind(job_name)
     .fetch_optional(pool)
     .await?;
 
-    let job_id = row.map(|(id,)| id);
-    if let Some(id) = job_id {
+    if let Some((id, _)) = row {
         debug!("Claimed job {} with id {}", job_name, id);
     }
-    Ok(job_id)
+    Ok(row)
 }
 
 pub async fn complete_job(pool: &PgPool, job_id: i64, result: &str) -> Result<(), sqlx::Error> {

--- a/applications/data_manager/src/database.rs
+++ b/applications/data_manager/src/database.rs
@@ -1,4 +1,8 @@
+use chrono::NaiveDate;
 use internal::market::{EquityBar, EquityDetails, EquityQuote};
+use internal::trading::{
+    EquityAllocation, EquityOrder, EquityPair, EquityPortfolioSnapshot, EquityRebalanceSession,
+};
 use sqlx::PgPool;
 use tracing::{debug, info, warn};
 
@@ -212,16 +216,144 @@ pub async fn populate_equity_details_if_empty(
     Ok(rows_affected)
 }
 
-pub async fn set_bucket_guc(pool: &PgPool, bucket_name: &str) -> Result<(), sqlx::Error> {
-    let alter_statement: String = sqlx::query_scalar(
-        r#"SELECT format('ALTER DATABASE %I SET "app.bucket_name" = %L', current_database(), $1)"#,
+pub async fn query_equity_quotes_for_date(
+    pool: &PgPool,
+    date: NaiveDate,
+) -> Result<Vec<EquityQuote>, sqlx::Error> {
+    let date_start = date.and_hms_opt(0, 0, 0).unwrap().and_utc();
+    let date_end = date
+        .succ_opt()
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc();
+
+    let quotes = sqlx::query_as::<_, EquityQuote>(
+        "SELECT timestamp, ticker, bid_price, ask_price, bid_size, ask_size
+         FROM equity_quotes
+         WHERE timestamp >= $1 AND timestamp < $2
+         ORDER BY timestamp ASC",
     )
-    .bind(bucket_name)
-    .fetch_one(pool)
+    .bind(date_start)
+    .bind(date_end)
+    .fetch_all(pool)
     .await?;
-    sqlx::query(&alter_statement).execute(pool).await?;
-    info!("Set app.bucket_name database GUC to {}", bucket_name);
-    Ok(())
+
+    debug!("Queried {} equity quotes for {}", quotes.len(), date);
+    Ok(quotes)
+}
+
+pub async fn delete_equity_quotes_for_date(
+    pool: &PgPool,
+    date: NaiveDate,
+) -> Result<u64, sqlx::Error> {
+    let date_start = date.and_hms_opt(0, 0, 0).unwrap().and_utc();
+    let date_end = date
+        .succ_opt()
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc();
+
+    let result = sqlx::query("DELETE FROM equity_quotes WHERE timestamp >= $1 AND timestamp < $2")
+        .bind(date_start)
+        .bind(date_end)
+        .execute(pool)
+        .await?;
+
+    let deleted = result.rows_affected();
+    info!(
+        "Deleted {} equity quotes from PostgreSQL for {}",
+        deleted, date
+    );
+    Ok(deleted)
+}
+
+pub async fn query_equity_bars_for_date(
+    pool: &PgPool,
+    date: NaiveDate,
+) -> Result<Vec<EquityBar>, sqlx::Error> {
+    let date_start = date.and_hms_opt(0, 0, 0).unwrap().and_utc();
+    let date_end = date
+        .succ_opt()
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc();
+
+    let bars = sqlx::query_as::<_, EquityBar>(
+        "SELECT ticker, timestamp, open_price, high_price, low_price, close_price, volume,
+         volume_weighted_average_price, transactions, inserted_at
+         FROM equity_bars
+         WHERE timestamp >= $1 AND timestamp < $2
+         ORDER BY ticker ASC, timestamp ASC",
+    )
+    .bind(date_start)
+    .bind(date_end)
+    .fetch_all(pool)
+    .await?;
+
+    debug!("Queried {} equity bars for {}", bars.len(), date);
+    Ok(bars)
+}
+
+pub async fn query_equity_rebalance_sessions(
+    pool: &PgPool,
+) -> Result<Vec<EquityRebalanceSession>, sqlx::Error> {
+    sqlx::query_as::<_, EquityRebalanceSession>(
+        "SELECT id, triggered_at, trigger_reason, model_run_id, completed_at, status
+         FROM equity_rebalance_sessions
+         ORDER BY triggered_at ASC",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+pub async fn query_equity_pairs(pool: &PgPool) -> Result<Vec<EquityPair>, sqlx::Error> {
+    sqlx::query_as::<_, EquityPair>(
+        "SELECT id, rebalance_id, pair_id, long_ticker, short_ticker, z_score, hedge_ratio,
+         signal_strength, status, opened_at, closed_at, realized_profit_and_loss,
+         return_percent, holding_days
+         FROM equity_pairs
+         ORDER BY opened_at ASC",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+pub async fn query_equity_allocations(pool: &PgPool) -> Result<Vec<EquityAllocation>, sqlx::Error> {
+    sqlx::query_as::<_, EquityAllocation>(
+        "SELECT id, rebalance_id, equity_pair_id, generated_at, model_run_id, ticker, side,
+         action, dollar_amount, entry_price, quantity, notional
+         FROM equity_allocations
+         ORDER BY generated_at ASC",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+pub async fn query_equity_orders(pool: &PgPool) -> Result<Vec<EquityOrder>, sqlx::Error> {
+    sqlx::query_as::<_, EquityOrder>(
+        "SELECT id, allocation_id, submitted_at, ticker, side, quantity, order_type,
+         limit_price, alpaca_order_id
+         FROM equity_orders
+         ORDER BY submitted_at ASC",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+pub async fn query_equity_portfolio_snapshots(
+    pool: &PgPool,
+) -> Result<Vec<EquityPortfolioSnapshot>, sqlx::Error> {
+    sqlx::query_as::<_, EquityPortfolioSnapshot>(
+        "SELECT id, snapshot_timestamp, snapshot_type, net_asset_value, gross_return,
+         net_return, total_slippage_cost, created_at
+         FROM equity_portfolio_snapshots
+         ORDER BY snapshot_timestamp ASC",
+    )
+    .fetch_all(pool)
+    .await
 }
 
 pub async fn requeue_stale_claimed_jobs(
@@ -366,7 +498,55 @@ mod tests {
     }
 
     #[test]
-    fn test_set_bucket_guc_compiles() {
+    fn test_query_equity_quotes_for_date_compiles() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            use chrono::NaiveDate;
+            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
+                .expect("lazy pool creation should not fail");
+            let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+            let result = query_equity_quotes_for_date(&pool, date).await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_delete_equity_quotes_for_date_compiles() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            use chrono::NaiveDate;
+            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
+                .expect("lazy pool creation should not fail");
+            let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+            let result = delete_equity_quotes_for_date(&pool, date).await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_query_equity_bars_for_date_compiles() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            use chrono::NaiveDate;
+            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
+                .expect("lazy pool creation should not fail");
+            let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+            let result = query_equity_bars_for_date(&pool, date).await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_query_equity_rebalance_sessions_compiles() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -374,7 +554,63 @@ mod tests {
         runtime.block_on(async {
             let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
                 .expect("lazy pool creation should not fail");
-            let result = set_bucket_guc(&pool, "test-bucket").await;
+            let result = query_equity_rebalance_sessions(&pool).await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_query_equity_pairs_compiles() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
+                .expect("lazy pool creation should not fail");
+            let result = query_equity_pairs(&pool).await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_query_equity_allocations_compiles() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
+                .expect("lazy pool creation should not fail");
+            let result = query_equity_allocations(&pool).await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_query_equity_orders_compiles() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
+                .expect("lazy pool creation should not fail");
+            let result = query_equity_orders(&pool).await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_query_equity_portfolio_snapshots_compiles() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
+                .expect("lazy pool creation should not fail");
+            let result = query_equity_portfolio_snapshots(&pool).await;
             assert!(result.is_err());
         });
     }

--- a/applications/data_manager/src/export.rs
+++ b/applications/data_manager/src/export.rs
@@ -206,28 +206,28 @@ async fn write_dataframe_to_s3(
 
 fn create_equity_quote_dataframe(quotes: &[EquityQuote]) -> Result<DataFrame, String> {
     df!(
-        "timestamp" => quotes.iter().map(|q| q.timestamp.timestamp_millis()).collect::<Vec<i64>>(),
-        "ticker" => quotes.iter().map(|q| q.ticker.as_str()).collect::<Vec<&str>>(),
-        "bid_price" => quotes.iter().map(|q| q.bid_price).collect::<Vec<f64>>(),
-        "ask_price" => quotes.iter().map(|q| q.ask_price).collect::<Vec<f64>>(),
-        "bid_size" => quotes.iter().map(|q| q.bid_size).collect::<Vec<i32>>(),
-        "ask_size" => quotes.iter().map(|q| q.ask_size).collect::<Vec<i32>>(),
+        "timestamp" => quotes.iter().map(|quote| quote.timestamp.timestamp_millis()).collect::<Vec<i64>>(),
+        "ticker" => quotes.iter().map(|quote| quote.ticker.as_str()).collect::<Vec<&str>>(),
+        "bid_price" => quotes.iter().map(|quote| quote.bid_price).collect::<Vec<f64>>(),
+        "ask_price" => quotes.iter().map(|quote| quote.ask_price).collect::<Vec<f64>>(),
+        "bid_size" => quotes.iter().map(|quote| quote.bid_size).collect::<Vec<i32>>(),
+        "ask_size" => quotes.iter().map(|quote| quote.ask_size).collect::<Vec<i32>>(),
     )
     .map_err(|error| format!("Failed to create equity quote DataFrame: {}", error))
 }
 
 fn create_equity_bar_export_dataframe(bars: &[EquityBar]) -> Result<DataFrame, String> {
     df!(
-        "ticker" => bars.iter().map(|b| b.ticker.as_str()).collect::<Vec<&str>>(),
-        "timestamp" => bars.iter().map(|b| b.timestamp.timestamp_millis()).collect::<Vec<i64>>(),
-        "open_price" => bars.iter().map(|b| b.open_price).collect::<Vec<f64>>(),
-        "high_price" => bars.iter().map(|b| b.high_price).collect::<Vec<f64>>(),
-        "low_price" => bars.iter().map(|b| b.low_price).collect::<Vec<f64>>(),
-        "close_price" => bars.iter().map(|b| b.close_price).collect::<Vec<f64>>(),
-        "volume" => bars.iter().map(|b| b.volume).collect::<Vec<i64>>(),
-        "volume_weighted_average_price" => bars.iter().map(|b| b.volume_weighted_average_price).collect::<Vec<Option<f64>>>(),
-        "transactions" => bars.iter().map(|b| b.transactions).collect::<Vec<Option<i64>>>(),
-        "inserted_at" => bars.iter().map(|b| b.inserted_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "ticker" => bars.iter().map(|bar| bar.ticker.as_str()).collect::<Vec<&str>>(),
+        "timestamp" => bars.iter().map(|bar| bar.timestamp.timestamp_millis()).collect::<Vec<i64>>(),
+        "open_price" => bars.iter().map(|bar| bar.open_price).collect::<Vec<f64>>(),
+        "high_price" => bars.iter().map(|bar| bar.high_price).collect::<Vec<f64>>(),
+        "low_price" => bars.iter().map(|bar| bar.low_price).collect::<Vec<f64>>(),
+        "close_price" => bars.iter().map(|bar| bar.close_price).collect::<Vec<f64>>(),
+        "volume" => bars.iter().map(|bar| bar.volume).collect::<Vec<i64>>(),
+        "volume_weighted_average_price" => bars.iter().map(|bar| bar.volume_weighted_average_price).collect::<Vec<Option<f64>>>(),
+        "transactions" => bars.iter().map(|bar| bar.transactions).collect::<Vec<Option<i64>>>(),
+        "inserted_at" => bars.iter().map(|bar| bar.inserted_at.timestamp_millis()).collect::<Vec<i64>>(),
     )
     .map_err(|error| format!("Failed to create equity bar export DataFrame: {}", error))
 }
@@ -236,12 +236,12 @@ fn create_equity_rebalance_session_dataframe(
     sessions: &[EquityRebalanceSession],
 ) -> Result<DataFrame, String> {
     df!(
-        "id" => sessions.iter().map(|s| s.id.to_string()).collect::<Vec<String>>(),
-        "triggered_at" => sessions.iter().map(|s| s.triggered_at.timestamp_millis()).collect::<Vec<i64>>(),
-        "trigger_reason" => sessions.iter().map(|s| s.trigger_reason.as_str()).collect::<Vec<&str>>(),
-        "model_run_id" => sessions.iter().map(|s| s.model_run_id.as_deref()).collect::<Vec<Option<&str>>>(),
-        "completed_at" => sessions.iter().map(|s| s.completed_at.map(|t| t.timestamp_millis())).collect::<Vec<Option<i64>>>(),
-        "status" => sessions.iter().map(|s| s.status.as_str()).collect::<Vec<&str>>(),
+        "id" => sessions.iter().map(|session| session.id.to_string()).collect::<Vec<String>>(),
+        "triggered_at" => sessions.iter().map(|session| session.triggered_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "trigger_reason" => sessions.iter().map(|session| session.trigger_reason.as_str()).collect::<Vec<&str>>(),
+        "model_run_id" => sessions.iter().map(|session| session.model_run_id.as_deref()).collect::<Vec<Option<&str>>>(),
+        "completed_at" => sessions.iter().map(|session| session.completed_at.map(|timestamp| timestamp.timestamp_millis())).collect::<Vec<Option<i64>>>(),
+        "status" => sessions.iter().map(|session| session.status.as_str()).collect::<Vec<&str>>(),
     )
     .map_err(|error| {
         format!(
@@ -253,20 +253,20 @@ fn create_equity_rebalance_session_dataframe(
 
 fn create_equity_pair_dataframe(pairs: &[EquityPair]) -> Result<DataFrame, String> {
     df!(
-        "id" => pairs.iter().map(|p| p.id.to_string()).collect::<Vec<String>>(),
-        "rebalance_id" => pairs.iter().map(|p| p.rebalance_id.to_string()).collect::<Vec<String>>(),
-        "pair_id" => pairs.iter().map(|p| p.pair_id.as_str()).collect::<Vec<&str>>(),
-        "long_ticker" => pairs.iter().map(|p| p.long_ticker.as_str()).collect::<Vec<&str>>(),
-        "short_ticker" => pairs.iter().map(|p| p.short_ticker.as_str()).collect::<Vec<&str>>(),
-        "z_score" => pairs.iter().map(|p| p.z_score.to_string()).collect::<Vec<String>>(),
-        "hedge_ratio" => pairs.iter().map(|p| p.hedge_ratio.to_string()).collect::<Vec<String>>(),
-        "signal_strength" => pairs.iter().map(|p| p.signal_strength.to_string()).collect::<Vec<String>>(),
-        "status" => pairs.iter().map(|p| p.status.as_str()).collect::<Vec<&str>>(),
-        "opened_at" => pairs.iter().map(|p| p.opened_at.timestamp_millis()).collect::<Vec<i64>>(),
-        "closed_at" => pairs.iter().map(|p| p.closed_at.map(|t| t.timestamp_millis())).collect::<Vec<Option<i64>>>(),
-        "realized_profit_and_loss" => pairs.iter().map(|p| p.realized_profit_and_loss.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
-        "return_percent" => pairs.iter().map(|p| p.return_percent.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
-        "holding_days" => pairs.iter().map(|p| p.holding_days).collect::<Vec<Option<i32>>>(),
+        "id" => pairs.iter().map(|pair| pair.id.to_string()).collect::<Vec<String>>(),
+        "rebalance_id" => pairs.iter().map(|pair| pair.rebalance_id.to_string()).collect::<Vec<String>>(),
+        "pair_id" => pairs.iter().map(|pair| pair.pair_id.as_str()).collect::<Vec<&str>>(),
+        "long_ticker" => pairs.iter().map(|pair| pair.long_ticker.as_str()).collect::<Vec<&str>>(),
+        "short_ticker" => pairs.iter().map(|pair| pair.short_ticker.as_str()).collect::<Vec<&str>>(),
+        "z_score" => pairs.iter().map(|pair| pair.z_score.to_string()).collect::<Vec<String>>(),
+        "hedge_ratio" => pairs.iter().map(|pair| pair.hedge_ratio.to_string()).collect::<Vec<String>>(),
+        "signal_strength" => pairs.iter().map(|pair| pair.signal_strength.to_string()).collect::<Vec<String>>(),
+        "status" => pairs.iter().map(|pair| pair.status.as_str()).collect::<Vec<&str>>(),
+        "opened_at" => pairs.iter().map(|pair| pair.opened_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "closed_at" => pairs.iter().map(|pair| pair.closed_at.map(|timestamp| timestamp.timestamp_millis())).collect::<Vec<Option<i64>>>(),
+        "realized_profit_and_loss" => pairs.iter().map(|pair| pair.realized_profit_and_loss.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "return_percent" => pairs.iter().map(|pair| pair.return_percent.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "holding_days" => pairs.iter().map(|pair| pair.holding_days).collect::<Vec<Option<i32>>>(),
     )
     .map_err(|error| format!("Failed to create equity pair DataFrame: {}", error))
 }
@@ -275,33 +275,33 @@ fn create_equity_allocation_dataframe(
     allocations: &[EquityAllocation],
 ) -> Result<DataFrame, String> {
     df!(
-        "id" => allocations.iter().map(|a| a.id.to_string()).collect::<Vec<String>>(),
-        "rebalance_id" => allocations.iter().map(|a| a.rebalance_id.to_string()).collect::<Vec<String>>(),
-        "equity_pair_id" => allocations.iter().map(|a| a.equity_pair_id.to_string()).collect::<Vec<String>>(),
-        "generated_at" => allocations.iter().map(|a| a.generated_at.timestamp_millis()).collect::<Vec<i64>>(),
-        "model_run_id" => allocations.iter().map(|a| a.model_run_id.as_deref()).collect::<Vec<Option<&str>>>(),
-        "ticker" => allocations.iter().map(|a| a.ticker.as_str()).collect::<Vec<&str>>(),
-        "side" => allocations.iter().map(|a| a.side.as_str()).collect::<Vec<&str>>(),
-        "action" => allocations.iter().map(|a| a.action.as_str()).collect::<Vec<&str>>(),
-        "dollar_amount" => allocations.iter().map(|a| a.dollar_amount.to_string()).collect::<Vec<String>>(),
-        "entry_price" => allocations.iter().map(|a| a.entry_price.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
-        "quantity" => allocations.iter().map(|a| a.quantity.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
-        "notional" => allocations.iter().map(|a| a.notional.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
+        "id" => allocations.iter().map(|allocation| allocation.id.to_string()).collect::<Vec<String>>(),
+        "rebalance_id" => allocations.iter().map(|allocation| allocation.rebalance_id.to_string()).collect::<Vec<String>>(),
+        "equity_pair_id" => allocations.iter().map(|allocation| allocation.equity_pair_id.to_string()).collect::<Vec<String>>(),
+        "generated_at" => allocations.iter().map(|allocation| allocation.generated_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "model_run_id" => allocations.iter().map(|allocation| allocation.model_run_id.as_deref()).collect::<Vec<Option<&str>>>(),
+        "ticker" => allocations.iter().map(|allocation| allocation.ticker.as_str()).collect::<Vec<&str>>(),
+        "side" => allocations.iter().map(|allocation| allocation.side.as_str()).collect::<Vec<&str>>(),
+        "action" => allocations.iter().map(|allocation| allocation.action.as_str()).collect::<Vec<&str>>(),
+        "dollar_amount" => allocations.iter().map(|allocation| allocation.dollar_amount.to_string()).collect::<Vec<String>>(),
+        "entry_price" => allocations.iter().map(|allocation| allocation.entry_price.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "quantity" => allocations.iter().map(|allocation| allocation.quantity.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "notional" => allocations.iter().map(|allocation| allocation.notional.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
     )
     .map_err(|error| format!("Failed to create equity allocation DataFrame: {}", error))
 }
 
 fn create_equity_order_dataframe(orders: &[EquityOrder]) -> Result<DataFrame, String> {
     df!(
-        "id" => orders.iter().map(|o| o.id.to_string()).collect::<Vec<String>>(),
-        "allocation_id" => orders.iter().map(|o| o.allocation_id.to_string()).collect::<Vec<String>>(),
-        "submitted_at" => orders.iter().map(|o| o.submitted_at.timestamp_millis()).collect::<Vec<i64>>(),
-        "ticker" => orders.iter().map(|o| o.ticker.as_str()).collect::<Vec<&str>>(),
-        "side" => orders.iter().map(|o| o.side.as_str()).collect::<Vec<&str>>(),
-        "quantity" => orders.iter().map(|o| o.quantity.to_string()).collect::<Vec<String>>(),
-        "order_type" => orders.iter().map(|o| o.order_type.as_str()).collect::<Vec<&str>>(),
-        "limit_price" => orders.iter().map(|o| o.limit_price.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
-        "alpaca_order_id" => orders.iter().map(|o| o.alpaca_order_id.as_str()).collect::<Vec<&str>>(),
+        "id" => orders.iter().map(|order| order.id.to_string()).collect::<Vec<String>>(),
+        "allocation_id" => orders.iter().map(|order| order.allocation_id.to_string()).collect::<Vec<String>>(),
+        "submitted_at" => orders.iter().map(|order| order.submitted_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "ticker" => orders.iter().map(|order| order.ticker.as_str()).collect::<Vec<&str>>(),
+        "side" => orders.iter().map(|order| order.side.as_str()).collect::<Vec<&str>>(),
+        "quantity" => orders.iter().map(|order| order.quantity.to_string()).collect::<Vec<String>>(),
+        "order_type" => orders.iter().map(|order| order.order_type.as_str()).collect::<Vec<&str>>(),
+        "limit_price" => orders.iter().map(|order| order.limit_price.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "alpaca_order_id" => orders.iter().map(|order| order.alpaca_order_id.as_str()).collect::<Vec<&str>>(),
     )
     .map_err(|error| format!("Failed to create equity order DataFrame: {}", error))
 }
@@ -310,14 +310,14 @@ fn create_equity_portfolio_snapshot_dataframe(
     snapshots: &[EquityPortfolioSnapshot],
 ) -> Result<DataFrame, String> {
     df!(
-        "id" => snapshots.iter().map(|s| s.id).collect::<Vec<i64>>(),
-        "snapshot_timestamp" => snapshots.iter().map(|s| s.snapshot_timestamp.timestamp_millis()).collect::<Vec<i64>>(),
-        "snapshot_type" => snapshots.iter().map(|s| s.snapshot_type.as_str()).collect::<Vec<&str>>(),
-        "net_asset_value" => snapshots.iter().map(|s| s.net_asset_value.to_string()).collect::<Vec<String>>(),
-        "gross_return" => snapshots.iter().map(|s| s.gross_return.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
-        "net_return" => snapshots.iter().map(|s| s.net_return.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
-        "total_slippage_cost" => snapshots.iter().map(|s| s.total_slippage_cost.to_string()).collect::<Vec<String>>(),
-        "created_at" => snapshots.iter().map(|s| s.created_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "id" => snapshots.iter().map(|snapshot| snapshot.id).collect::<Vec<i64>>(),
+        "snapshot_timestamp" => snapshots.iter().map(|snapshot| snapshot.snapshot_timestamp.timestamp_millis()).collect::<Vec<i64>>(),
+        "snapshot_type" => snapshots.iter().map(|snapshot| snapshot.snapshot_type.as_str()).collect::<Vec<&str>>(),
+        "net_asset_value" => snapshots.iter().map(|snapshot| snapshot.net_asset_value.to_string()).collect::<Vec<String>>(),
+        "gross_return" => snapshots.iter().map(|snapshot| snapshot.gross_return.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "net_return" => snapshots.iter().map(|snapshot| snapshot.net_return.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "total_slippage_cost" => snapshots.iter().map(|snapshot| snapshot.total_slippage_cost.to_string()).collect::<Vec<String>>(),
+        "created_at" => snapshots.iter().map(|snapshot| snapshot.created_at.timestamp_millis()).collect::<Vec<i64>>(),
     )
     .map_err(|error| {
         format!(

--- a/applications/data_manager/src/export.rs
+++ b/applications/data_manager/src/export.rs
@@ -1,0 +1,723 @@
+//! Parquet export tasks for equity market data and trading history.
+//!
+//! Each task reads rows from PostgreSQL into typed structs using explicit
+//! column lists, serializes to Parquet with deterministic column ordering,
+//! and writes to S3. Failures are surfaced as structured log entries.
+
+use crate::{database, state::State};
+use aws_sdk_s3::primitives::ByteStream;
+use chrono::{Datelike, NaiveDate};
+use internal::market::{EquityBar, EquityQuote};
+use internal::trading::{
+    EquityAllocation, EquityOrder, EquityPair, EquityPortfolioSnapshot, EquityRebalanceSession,
+};
+use polars::prelude::*;
+use tracing::info;
+
+/// Exports equity quotes for the given date to S3 Parquet and deletes
+/// the exported rows from the database.
+pub async fn export_equity_quotes(state: &State, date: NaiveDate) -> Result<usize, String> {
+    let pool = state
+        .database
+        .pool()
+        .ok_or_else(|| "database not connected".to_string())?;
+
+    let quotes = database::query_equity_quotes_for_date(pool, date)
+        .await
+        .map_err(|error| format!("Failed to query equity quotes: {}", error))?;
+
+    let count = quotes.len();
+
+    if count == 0 {
+        info!("No equity quotes to export for {}", date);
+        return Ok(0);
+    }
+
+    let mut dataframe = create_equity_quote_dataframe(&quotes)?;
+    let key = format!(
+        "data/equity/quotes/year={}/month={:02}/day={:02}/data.parquet",
+        date.year(),
+        date.month(),
+        date.day()
+    );
+    write_dataframe_to_s3(state, &mut dataframe, &key).await?;
+    info!("Exported {} equity quotes to S3: {}", count, key);
+
+    database::delete_equity_quotes_for_date(pool, date)
+        .await
+        .map_err(|error| format!("Failed to delete equity quotes: {}", error))?;
+
+    Ok(count)
+}
+
+/// Exports equity bars for the given date to S3 Parquet.
+pub async fn export_equity_bars(state: &State, date: NaiveDate) -> Result<usize, String> {
+    let pool = state
+        .database
+        .pool()
+        .ok_or_else(|| "database not connected".to_string())?;
+
+    let bars = database::query_equity_bars_for_date(pool, date)
+        .await
+        .map_err(|error| format!("Failed to query equity bars: {}", error))?;
+
+    let count = bars.len();
+
+    if count == 0 {
+        info!("No equity bars to export for {}", date);
+        return Ok(0);
+    }
+
+    let mut dataframe = create_equity_bar_export_dataframe(&bars)?;
+    let key = format!(
+        "data/equity/bars/year={}/month={:02}/day={:02}/data.parquet",
+        date.year(),
+        date.month(),
+        date.day()
+    );
+    write_dataframe_to_s3(state, &mut dataframe, &key).await?;
+    info!("Exported {} equity bars to S3: {}", count, key);
+
+    Ok(count)
+}
+
+/// Exports all trading history tables to S3 Parquet.
+pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<usize, String> {
+    let pool = state
+        .database
+        .pool()
+        .ok_or_else(|| "database not connected".to_string())?;
+
+    let sessions = database::query_equity_rebalance_sessions(pool)
+        .await
+        .map_err(|error| format!("Failed to query equity rebalance sessions: {}", error))?;
+    let session_count = sessions.len();
+    let mut session_dataframe = create_equity_rebalance_session_dataframe(&sessions)?;
+    write_dataframe_to_s3(
+        state,
+        &mut session_dataframe,
+        &format!(
+            "exports/equity/rebalance-sessions/year={}/month={:02}/day={:02}/data.parquet",
+            date.year(),
+            date.month(),
+            date.day()
+        ),
+    )
+    .await?;
+
+    let pairs = database::query_equity_pairs(pool)
+        .await
+        .map_err(|error| format!("Failed to query equity pairs: {}", error))?;
+    let pair_count = pairs.len();
+    let mut pair_dataframe = create_equity_pair_dataframe(&pairs)?;
+    write_dataframe_to_s3(
+        state,
+        &mut pair_dataframe,
+        &format!(
+            "exports/equity/pairs/year={}/month={:02}/day={:02}/data.parquet",
+            date.year(),
+            date.month(),
+            date.day()
+        ),
+    )
+    .await?;
+
+    let allocations = database::query_equity_allocations(pool)
+        .await
+        .map_err(|error| format!("Failed to query equity allocations: {}", error))?;
+    let allocation_count = allocations.len();
+    let mut allocation_dataframe = create_equity_allocation_dataframe(&allocations)?;
+    write_dataframe_to_s3(
+        state,
+        &mut allocation_dataframe,
+        &format!(
+            "exports/equity/allocations/year={}/month={:02}/day={:02}/data.parquet",
+            date.year(),
+            date.month(),
+            date.day()
+        ),
+    )
+    .await?;
+
+    let orders = database::query_equity_orders(pool)
+        .await
+        .map_err(|error| format!("Failed to query equity orders: {}", error))?;
+    let order_count = orders.len();
+    let mut order_dataframe = create_equity_order_dataframe(&orders)?;
+    write_dataframe_to_s3(
+        state,
+        &mut order_dataframe,
+        &format!(
+            "exports/equity/orders/year={}/month={:02}/day={:02}/data.parquet",
+            date.year(),
+            date.month(),
+            date.day()
+        ),
+    )
+    .await?;
+
+    let snapshots = database::query_equity_portfolio_snapshots(pool)
+        .await
+        .map_err(|error| format!("Failed to query equity portfolio snapshots: {}", error))?;
+    let snapshot_count = snapshots.len();
+    let mut snapshot_dataframe = create_equity_portfolio_snapshot_dataframe(&snapshots)?;
+    write_dataframe_to_s3(
+        state,
+        &mut snapshot_dataframe,
+        &format!(
+            "exports/equity/portfolio-snapshots/year={}/month={:02}/day={:02}/data.parquet",
+            date.year(),
+            date.month(),
+            date.day()
+        ),
+    )
+    .await?;
+
+    info!(
+        "Exported trading history to S3: {} sessions, {} pairs, {} allocations, {} orders, {} snapshots",
+        session_count, pair_count, allocation_count, order_count, snapshot_count
+    );
+
+    Ok(session_count + pair_count + allocation_count + order_count + snapshot_count)
+}
+
+async fn write_dataframe_to_s3(
+    state: &State,
+    dataframe: &mut DataFrame,
+    key: &str,
+) -> Result<(), String> {
+    let mut buffer = Vec::new();
+    ParquetWriter::new(&mut buffer)
+        .finish(dataframe)
+        .map_err(|error| format!("Failed to serialize Parquet for {}: {}", key, error))?;
+
+    state
+        .s3_client
+        .put_object()
+        .bucket(&state.bucket_name)
+        .key(key)
+        .body(ByteStream::from(buffer))
+        .send()
+        .await
+        .map_err(|error| format!("Failed to upload to S3 {}: {}", key, error))?;
+
+    Ok(())
+}
+
+fn create_equity_quote_dataframe(quotes: &[EquityQuote]) -> Result<DataFrame, String> {
+    df!(
+        "timestamp" => quotes.iter().map(|q| q.timestamp.timestamp_millis()).collect::<Vec<i64>>(),
+        "ticker" => quotes.iter().map(|q| q.ticker.as_str()).collect::<Vec<&str>>(),
+        "bid_price" => quotes.iter().map(|q| q.bid_price).collect::<Vec<f64>>(),
+        "ask_price" => quotes.iter().map(|q| q.ask_price).collect::<Vec<f64>>(),
+        "bid_size" => quotes.iter().map(|q| q.bid_size).collect::<Vec<i32>>(),
+        "ask_size" => quotes.iter().map(|q| q.ask_size).collect::<Vec<i32>>(),
+    )
+    .map_err(|error| format!("Failed to create equity quote DataFrame: {}", error))
+}
+
+fn create_equity_bar_export_dataframe(bars: &[EquityBar]) -> Result<DataFrame, String> {
+    df!(
+        "ticker" => bars.iter().map(|b| b.ticker.as_str()).collect::<Vec<&str>>(),
+        "timestamp" => bars.iter().map(|b| b.timestamp.timestamp_millis()).collect::<Vec<i64>>(),
+        "open_price" => bars.iter().map(|b| b.open_price).collect::<Vec<f64>>(),
+        "high_price" => bars.iter().map(|b| b.high_price).collect::<Vec<f64>>(),
+        "low_price" => bars.iter().map(|b| b.low_price).collect::<Vec<f64>>(),
+        "close_price" => bars.iter().map(|b| b.close_price).collect::<Vec<f64>>(),
+        "volume" => bars.iter().map(|b| b.volume).collect::<Vec<i64>>(),
+        "volume_weighted_average_price" => bars.iter().map(|b| b.volume_weighted_average_price).collect::<Vec<Option<f64>>>(),
+        "transactions" => bars.iter().map(|b| b.transactions).collect::<Vec<Option<i64>>>(),
+        "inserted_at" => bars.iter().map(|b| b.inserted_at.timestamp_millis()).collect::<Vec<i64>>(),
+    )
+    .map_err(|error| format!("Failed to create equity bar export DataFrame: {}", error))
+}
+
+fn create_equity_rebalance_session_dataframe(
+    sessions: &[EquityRebalanceSession],
+) -> Result<DataFrame, String> {
+    df!(
+        "id" => sessions.iter().map(|s| s.id.to_string()).collect::<Vec<String>>(),
+        "triggered_at" => sessions.iter().map(|s| s.triggered_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "trigger_reason" => sessions.iter().map(|s| s.trigger_reason.as_str()).collect::<Vec<&str>>(),
+        "model_run_id" => sessions.iter().map(|s| s.model_run_id.as_deref()).collect::<Vec<Option<&str>>>(),
+        "completed_at" => sessions.iter().map(|s| s.completed_at.map(|t| t.timestamp_millis())).collect::<Vec<Option<i64>>>(),
+        "status" => sessions.iter().map(|s| s.status.as_str()).collect::<Vec<&str>>(),
+    )
+    .map_err(|error| {
+        format!(
+            "Failed to create equity rebalance session DataFrame: {}",
+            error
+        )
+    })
+}
+
+fn create_equity_pair_dataframe(pairs: &[EquityPair]) -> Result<DataFrame, String> {
+    df!(
+        "id" => pairs.iter().map(|p| p.id.to_string()).collect::<Vec<String>>(),
+        "rebalance_id" => pairs.iter().map(|p| p.rebalance_id.to_string()).collect::<Vec<String>>(),
+        "pair_id" => pairs.iter().map(|p| p.pair_id.as_str()).collect::<Vec<&str>>(),
+        "long_ticker" => pairs.iter().map(|p| p.long_ticker.as_str()).collect::<Vec<&str>>(),
+        "short_ticker" => pairs.iter().map(|p| p.short_ticker.as_str()).collect::<Vec<&str>>(),
+        "z_score" => pairs.iter().map(|p| p.z_score.to_string()).collect::<Vec<String>>(),
+        "hedge_ratio" => pairs.iter().map(|p| p.hedge_ratio.to_string()).collect::<Vec<String>>(),
+        "signal_strength" => pairs.iter().map(|p| p.signal_strength.to_string()).collect::<Vec<String>>(),
+        "status" => pairs.iter().map(|p| p.status.as_str()).collect::<Vec<&str>>(),
+        "opened_at" => pairs.iter().map(|p| p.opened_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "closed_at" => pairs.iter().map(|p| p.closed_at.map(|t| t.timestamp_millis())).collect::<Vec<Option<i64>>>(),
+        "realized_profit_and_loss" => pairs.iter().map(|p| p.realized_profit_and_loss.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
+        "return_percent" => pairs.iter().map(|p| p.return_percent.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
+        "holding_days" => pairs.iter().map(|p| p.holding_days).collect::<Vec<Option<i32>>>(),
+    )
+    .map_err(|error| format!("Failed to create equity pair DataFrame: {}", error))
+}
+
+fn create_equity_allocation_dataframe(
+    allocations: &[EquityAllocation],
+) -> Result<DataFrame, String> {
+    df!(
+        "id" => allocations.iter().map(|a| a.id.to_string()).collect::<Vec<String>>(),
+        "rebalance_id" => allocations.iter().map(|a| a.rebalance_id.to_string()).collect::<Vec<String>>(),
+        "equity_pair_id" => allocations.iter().map(|a| a.equity_pair_id.to_string()).collect::<Vec<String>>(),
+        "generated_at" => allocations.iter().map(|a| a.generated_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "model_run_id" => allocations.iter().map(|a| a.model_run_id.as_deref()).collect::<Vec<Option<&str>>>(),
+        "ticker" => allocations.iter().map(|a| a.ticker.as_str()).collect::<Vec<&str>>(),
+        "side" => allocations.iter().map(|a| a.side.as_str()).collect::<Vec<&str>>(),
+        "action" => allocations.iter().map(|a| a.action.as_str()).collect::<Vec<&str>>(),
+        "dollar_amount" => allocations.iter().map(|a| a.dollar_amount.to_string()).collect::<Vec<String>>(),
+        "entry_price" => allocations.iter().map(|a| a.entry_price.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
+        "quantity" => allocations.iter().map(|a| a.quantity.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
+        "notional" => allocations.iter().map(|a| a.notional.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
+    )
+    .map_err(|error| format!("Failed to create equity allocation DataFrame: {}", error))
+}
+
+fn create_equity_order_dataframe(orders: &[EquityOrder]) -> Result<DataFrame, String> {
+    df!(
+        "id" => orders.iter().map(|o| o.id.to_string()).collect::<Vec<String>>(),
+        "allocation_id" => orders.iter().map(|o| o.allocation_id.to_string()).collect::<Vec<String>>(),
+        "submitted_at" => orders.iter().map(|o| o.submitted_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "ticker" => orders.iter().map(|o| o.ticker.as_str()).collect::<Vec<&str>>(),
+        "side" => orders.iter().map(|o| o.side.as_str()).collect::<Vec<&str>>(),
+        "quantity" => orders.iter().map(|o| o.quantity.to_string()).collect::<Vec<String>>(),
+        "order_type" => orders.iter().map(|o| o.order_type.as_str()).collect::<Vec<&str>>(),
+        "limit_price" => orders.iter().map(|o| o.limit_price.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
+        "alpaca_order_id" => orders.iter().map(|o| o.alpaca_order_id.as_str()).collect::<Vec<&str>>(),
+    )
+    .map_err(|error| format!("Failed to create equity order DataFrame: {}", error))
+}
+
+fn create_equity_portfolio_snapshot_dataframe(
+    snapshots: &[EquityPortfolioSnapshot],
+) -> Result<DataFrame, String> {
+    df!(
+        "id" => snapshots.iter().map(|s| s.id).collect::<Vec<i64>>(),
+        "snapshot_timestamp" => snapshots.iter().map(|s| s.snapshot_timestamp.timestamp_millis()).collect::<Vec<i64>>(),
+        "snapshot_type" => snapshots.iter().map(|s| s.snapshot_type.as_str()).collect::<Vec<&str>>(),
+        "net_asset_value" => snapshots.iter().map(|s| s.net_asset_value.to_string()).collect::<Vec<String>>(),
+        "gross_return" => snapshots.iter().map(|s| s.gross_return.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
+        "net_return" => snapshots.iter().map(|s| s.net_return.as_ref().map(|d| d.to_string())).collect::<Vec<Option<String>>>(),
+        "total_slippage_cost" => snapshots.iter().map(|s| s.total_slippage_cost.to_string()).collect::<Vec<String>>(),
+        "created_at" => snapshots.iter().map(|s| s.created_at.timestamp_millis()).collect::<Vec<i64>>(),
+    )
+    .map_err(|error| {
+        format!(
+            "Failed to create equity portfolio snapshot DataFrame: {}",
+            error
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use internal::market::Ticker;
+
+    fn sample_quotes() -> Vec<EquityQuote> {
+        let now = Utc::now();
+        vec![
+            EquityQuote {
+                timestamp: now,
+                ticker: Ticker::new("AAPL").unwrap(),
+                bid_price: 150.50,
+                ask_price: 150.55,
+                bid_size: 10,
+                ask_size: 5,
+            },
+            EquityQuote {
+                timestamp: now,
+                ticker: Ticker::new("MSFT").unwrap(),
+                bid_price: 420.10,
+                ask_price: 420.20,
+                bid_size: 2,
+                ask_size: 4,
+            },
+        ]
+    }
+
+    fn sample_bars() -> Vec<EquityBar> {
+        let now = Utc::now();
+        vec![EquityBar {
+            ticker: Ticker::new("AAPL").unwrap(),
+            timestamp: now,
+            open_price: 150.0,
+            high_price: 155.0,
+            low_price: 149.0,
+            close_price: 153.0,
+            volume: 1_000_000,
+            volume_weighted_average_price: Some(152.0),
+            transactions: Some(50_000),
+            inserted_at: now,
+        }]
+    }
+
+    // Construct EquityRebalanceSession without importing uuid directly;
+    // the id field type (Uuid) is inferred from the struct definition.
+    fn sample_sessions() -> Vec<EquityRebalanceSession> {
+        vec![EquityRebalanceSession {
+            id: "550e8400-e29b-41d4-a716-446655440001".parse().unwrap(),
+            triggered_at: Utc::now(),
+            trigger_reason: "intraday_check".to_string(),
+            model_run_id: Some("run-abc123".to_string()),
+            completed_at: None,
+            status: "completed".to_string(),
+        }]
+    }
+
+    // Construct EquityPair without importing rust_decimal directly;
+    // Decimal fields are inferred from the struct definition.
+    fn sample_pairs() -> Vec<EquityPair> {
+        vec![EquityPair {
+            id: "550e8400-e29b-41d4-a716-446655440002".parse().unwrap(),
+            rebalance_id: "550e8400-e29b-41d4-a716-446655440001".parse().unwrap(),
+            pair_id: "AAPL-MSFT".to_string(),
+            long_ticker: "AAPL".to_string(),
+            short_ticker: "MSFT".to_string(),
+            z_score: "2".parse().unwrap(),
+            hedge_ratio: "1".parse().unwrap(),
+            signal_strength: "0.75".parse().unwrap(),
+            status: "open".to_string(),
+            opened_at: Utc::now(),
+            closed_at: None,
+            realized_profit_and_loss: None,
+            return_percent: None,
+            holding_days: None,
+        }]
+    }
+
+    fn sample_allocations() -> Vec<EquityAllocation> {
+        vec![EquityAllocation {
+            id: "550e8400-e29b-41d4-a716-446655440003".parse().unwrap(),
+            rebalance_id: "550e8400-e29b-41d4-a716-446655440001".parse().unwrap(),
+            equity_pair_id: "550e8400-e29b-41d4-a716-446655440002".parse().unwrap(),
+            generated_at: Utc::now(),
+            model_run_id: None,
+            ticker: "AAPL".to_string(),
+            side: "LONG".to_string(),
+            action: "OPEN_POSITION".to_string(),
+            dollar_amount: "10000".parse().unwrap(),
+            entry_price: Some("150".parse().unwrap()),
+            quantity: None,
+            notional: Some("10000".parse().unwrap()),
+        }]
+    }
+
+    fn sample_orders() -> Vec<EquityOrder> {
+        vec![EquityOrder {
+            id: "550e8400-e29b-41d4-a716-446655440004".parse().unwrap(),
+            allocation_id: "550e8400-e29b-41d4-a716-446655440003".parse().unwrap(),
+            submitted_at: Utc::now(),
+            ticker: "MSFT".to_string(),
+            side: "SHORT".to_string(),
+            quantity: "25".parse().unwrap(),
+            order_type: "market".to_string(),
+            limit_price: None,
+            alpaca_order_id: "alpaca-order-xyz".to_string(),
+        }]
+    }
+
+    fn sample_snapshots() -> Vec<EquityPortfolioSnapshot> {
+        vec![EquityPortfolioSnapshot {
+            id: 1,
+            snapshot_timestamp: Utc::now(),
+            snapshot_type: "end_of_day".to_string(),
+            net_asset_value: "100000".parse().unwrap(),
+            gross_return: Some("0.02".parse().unwrap()),
+            net_return: Some("0.018".parse().unwrap()),
+            total_slippage_cost: "50".parse().unwrap(),
+            created_at: Utc::now(),
+        }]
+    }
+
+    #[test]
+    fn test_create_equity_quote_dataframe_columns_and_rows() {
+        let quotes = sample_quotes();
+        let dataframe = create_equity_quote_dataframe(&quotes).unwrap();
+        assert_eq!(dataframe.height(), 2);
+        assert_eq!(dataframe.width(), 6);
+        assert!(dataframe.column("timestamp").is_ok());
+        assert!(dataframe.column("ticker").is_ok());
+        assert!(dataframe.column("bid_price").is_ok());
+        assert!(dataframe.column("ask_price").is_ok());
+        assert!(dataframe.column("bid_size").is_ok());
+        assert!(dataframe.column("ask_size").is_ok());
+    }
+
+    #[test]
+    fn test_create_equity_quote_dataframe_empty() {
+        let dataframe = create_equity_quote_dataframe(&[]).unwrap();
+        assert_eq!(dataframe.height(), 0);
+        assert_eq!(dataframe.width(), 6);
+    }
+
+    #[test]
+    fn test_create_equity_bar_export_dataframe_columns_and_rows() {
+        let bars = sample_bars();
+        let dataframe = create_equity_bar_export_dataframe(&bars).unwrap();
+        assert_eq!(dataframe.height(), 1);
+        assert_eq!(dataframe.width(), 10);
+        assert!(dataframe.column("ticker").is_ok());
+        assert!(dataframe.column("open_price").is_ok());
+        assert!(dataframe.column("volume").is_ok());
+        assert!(dataframe.column("inserted_at").is_ok());
+    }
+
+    #[test]
+    fn test_create_equity_bar_export_dataframe_empty() {
+        let dataframe = create_equity_bar_export_dataframe(&[]).unwrap();
+        assert_eq!(dataframe.height(), 0);
+        assert_eq!(dataframe.width(), 10);
+    }
+
+    #[test]
+    fn test_create_equity_rebalance_session_dataframe_columns_and_rows() {
+        let sessions = sample_sessions();
+        let dataframe = create_equity_rebalance_session_dataframe(&sessions).unwrap();
+        assert_eq!(dataframe.height(), 1);
+        assert_eq!(dataframe.width(), 6);
+        assert!(dataframe.column("id").is_ok());
+        assert!(dataframe.column("trigger_reason").is_ok());
+        assert!(dataframe.column("status").is_ok());
+    }
+
+    #[test]
+    fn test_create_equity_rebalance_session_dataframe_empty() {
+        let dataframe = create_equity_rebalance_session_dataframe(&[]).unwrap();
+        assert_eq!(dataframe.height(), 0);
+        assert_eq!(dataframe.width(), 6);
+    }
+
+    #[test]
+    fn test_create_equity_pair_dataframe_columns_and_rows() {
+        let pairs = sample_pairs();
+        let dataframe = create_equity_pair_dataframe(&pairs).unwrap();
+        assert_eq!(dataframe.height(), 1);
+        assert_eq!(dataframe.width(), 14);
+        assert!(dataframe.column("id").is_ok());
+        assert!(dataframe.column("z_score").is_ok());
+        assert!(dataframe.column("holding_days").is_ok());
+    }
+
+    #[test]
+    fn test_create_equity_pair_dataframe_empty() {
+        let dataframe = create_equity_pair_dataframe(&[]).unwrap();
+        assert_eq!(dataframe.height(), 0);
+        assert_eq!(dataframe.width(), 14);
+    }
+
+    #[test]
+    fn test_create_equity_allocation_dataframe_columns_and_rows() {
+        let allocations = sample_allocations();
+        let dataframe = create_equity_allocation_dataframe(&allocations).unwrap();
+        assert_eq!(dataframe.height(), 1);
+        assert_eq!(dataframe.width(), 12);
+        assert!(dataframe.column("ticker").is_ok());
+        assert!(dataframe.column("dollar_amount").is_ok());
+        assert!(dataframe.column("notional").is_ok());
+    }
+
+    #[test]
+    fn test_create_equity_allocation_dataframe_empty() {
+        let dataframe = create_equity_allocation_dataframe(&[]).unwrap();
+        assert_eq!(dataframe.height(), 0);
+        assert_eq!(dataframe.width(), 12);
+    }
+
+    #[test]
+    fn test_create_equity_order_dataframe_columns_and_rows() {
+        let orders = sample_orders();
+        let dataframe = create_equity_order_dataframe(&orders).unwrap();
+        assert_eq!(dataframe.height(), 1);
+        assert_eq!(dataframe.width(), 9);
+        assert!(dataframe.column("ticker").is_ok());
+        assert!(dataframe.column("quantity").is_ok());
+        assert!(dataframe.column("alpaca_order_id").is_ok());
+    }
+
+    #[test]
+    fn test_create_equity_order_dataframe_empty() {
+        let dataframe = create_equity_order_dataframe(&[]).unwrap();
+        assert_eq!(dataframe.height(), 0);
+        assert_eq!(dataframe.width(), 9);
+    }
+
+    #[test]
+    fn test_create_equity_portfolio_snapshot_dataframe_columns_and_rows() {
+        let snapshots = sample_snapshots();
+        let dataframe = create_equity_portfolio_snapshot_dataframe(&snapshots).unwrap();
+        assert_eq!(dataframe.height(), 1);
+        assert_eq!(dataframe.width(), 8);
+        assert!(dataframe.column("id").is_ok());
+        assert!(dataframe.column("net_asset_value").is_ok());
+        assert!(dataframe.column("snapshot_type").is_ok());
+    }
+
+    #[test]
+    fn test_create_equity_portfolio_snapshot_dataframe_empty() {
+        let dataframe = create_equity_portfolio_snapshot_dataframe(&[]).unwrap();
+        assert_eq!(dataframe.height(), 0);
+        assert_eq!(dataframe.width(), 8);
+    }
+
+    #[test]
+    fn test_create_equity_pair_dataframe_serializes_decimal_as_string() {
+        let pairs = sample_pairs();
+        let dataframe = create_equity_pair_dataframe(&pairs).unwrap();
+        let z_score_series = dataframe.column("z_score").unwrap();
+        assert_eq!(z_score_series.dtype(), &DataType::String);
+    }
+
+    #[test]
+    fn test_create_equity_allocation_dataframe_serializes_decimal_as_string() {
+        let allocations = sample_allocations();
+        let dataframe = create_equity_allocation_dataframe(&allocations).unwrap();
+        let amount_series = dataframe.column("dollar_amount").unwrap();
+        assert_eq!(amount_series.dtype(), &DataType::String);
+    }
+
+    #[test]
+    fn test_export_equity_quotes_returns_zero_when_no_database() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            use crate::state::{DatabaseState, MassiveSecrets, State};
+            use aws_credential_types::Credentials;
+            use aws_sdk_s3::config::Region;
+            use chrono::NaiveDate;
+
+            let credentials =
+                Credentials::new("test-access-key", "test-secret-key", None, None, "tests");
+            let shared_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+                .region(Region::new("us-east-1"))
+                .credentials_provider(credentials)
+                .endpoint_url("http://127.0.0.1:9")
+                .load()
+                .await;
+            let s3_config = aws_sdk_s3::config::Builder::from(&shared_config)
+                .force_path_style(true)
+                .build();
+            let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+            let state = State::new(
+                reqwest::Client::new(),
+                MassiveSecrets {
+                    base: "http://127.0.0.1:1".to_string(),
+                    key: "test-api-key".to_string(),
+                },
+                s3_client,
+                "test-bucket".to_string(),
+            );
+            assert!(matches!(state.database, DatabaseState::NotConfigured));
+
+            let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+            let result = export_equity_quotes(&state, date).await;
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("database not connected"));
+        });
+    }
+
+    #[test]
+    fn test_export_equity_bars_returns_error_when_no_database() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            use crate::state::{DatabaseState, MassiveSecrets, State};
+            use aws_credential_types::Credentials;
+            use aws_sdk_s3::config::Region;
+            use chrono::NaiveDate;
+
+            let credentials =
+                Credentials::new("test-access-key", "test-secret-key", None, None, "tests");
+            let shared_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+                .region(Region::new("us-east-1"))
+                .credentials_provider(credentials)
+                .endpoint_url("http://127.0.0.1:9")
+                .load()
+                .await;
+            let s3_config = aws_sdk_s3::config::Builder::from(&shared_config)
+                .force_path_style(true)
+                .build();
+            let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+            let state = State::new(
+                reqwest::Client::new(),
+                MassiveSecrets {
+                    base: "http://127.0.0.1:1".to_string(),
+                    key: "test-api-key".to_string(),
+                },
+                s3_client,
+                "test-bucket".to_string(),
+            );
+            assert!(matches!(state.database, DatabaseState::NotConfigured));
+
+            let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+            let result = export_equity_bars(&state, date).await;
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("database not connected"));
+        });
+    }
+
+    #[test]
+    fn test_export_trading_history_returns_error_when_no_database() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            use crate::state::{DatabaseState, MassiveSecrets, State};
+            use aws_credential_types::Credentials;
+            use aws_sdk_s3::config::Region;
+            use chrono::NaiveDate;
+
+            let credentials =
+                Credentials::new("test-access-key", "test-secret-key", None, None, "tests");
+            let shared_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+                .region(Region::new("us-east-1"))
+                .credentials_provider(credentials)
+                .endpoint_url("http://127.0.0.1:9")
+                .load()
+                .await;
+            let s3_config = aws_sdk_s3::config::Builder::from(&shared_config)
+                .force_path_style(true)
+                .build();
+            let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+            let state = State::new(
+                reqwest::Client::new(),
+                MassiveSecrets {
+                    base: "http://127.0.0.1:1".to_string(),
+                    key: "test-api-key".to_string(),
+                },
+                s3_client,
+                "test-bucket".to_string(),
+            );
+            assert!(matches!(state.database, DatabaseState::NotConfigured));
+
+            let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+            let result = export_trading_history(&state, date).await;
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("database not connected"));
+        });
+    }
+}

--- a/applications/data_manager/src/lib.rs
+++ b/applications/data_manager/src/lib.rs
@@ -4,6 +4,7 @@ pub mod equity_bars;
 pub mod equity_details;
 pub mod equity_quotes;
 pub mod errors;
+pub mod export;
 pub mod health;
 pub mod router;
 pub mod scheduler;

--- a/applications/data_manager/src/scheduler.rs
+++ b/applications/data_manager/src/scheduler.rs
@@ -100,8 +100,8 @@ async fn sync_loop(state: State) {
             Ok(None) => {
                 info!("No equity bar data available for scheduled sync");
             }
-            Err(err) => {
-                error!("Equity bar sync failed: {}", err);
+            Err(error) => {
+                error!("Equity bar sync failed: {}", error);
             }
         }
     }
@@ -153,7 +153,7 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
 
     loop {
         match database::claim_pending_job(pool, "equity-bar-sync").await {
-            Ok(Some(job_id)) => {
+            Ok(Some((job_id, _))) => {
                 info!("Draining pending equity-bar-sync job on reconnect");
                 match run_equity_bar_sync(state).await {
                     Ok(Some(bar_count)) => {
@@ -178,10 +178,10 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
                             warn!("Failed to complete drained job {}: {}", job_id, error);
                         }
                     }
-                    Err(err) => {
-                        error!("Drained equity-bar-sync job failed: {}", err);
-                        if let Err(error) = database::fail_job(pool, job_id, &err).await {
-                            warn!("Failed to fail drained job {}: {}", job_id, error);
+                    Err(error) => {
+                        error!("Drained equity-bar-sync job failed: {}", error);
+                        if let Err(fail_error) = database::fail_job(pool, job_id, &error).await {
+                            warn!("Failed to fail drained job {}: {}", job_id, fail_error);
                         }
                     }
                 }
@@ -199,11 +199,28 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
         "export-equity-bars",
         "export-trading-history",
     ] {
+        match database::requeue_stale_claimed_jobs(
+            pool,
+            export_job,
+            std::time::Duration::from_secs(2 * 3600),
+        )
+        .await
+        {
+            Ok(count) if count > 0 => {
+                info!("Requeued {} stale claimed job(s) for {}", count, export_job)
+            }
+            Ok(_) => {}
+            Err(error) => warn!(
+                "Failed to requeue stale claimed jobs for {}: {}",
+                export_job, error
+            ),
+        }
+
         loop {
             match database::claim_pending_job(pool, export_job).await {
-                Ok(Some(job_id)) => {
+                Ok(Some((job_id, scheduled_at))) => {
                     info!("Draining pending {} job on reconnect", export_job);
-                    let export_date = Utc::now().date_naive();
+                    let export_date = scheduled_at.date_naive();
                     let result = run_export_job(state, export_job, export_date).await;
                     match result {
                         Ok(count) => {
@@ -214,10 +231,10 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
                                 warn!("Failed to complete drained job {}: {}", job_id, error);
                             }
                         }
-                        Err(ref err) => {
-                            error!("Drained {} failed: {}", export_job, err);
-                            if let Err(error) = database::fail_job(pool, job_id, err).await {
-                                warn!("Failed to fail drained job {}: {}", job_id, error);
+                        Err(ref error) => {
+                            error!("Drained {} failed: {}", export_job, error);
+                            if let Err(fail_error) = database::fail_job(pool, job_id, error).await {
+                                warn!("Failed to fail drained job {}: {}", job_id, fail_error);
                             }
                         }
                     }
@@ -240,7 +257,7 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
                 info!("Received NOTIFY for equity-bar-sync");
 
                 let job_id = match database::claim_pending_job(pool, "equity-bar-sync").await {
-                    Ok(Some(id)) => id,
+                    Ok(Some((id, _))) => id,
                     Ok(None) => {
                         info!("No pending equity-bar-sync job to claim");
                         continue;
@@ -278,11 +295,12 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
                             warn!("Failed to complete job {}: {}", job_id, error);
                         }
                     }
-                    Err(err) => {
-                        error!("LISTEN-triggered sync failed: {}", err);
-                        if let Err(error) = database::fail_job(pool, job_id, &err.to_string()).await
+                    Err(error) => {
+                        error!("LISTEN-triggered sync failed: {}", error);
+                        if let Err(fail_error) =
+                            database::fail_job(pool, job_id, &error.to_string()).await
                         {
-                            warn!("Failed to fail job {}: {}", job_id, error);
+                            warn!("Failed to fail job {}: {}", job_id, fail_error);
                         }
                     }
                 }
@@ -290,8 +308,9 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
             "export-equity-quotes" | "export-equity-bars" | "export-trading-history" => {
                 info!("Received NOTIFY for {}", payload);
 
-                let job_id = match database::claim_pending_job(pool, payload).await {
-                    Ok(Some(id)) => id,
+                let (job_id, scheduled_at) = match database::claim_pending_job(pool, payload).await
+                {
+                    Ok(Some(row)) => row,
                     Ok(None) => {
                         info!("No pending {} job to claim", payload);
                         continue;
@@ -302,7 +321,7 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
                     }
                 };
 
-                let export_date = Utc::now().date_naive();
+                let export_date = scheduled_at.date_naive();
                 match run_export_job(state, payload, export_date).await {
                     Ok(count) => {
                         info!("{} completed, count: {}", payload, count);
@@ -312,10 +331,10 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
                             warn!("Failed to complete job {}: {}", job_id, error);
                         }
                     }
-                    Err(ref err) => {
-                        error!("{} failed: {}", payload, err);
-                        if let Err(error) = database::fail_job(pool, job_id, err).await {
-                            warn!("Failed to fail job {}: {}", job_id, error);
+                    Err(ref error) => {
+                        error!("{} failed: {}", payload, error);
+                        if let Err(fail_error) = database::fail_job(pool, job_id, error).await {
+                            warn!("Failed to fail job {}: {}", job_id, fail_error);
                         }
                     }
                 }

--- a/applications/data_manager/src/scheduler.rs
+++ b/applications/data_manager/src/scheduler.rs
@@ -1,6 +1,7 @@
 use crate::data::TradingDate;
 use crate::database;
 use crate::equity_bars::fetch_and_store;
+use crate::export;
 use crate::state::State;
 use chrono::{DateTime, Datelike, NaiveDate, NaiveTime, TimeZone, Utc, Weekday};
 use chrono_tz::US::Eastern;
@@ -193,63 +194,156 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
         }
     }
 
+    for export_job in &[
+        "export-equity-quotes",
+        "export-equity-bars",
+        "export-trading-history",
+    ] {
+        loop {
+            match database::claim_pending_job(pool, export_job).await {
+                Ok(Some(job_id)) => {
+                    info!("Draining pending {} job on reconnect", export_job);
+                    let export_date = Utc::now().date_naive();
+                    let result = run_export_job(state, export_job, export_date).await;
+                    match result {
+                        Ok(count) => {
+                            if let Err(error) =
+                                database::complete_job(pool, job_id, &format!("count: {}", count))
+                                    .await
+                            {
+                                warn!("Failed to complete drained job {}: {}", job_id, error);
+                            }
+                        }
+                        Err(ref err) => {
+                            error!("Drained {} failed: {}", export_job, err);
+                            if let Err(error) = database::fail_job(pool, job_id, err).await {
+                                warn!("Failed to fail drained job {}: {}", job_id, error);
+                            }
+                        }
+                    }
+                }
+                Ok(None) => break,
+                Err(error) => {
+                    warn!("Failed to drain pending {} jobs: {}", export_job, error);
+                    break;
+                }
+            }
+        }
+    }
+
     loop {
         let notification = listener.recv().await?;
         let payload = notification.payload();
 
-        if payload != "equity-bar-sync" {
-            continue;
+        match payload {
+            "equity-bar-sync" => {
+                info!("Received NOTIFY for equity-bar-sync");
+
+                let job_id = match database::claim_pending_job(pool, "equity-bar-sync").await {
+                    Ok(Some(id)) => id,
+                    Ok(None) => {
+                        info!("No pending equity-bar-sync job to claim");
+                        continue;
+                    }
+                    Err(error) => {
+                        warn!("Failed to claim job: {}", error);
+                        continue;
+                    }
+                };
+
+                let trading_date = sync_date_for(Utc::now());
+
+                match fetch_and_store(state, &trading_date).await {
+                    Ok(Some(bar_count)) => {
+                        info!("LISTEN-triggered sync completed, bar_count: {}", bar_count);
+                        if let Err(error) = database::complete_job(
+                            pool,
+                            job_id,
+                            &format!("bar_count: {}", bar_count),
+                        )
+                        .await
+                        {
+                            warn!("Failed to complete job {}: {}", job_id, error);
+                        }
+                        if let Err(error) = database::emit_equity_bars_synced(pool).await {
+                            warn!("Failed to emit equity_bars_synced: {}", error);
+                        }
+                        state.mark_synced();
+                    }
+                    Ok(None) => {
+                        info!("No data available for LISTEN-triggered sync");
+                        if let Err(error) =
+                            database::complete_job(pool, job_id, "no data available").await
+                        {
+                            warn!("Failed to complete job {}: {}", job_id, error);
+                        }
+                    }
+                    Err(err) => {
+                        error!("LISTEN-triggered sync failed: {}", err);
+                        if let Err(error) = database::fail_job(pool, job_id, &err.to_string()).await
+                        {
+                            warn!("Failed to fail job {}: {}", job_id, error);
+                        }
+                    }
+                }
+            }
+            "export-equity-quotes" | "export-equity-bars" | "export-trading-history" => {
+                info!("Received NOTIFY for {}", payload);
+
+                let job_id = match database::claim_pending_job(pool, payload).await {
+                    Ok(Some(id)) => id,
+                    Ok(None) => {
+                        info!("No pending {} job to claim", payload);
+                        continue;
+                    }
+                    Err(error) => {
+                        warn!("Failed to claim {} job: {}", payload, error);
+                        continue;
+                    }
+                };
+
+                let export_date = Utc::now().date_naive();
+                match run_export_job(state, payload, export_date).await {
+                    Ok(count) => {
+                        info!("{} completed, count: {}", payload, count);
+                        if let Err(error) =
+                            database::complete_job(pool, job_id, &format!("count: {}", count)).await
+                        {
+                            warn!("Failed to complete job {}: {}", job_id, error);
+                        }
+                    }
+                    Err(ref err) => {
+                        error!("{} failed: {}", payload, err);
+                        if let Err(error) = database::fail_job(pool, job_id, err).await {
+                            warn!("Failed to fail job {}: {}", job_id, error);
+                        }
+                    }
+                }
+            }
+            _ => {}
         }
+    }
+}
 
-        info!("Received NOTIFY for equity-bar-sync");
-
-        let job_id = match database::claim_pending_job(pool, "equity-bar-sync").await {
-            Ok(Some(id)) => id,
-            Ok(None) => {
-                info!("No pending equity-bar-sync job to claim");
-                continue;
-            }
-            Err(error) => {
-                warn!("Failed to claim job: {}", error);
-                continue;
-            }
-        };
-
-        let trading_date = sync_date_for(Utc::now());
-
-        match fetch_and_store(state, &trading_date).await {
-            Ok(Some(bar_count)) => {
-                info!("LISTEN-triggered sync completed, bar_count: {}", bar_count);
-                if let Err(error) =
-                    database::complete_job(pool, job_id, &format!("bar_count: {}", bar_count)).await
-                {
-                    warn!("Failed to complete job {}: {}", job_id, error);
-                }
-                if let Err(error) = database::emit_equity_bars_synced(pool).await {
-                    warn!("Failed to emit equity_bars_synced: {}", error);
-                }
-                state.mark_synced();
-            }
-            Ok(None) => {
-                info!("No data available for LISTEN-triggered sync");
-                if let Err(error) = database::complete_job(pool, job_id, "no data available").await
-                {
-                    warn!("Failed to complete job {}: {}", job_id, error);
-                }
-            }
-            Err(err) => {
-                error!("LISTEN-triggered sync failed: {}", err);
-                if let Err(error) = database::fail_job(pool, job_id, &err.to_string()).await {
-                    warn!("Failed to fail job {}: {}", job_id, error);
-                }
-            }
+async fn run_export_job(
+    state: &State,
+    job_name: &str,
+    export_date: NaiveDate,
+) -> Result<usize, String> {
+    match job_name {
+        "export-equity-quotes" => export::export_equity_quotes(state, export_date).await,
+        "export-equity-bars" => export::export_equity_bars(state, export_date).await,
+        "export-trading-history" => export::export_trading_history(state, export_date).await,
+        _ => {
+            let message = format!("Unknown export job: {}", job_name);
+            Err(message)
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{duration_until_next_sync, prior_trading_day, sync_date_for};
+    use super::{duration_until_next_sync, prior_trading_day, run_export_job, sync_date_for};
     use chrono::{NaiveDate, TimeZone, Utc};
     use chrono_tz::US::Eastern;
     use std::time::Duration;
@@ -385,5 +479,44 @@ mod tests {
             sync_date.as_naive_date(),
             NaiveDate::from_ymd_opt(2026, 4, 28).unwrap()
         );
+    }
+
+    #[test]
+    fn test_run_export_job_returns_error_for_unknown_job() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            use crate::state::{MassiveSecrets, State};
+            use aws_credential_types::Credentials;
+            use aws_sdk_s3::config::Region;
+
+            let credentials =
+                Credentials::new("test-access-key", "test-secret-key", None, None, "tests");
+            let shared_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+                .region(Region::new("us-east-1"))
+                .credentials_provider(credentials)
+                .endpoint_url("http://127.0.0.1:9")
+                .load()
+                .await;
+            let s3_config = aws_sdk_s3::config::Builder::from(&shared_config)
+                .force_path_style(true)
+                .build();
+            let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+            let state = State::new(
+                reqwest::Client::new(),
+                MassiveSecrets {
+                    base: "http://127.0.0.1:1".to_string(),
+                    key: "test-api-key".to_string(),
+                },
+                s3_client,
+                "test-bucket".to_string(),
+            );
+            let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+            let result = run_export_job(&state, "unknown-job", date).await;
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("Unknown export job"));
+        });
     }
 }

--- a/applications/data_manager/src/state.rs
+++ b/applications/data_manager/src/state.rs
@@ -10,8 +10,6 @@ use sqlx::PgPool;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
-use crate::database::set_bucket_guc;
-
 /// Alpaca API credentials.
 ///
 /// The private fields enforce that credentials are only constructed when both
@@ -148,9 +146,6 @@ impl State {
                 match PgPool::connect(&database_url).await {
                     Ok(pool) => {
                         info!("Connected to PostgreSQL");
-                        if let Err(error) = set_bucket_guc(&pool, &bucket_name).await {
-                            warn!("Failed to set app.bucket_name database GUC: {}", error);
-                        }
                         DatabaseState::Connected(pool)
                     }
                     Err(error) => {

--- a/applications/data_manager/tests/test_database.rs
+++ b/applications/data_manager/tests/test_database.rs
@@ -3,7 +3,10 @@ mod common;
 use chrono::Utc;
 use data_manager::data::{EquityBar, Ticker};
 use data_manager::database::{
-    claim_pending_job, complete_job, fail_job, insert_equity_bars, set_bucket_guc,
+    claim_pending_job, complete_job, fail_job, insert_equity_bars, query_equity_allocations,
+    query_equity_bars_for_date, query_equity_orders, query_equity_pairs,
+    query_equity_portfolio_snapshots, query_equity_quotes_for_date,
+    query_equity_rebalance_sessions,
 };
 use serial_test::serial;
 use sqlx::PgPool;
@@ -321,29 +324,62 @@ async fn test_complete_job() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
-async fn test_set_bucket_guc_persists() {
+async fn test_query_equity_quotes_for_date_returns_empty() {
     let pool = get_pg_pool().await;
+    use chrono::NaiveDate;
+    let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+    let quotes = query_equity_quotes_for_date(&pool, date).await.unwrap();
+    assert!(quotes.is_empty());
+}
 
-    set_bucket_guc(&pool, "fund-test-data").await.unwrap();
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn test_query_equity_bars_for_date_returns_empty_for_future_date() {
+    let pool = get_pg_pool().await;
+    use chrono::NaiveDate;
+    let date = NaiveDate::from_ymd_opt(2099, 1, 1).unwrap();
+    let bars = query_equity_bars_for_date(&pool, date).await.unwrap();
+    assert!(bars.is_empty());
+}
 
-    // ALTER DATABASE persists the GUC in pg_db_role_setting for all future connections.
-    // Verify the setting appears there with the expected value.
-    let settings: Vec<String> = sqlx::query_scalar(
-        "SELECT unnest(setconfig) FROM pg_db_role_setting \
-         WHERE setdatabase = (SELECT oid FROM pg_database WHERE datname = current_database()) \
-         AND setrole = 0",
-    )
-    .fetch_all(&pool)
-    .await
-    .unwrap();
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn test_query_equity_rebalance_sessions_returns_empty() {
+    let pool = get_pg_pool().await;
+    let sessions = query_equity_rebalance_sessions(&pool).await.unwrap();
+    assert!(sessions.is_empty());
+}
 
-    assert!(
-        settings.iter().any(
-            |setting| setting.contains("app.bucket_name") && setting.contains("fund-test-data")
-        ),
-        "Expected app.bucket_name GUC to be persisted, got: {:?}",
-        settings
-    );
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn test_query_equity_pairs_returns_empty() {
+    let pool = get_pg_pool().await;
+    let pairs = query_equity_pairs(&pool).await.unwrap();
+    assert!(pairs.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn test_query_equity_allocations_returns_empty() {
+    let pool = get_pg_pool().await;
+    let allocations = query_equity_allocations(&pool).await.unwrap();
+    assert!(allocations.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn test_query_equity_orders_returns_empty() {
+    let pool = get_pg_pool().await;
+    let orders = query_equity_orders(&pool).await.unwrap();
+    assert!(orders.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn test_query_equity_portfolio_snapshots_returns_empty() {
+    let pool = get_pg_pool().await;
+    let snapshots = query_equity_portfolio_snapshots(&pool).await.unwrap();
+    assert!(snapshots.is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/applications/data_manager/tests/test_database.rs
+++ b/applications/data_manager/tests/test_database.rs
@@ -305,7 +305,7 @@ async fn test_complete_job() {
     .await
     .unwrap();
 
-    let job_id = claim_pending_job(&pool, "equity-bar-sync")
+    let (job_id, _) = claim_pending_job(&pool, "equity-bar-sync")
         .await
         .unwrap()
         .unwrap();
@@ -396,7 +396,7 @@ async fn test_fail_job() {
     .await
     .unwrap();
 
-    let job_id = claim_pending_job(&pool, "equity-bar-sync")
+    let (job_id, _) = claim_pending_job(&pool, "equity-bar-sync")
         .await
         .unwrap()
         .unwrap();

--- a/schema.sql
+++ b/schema.sql
@@ -4,18 +4,6 @@
 CREATE EXTENSION IF NOT EXISTS timescaledb;
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 
--- pg_parquet is installed on Linux deployments via nix/pg_parquet.nix.
--- Silently skipped on environments where the extension is not available (e.g., macOS dev).
-DO $do$
-BEGIN
-    IF EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'pg_parquet') THEN
-        CREATE EXTENSION IF NOT EXISTS pg_parquet;
-    ELSE
-        RAISE WARNING 'pg_parquet is not available; quote archival is disabled';
-    END IF;
-END;
-$do$;
-
 -- equity_bars: Rolling buffer for equity bar data (last 90 days; ensemble needs 70-day lookback)
 -- Source: Massive API (historical), Alpaca REST (EOD backfill)
 CREATE TABLE IF NOT EXISTS equity_bars (
@@ -33,23 +21,9 @@ CREATE TABLE IF NOT EXISTS equity_bars (
 );
 
 SELECT create_hypertable('equity_bars', by_range('timestamp'), if_not_exists => TRUE);
-CREATE INDEX IF NOT EXISTS idx_equity_bars_inserted_at ON equity_bars (inserted_at);
-CREATE INDEX IF NOT EXISTS idx_equity_bars_timestamp ON equity_bars (timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_equity_bars_inserted_at ON equity_bars (inserted_at); -- noqa: PG01
+CREATE INDEX IF NOT EXISTS idx_equity_bars_timestamp ON equity_bars (timestamp DESC); -- noqa: PG01
 SELECT add_retention_policy('equity_bars', INTERVAL '90 days', if_not_exists => TRUE);
-
--- Migrate equity_quotes column types from NUMERIC to DOUBLE PRECISION if running against an older schema.
-DO $do$
-BEGIN
-    IF EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'equity_quotes' AND column_name = 'bid_price' AND data_type = 'numeric'
-    ) THEN
-        ALTER TABLE equity_quotes
-            ALTER COLUMN bid_price TYPE DOUBLE PRECISION,
-            ALTER COLUMN ask_price TYPE DOUBLE PRECISION;
-    END IF;
-END;
-$do$;
 
 -- equity_quotes: intraday bid/ask rolling 24-hour buffer
 -- Exported to S3 Parquet daily then purged; future use: replay simulation
@@ -62,44 +36,8 @@ CREATE TABLE IF NOT EXISTS equity_quotes (
     ask_size    INTEGER     NOT NULL
 );
 SELECT create_hypertable('equity_quotes', by_range('timestamp'), if_not_exists => TRUE);
-CREATE INDEX IF NOT EXISTS idx_equity_quotes_ticker_timestamp ON equity_quotes (ticker, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_equity_quotes_ticker_timestamp ON equity_quotes (ticker, timestamp DESC); -- noqa: PG01
 SELECT add_retention_policy('equity_quotes', INTERVAL '1 day', if_not_exists => TRUE);
-
--- export_equity_quotes: exports the current trading day's quotes to S3 Parquet then purges them.
--- Reads the S3 bucket name from the app.bucket_name database GUC (set by data-manager on startup).
--- pg_parquet must be installed and S3 credentials must be available to the PostgreSQL process.
--- Returns early with a WARNING if pg_parquet is not installed.
-CREATE OR REPLACE FUNCTION export_equity_quotes() RETURNS void AS $$
-DECLARE
-    export_date DATE := CURRENT_DATE;
-    bucket_name  TEXT := current_setting('app.bucket_name', true);
-    s3_path      TEXT;
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_parquet') THEN
-        RAISE WARNING 'pg_parquet is not installed; skipping equity quotes export';
-        RETURN;
-    END IF;
-    IF bucket_name IS NULL OR bucket_name = '' THEN
-        RAISE EXCEPTION 'app.bucket_name GUC is not set; cannot export equity quotes';
-    END IF;
-    s3_path := format(
-        's3://%s/data/equity/quotes/year=%s/month=%s/day=%s/data.parquet',
-        bucket_name,
-        to_char(export_date, 'YYYY'),
-        to_char(export_date, 'MM'),
-        to_char(export_date, 'DD')
-    );
-    EXECUTE format(
-        'COPY (SELECT timestamp, ticker, bid_price, ask_price, bid_size, ask_size FROM equity_quotes WHERE timestamp >= %L AND timestamp < %L) TO %L',
-        export_date::timestamptz,
-        (export_date + 1)::timestamptz,
-        s3_path
-    );
-    DELETE FROM equity_quotes
-    WHERE timestamp >= export_date::timestamptz
-      AND timestamp < (export_date + 1)::timestamptz;
-END;
-$$ LANGUAGE plpgsql;
 
 -- equity_rebalance_sessions: groups one full rebalance cycle (allocation to orders)
 CREATE TABLE IF NOT EXISTS equity_rebalance_sessions (
@@ -110,20 +48,6 @@ CREATE TABLE IF NOT EXISTS equity_rebalance_sessions (
     completed_at    TIMESTAMPTZ,
     status          TEXT        NOT NULL
 );
-
--- Drop NOT NULL on model_run_id if running against the old schema that had it NOT NULL.
-DO $do$
-BEGIN
-    IF EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'equity_rebalance_sessions'
-          AND column_name = 'model_run_id'
-          AND is_nullable = 'NO'
-    ) THEN
-        ALTER TABLE equity_rebalance_sessions ALTER COLUMN model_run_id DROP NOT NULL;
-    END IF;
-END;
-$do$;
 
 -- equity_pairs: one row per cointegrated pair per rebalance cycle
 -- Entry signals (z_score, hedge_ratio, signal_strength) are recorded at the time of opening.
@@ -145,33 +69,6 @@ CREATE TABLE IF NOT EXISTS equity_pairs (
     holding_days               INTEGER,
     UNIQUE (pair_id, opened_at)
 );
-
--- Add return_percent column if running against an older schema that lacked it.
-DO $do$
-BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'equity_pairs' AND column_name = 'return_percent'
-    ) THEN
-        ALTER TABLE equity_pairs ADD COLUMN return_percent NUMERIC;
-    END IF;
-END;
-$do$;
-
--- Drop equity_allocations (and equity_orders that reference it) if running against the old schema
--- (target_weight/reference_price columns). The new schema is incompatible: it requires FKs to
--- equity_pairs (a new table), so old rows cannot be preserved.
-DO $do$
-BEGIN
-    IF EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'equity_allocations' AND column_name = 'target_weight'
-    ) THEN
-        DROP TABLE IF EXISTS equity_orders;
-        DROP TABLE equity_allocations;
-    END IF;
-END;
-$do$;
 
 -- equity_allocations: one row per ticker leg per rebalance cycle
 -- side and action match PositionSide/PositionAction enums in portfolio_schema.py
@@ -195,23 +92,7 @@ CREATE TABLE IF NOT EXISTS equity_allocations (
         CHECK (quantity IS NOT NULL OR notional IS NOT NULL)
 );
 
-CREATE INDEX IF NOT EXISTS idx_equity_allocations_rebalance_id ON equity_allocations (rebalance_id);
-
--- Add quantity and notional columns with CHECK if running against an older schema.
-DO $do$
-BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'equity_allocations' AND column_name = 'quantity'
-    ) THEN
-        ALTER TABLE equity_allocations ADD COLUMN quantity NUMERIC;
-        ALTER TABLE equity_allocations ADD COLUMN notional NUMERIC;
-        ALTER TABLE equity_allocations
-            ADD CONSTRAINT equity_allocations_quantity_notional_check
-            CHECK (quantity IS NOT NULL OR notional IS NOT NULL) NOT VALID;
-    END IF;
-END;
-$do$;
+CREATE INDEX IF NOT EXISTS idx_equity_allocations_rebalance_id ON equity_allocations (rebalance_id); -- noqa: PG01
 
 -- equity_orders: orders submitted to Alpaca, linked to allocations
 CREATE TABLE IF NOT EXISTS equity_orders (
@@ -226,35 +107,7 @@ CREATE TABLE IF NOT EXISTS equity_orders (
     alpaca_order_id  TEXT        NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_equity_orders_allocation_id ON equity_orders (allocation_id);
-
--- Add FK from equity_orders.allocation_id to equity_allocations if running against a pre-migration schema
--- that had allocation_id as a plain UUID with no constraint.
-DO $do$
-BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM information_schema.table_constraints
-        WHERE table_name = 'equity_orders' AND constraint_name = 'equity_orders_allocation_id_fkey'
-    ) THEN
-        ALTER TABLE equity_orders
-            ADD CONSTRAINT equity_orders_allocation_id_fkey
-            FOREIGN KEY (allocation_id) REFERENCES equity_allocations(id);
-    END IF;
-END;
-$do$;
-
--- Migrate equity_portfolio_snapshots from the old snapshot_date-keyed schema to the new
--- per-rebalance schema with snapshot_type.  Old rows cannot be preserved (incompatible PK).
-DO $do$
-BEGIN
-    IF EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_name = 'equity_portfolio_snapshots' AND column_name = 'snapshot_date'
-    ) THEN
-        DROP TABLE equity_portfolio_snapshots;
-    END IF;
-END;
-$do$;
+CREATE INDEX IF NOT EXISTS idx_equity_orders_allocation_id ON equity_orders (allocation_id); -- noqa: PG01
 
 -- equity_portfolio_snapshots: per-rebalance portfolio state snapshots
 -- 'intraday' rows are recorded after each live rebalance; gross_return and net_return are NULL.
@@ -270,26 +123,11 @@ CREATE TABLE IF NOT EXISTS equity_portfolio_snapshots (
     created_at           TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- Reconcile databases created before the eod -> end_of_day rename. No-ops on a fresh
--- database; on an existing one they migrate stored values and swap the CHECK constraint
--- so end_of_day INSERTs are accepted. The old constraint is dropped BEFORE the UPDATE so
--- the new value does not violate the still-active old check.
-ALTER TABLE equity_portfolio_snapshots
-    DROP CONSTRAINT IF EXISTS equity_portfolio_snapshots_snapshot_type_check;
-UPDATE equity_portfolio_snapshots
-    SET snapshot_type = 'end_of_day'
-    WHERE snapshot_type = 'eod';
-ALTER TABLE equity_portfolio_snapshots
-    ADD CONSTRAINT equity_portfolio_snapshots_snapshot_type_check
-    CHECK (snapshot_type IN ('intraday', 'end_of_day'));
--- Drop the pre-rename partial unique index; the renamed, UTC-anchored index is created below.
-DROP INDEX IF EXISTS uq_equity_portfolio_snapshots_eod_date;
-
-CREATE INDEX IF NOT EXISTS idx_equity_portfolio_snapshots_timestamp
+CREATE INDEX IF NOT EXISTS idx_equity_portfolio_snapshots_timestamp -- noqa: PG01
     ON equity_portfolio_snapshots (snapshot_timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_equity_portfolio_snapshots_type_timestamp
+CREATE INDEX IF NOT EXISTS idx_equity_portfolio_snapshots_type_timestamp -- noqa: PG01
     ON equity_portfolio_snapshots (snapshot_type, snapshot_timestamp DESC);
-CREATE UNIQUE INDEX IF NOT EXISTS uq_equity_portfolio_snapshots_end_of_day_date
+CREATE UNIQUE INDEX IF NOT EXISTS uq_equity_portfolio_snapshots_end_of_day_date -- noqa: PG01
     ON equity_portfolio_snapshots (((snapshot_timestamp AT TIME ZONE 'UTC')::date))
     WHERE snapshot_type = 'end_of_day';
 
@@ -333,8 +171,8 @@ CREATE TABLE IF NOT EXISTS model_runs (
     completed_at                        TIMESTAMPTZ
 );
 
-CREATE INDEX IF NOT EXISTS idx_model_runs_status ON model_runs (status);
-CREATE INDEX IF NOT EXISTS idx_model_runs_started_at ON model_runs (started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_model_runs_status ON model_runs (status); -- noqa: PG01
+CREATE INDEX IF NOT EXISTS idx_model_runs_started_at ON model_runs (started_at DESC); -- noqa: PG01
 
 -- scheduled_jobs: Job queue for pg_cron + LISTEN/NOTIFY
 CREATE TABLE IF NOT EXISTS scheduled_jobs (
@@ -348,7 +186,7 @@ CREATE TABLE IF NOT EXISTS scheduled_jobs (
     result       TEXT
 );
 
-CREATE INDEX IF NOT EXISTS idx_scheduled_jobs_pending
+CREATE INDEX IF NOT EXISTS idx_scheduled_jobs_pending -- noqa: PG01
     ON scheduled_jobs (job_name, status) WHERE status = 'pending';
 
 -- Notify function: insert row then send NOTIFY on channel "jobs"
@@ -378,7 +216,7 @@ CREATE TABLE IF NOT EXISTS events (
 );
 
 SELECT create_hypertable('events', by_range('created_at'), if_not_exists => TRUE);
-CREATE INDEX IF NOT EXISTS idx_events_type_id ON events (event_type, id);
+CREATE INDEX IF NOT EXISTS idx_events_type_id ON events (event_type, id); -- noqa: PG01
 SELECT add_retention_policy('events', INTERVAL '30 days', if_not_exists => TRUE);
 
 -- notify_event: fires pg_notify on the 'events' channel after each insert.
@@ -425,19 +263,6 @@ CREATE TABLE IF NOT EXISTS event_consumer_offsets (
     updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- Rename predictions to equity_predictions on existing deployments.
-DO $do$
-BEGIN
-    IF EXISTS (
-        SELECT 1 FROM information_schema.tables WHERE table_name = 'predictions'
-    ) AND NOT EXISTS (
-        SELECT 1 FROM information_schema.tables WHERE table_name = 'equity_predictions'
-    ) THEN
-        ALTER TABLE predictions RENAME TO equity_predictions;
-    END IF;
-END;
-$do$;
-
 -- equity_predictions: model output quantiles (7-day rolling buffer)
 -- Columns match the Prediction struct in data_manager/src/data.rs and
 -- the predictions_schema pandera definition in ensemble_manager.
@@ -475,32 +300,6 @@ BEGIN
 END;
 $do$;
 
--- Remove legacy archive-quotes cron job and function on existing deployments.
-DO $do$
-BEGIN
-    IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'archive-quotes') THEN
-        PERFORM cron.unschedule('archive-quotes');
-    END IF;
-END;
-$do$;
-DROP FUNCTION IF EXISTS archive_equity_quotes();
-
--- Daily equity quotes export: weekdays at 21:05 UTC (after intraday-check window ends at 20:55 UTC
--- and after 4 PM Eastern market close in both EDT and EST)
--- Only scheduled when pg_parquet is available; export_equity_quotes() also guards at runtime.
-DO $do$
-BEGIN
-    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_parquet')
-       AND NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'export-equity-quotes') THEN
-        PERFORM cron.schedule(
-            'export-equity-quotes',
-            '5 21 * * 1-5',
-            $$SELECT export_equity_quotes()$$
-        );
-    END IF;
-END;
-$do$;
-
 -- record_end_of_day_snapshot: emits an event for portfolio-manager to record the day's final NAV and compute returns.
 CREATE OR REPLACE FUNCTION record_end_of_day_snapshot() RETURNS void AS $$
 BEGIN
@@ -522,144 +321,64 @@ BEGIN
 END;
 $do$;
 
--- Reconcile databases created before the eod -> end_of_day rename: remove the old pg_cron
--- job so it does not fire alongside record-end-of-day-snapshot (which would produce
--- duplicate end-of-day snapshots and orphaned eod_snapshot_requested events).
+-- Daily equity quotes export: weekdays at 21:05 UTC (after intraday-check window ends at 20:55 UTC
+-- and after 4 PM Eastern market close in both EDT and EST).
+-- Triggers a Rust export task in data_manager via the jobs channel.
 DO $do$
 BEGIN
-    IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'record-eod-snapshot') THEN
-        PERFORM cron.unschedule('record-eod-snapshot');
+    PERFORM cron.unschedule('export-equity-quotes');
+EXCEPTION WHEN OTHERS THEN NULL;
+END;
+$do$;
+DO $do$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'export-equity-quotes') THEN
+        PERFORM cron.schedule(
+            'export-equity-quotes',
+            '5 21 * * 1-5',
+            $$SELECT schedule_job('export-equity-quotes')$$
+        );
     END IF;
 END;
 $do$;
 
--- Drop the pre-rename function and rename any not-yet-consumed events so the new consumer
--- still processes them (harmless on already-consumed rows; consumers track progress by id).
-DROP FUNCTION IF EXISTS record_eod_snapshot();
-UPDATE events
-    SET event_type = 'end_of_day_snapshot_requested'
-    WHERE event_type = 'eod_snapshot_requested';
-
--- export_equity_bars: exports equity_bars for the past 120 days to S3 Parquet for model training.
--- Reads the S3 bucket name from the app.bucket_name GUC (set by data-manager on startup).
--- Returns early with a WARNING if pg_parquet is not installed.
-CREATE OR REPLACE FUNCTION export_equity_bars() RETURNS void AS $$
-DECLARE
-    export_date  DATE := CURRENT_DATE;
-    bucket_name  TEXT := current_setting('app.bucket_name', true);
-    s3_path      TEXT;
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_parquet') THEN
-        RAISE WARNING 'pg_parquet is not installed; skipping equity bars export';
-        RETURN;
-    END IF;
-    IF bucket_name IS NULL OR bucket_name = '' THEN
-        RAISE EXCEPTION 'app.bucket_name GUC is not set; cannot export equity bars';
-    END IF;
-    s3_path := format(
-        's3://%s/data/equity/bars/year=%s/month=%s/day=%s/data.parquet',
-        bucket_name,
-        to_char(export_date, 'YYYY'),
-        to_char(export_date, 'MM'),
-        to_char(export_date, 'DD')
-    );
-    EXECUTE format(
-        'COPY (SELECT ticker, timestamp, open_price, high_price, low_price, close_price, volume, volume_weighted_average_price, transactions, inserted_at FROM equity_bars WHERE timestamp >= %L AND timestamp < %L) TO %L',
-        export_date::timestamptz,
-        (export_date + INTERVAL '1 day')::timestamptz,
-        s3_path
-    );
-END;
-$$ LANGUAGE plpgsql;
-
--- Remove legacy export-training-parquet cron job on existing deployments.
+-- Nightly equity bars export: weekdays at 21:30 UTC.
+-- Triggers a Rust export task in data_manager via the jobs channel.
 DO $do$
 BEGIN
-    IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'export-training-parquet') THEN
-        PERFORM cron.unschedule('export-training-parquet');
-    END IF;
+    PERFORM cron.unschedule('export-equity-bars');
+EXCEPTION WHEN OTHERS THEN NULL;
 END;
 $do$;
-
--- Nightly equity bars export: weekdays at 21:30 UTC
--- Only scheduled when pg_parquet is available; export_equity_bars() also guards at runtime.
 DO $do$
 BEGIN
-    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_parquet')
-       AND NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'export-equity-bars') THEN
+    IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'export-equity-bars') THEN
         PERFORM cron.schedule(
             'export-equity-bars',
             '30 21 * * 1-5',
-            $$SELECT export_equity_bars()$$
+            $$SELECT schedule_job('export-equity-bars')$$
         );
     END IF;
 END;
 $do$;
 
--- export_trading_history: exports irreplaceable trading tables to S3 Parquet cold storage.
--- Reads the S3 bucket name from the app.bucket_name GUC (set by data-manager on startup).
--- Returns early with a WARNING if pg_parquet is not installed.
-CREATE OR REPLACE FUNCTION export_trading_history() RETURNS void AS $$
-DECLARE
-    export_date  DATE := CURRENT_DATE;
-    bucket_name  TEXT := current_setting('app.bucket_name', true);
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_parquet') THEN
-        RAISE WARNING 'pg_parquet is not installed; skipping trading history export';
-        RETURN;
-    END IF;
-    IF bucket_name IS NULL OR bucket_name = '' THEN
-        RAISE EXCEPTION 'app.bucket_name GUC is not set; cannot export trading history';
-    END IF;
-    EXECUTE format(
-        'COPY (SELECT * FROM equity_rebalance_sessions) TO %L',
-        format('s3://%s/exports/equity/rebalance-sessions/year=%s/month=%s/day=%s/data.parquet',
-               bucket_name, to_char(export_date, 'YYYY'), to_char(export_date, 'MM'), to_char(export_date, 'DD'))
-    );
-    EXECUTE format(
-        'COPY (SELECT * FROM equity_pairs) TO %L',
-        format('s3://%s/exports/equity/pairs/year=%s/month=%s/day=%s/data.parquet',
-               bucket_name, to_char(export_date, 'YYYY'), to_char(export_date, 'MM'), to_char(export_date, 'DD'))
-    );
-    EXECUTE format(
-        'COPY (SELECT * FROM equity_allocations) TO %L',
-        format('s3://%s/exports/equity/allocations/year=%s/month=%s/day=%s/data.parquet',
-               bucket_name, to_char(export_date, 'YYYY'), to_char(export_date, 'MM'), to_char(export_date, 'DD'))
-    );
-    EXECUTE format(
-        'COPY (SELECT * FROM equity_orders) TO %L',
-        format('s3://%s/exports/equity/orders/year=%s/month=%s/day=%s/data.parquet',
-               bucket_name, to_char(export_date, 'YYYY'), to_char(export_date, 'MM'), to_char(export_date, 'DD'))
-    );
-    EXECUTE format(
-        'COPY (SELECT * FROM equity_portfolio_snapshots) TO %L',
-        format('s3://%s/exports/equity/portfolio-snapshots/year=%s/month=%s/day=%s/data.parquet',
-               bucket_name, to_char(export_date, 'YYYY'), to_char(export_date, 'MM'), to_char(export_date, 'DD'))
-    );
-END;
-$$ LANGUAGE plpgsql;
-
--- Remove legacy backup-trading-history cron job on existing deployments.
+-- Nightly trading history export: weekdays at 21:45 UTC (after record-end-of-day-snapshot at 21:15
+-- so today's snapshot is included).
+-- Triggers a Rust export task in data_manager via the jobs channel.
 DO $do$
 BEGIN
-    IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'backup-trading-history') THEN
-        PERFORM cron.unschedule('backup-trading-history');
-    END IF;
+    PERFORM cron.unschedule('export-trading-history');
+EXCEPTION WHEN OTHERS THEN NULL;
 END;
 $do$;
-
--- Nightly trading history export: weekdays at 21:45 UTC (after record-end-of-day-snapshot at 21:15 so today's snapshot is included).
--- Only scheduled when pg_parquet is available; export_trading_history() also guards at runtime.
 DO $do$
 BEGIN
-    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_parquet')
-       AND NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'export-trading-history') THEN
+    IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'export-trading-history') THEN
         PERFORM cron.schedule(
             'export-trading-history',
             '45 21 * * 1-5',
-            $$SELECT export_trading_history()$$
+            $$SELECT schedule_job('export-trading-history')$$
         );
     END IF;
 END;
 $do$;
-


### PR DESCRIPTION
# Overview

## Changes

- Closes #906
- Implements Rust async export tasks for equity quotes, equity bars, and trading history, triggered via the existing pg_cron + LISTEN/NOTIFY jobs channel
- Adds `applications/data_manager/src/export.rs` with `export_equity_quotes`, `export_equity_bars`, and `export_trading_history`; each function queries PostgreSQL via `sqlx::query_as`, builds a Polars DataFrame, serializes to Parquet, and writes to S3 via `aws-sdk-s3`; `Decimal` and `Uuid` fields serialized as strings for cold-storage fidelity
- Adds eight new typed query/delete functions to `database.rs` (`query_equity_quotes_for_date`, `delete_equity_quotes_for_date`, `query_equity_bars_for_date`, `query_equity_rebalance_sessions`, `query_equity_pairs`, `query_equity_allocations`, `query_equity_orders`, `query_equity_portfolio_snapshots`)
- Removes `set_bucket_guc` from `database.rs` and `State::from_env` (pg_parquet GUC no longer needed)
- Extends `scheduler.rs` with a startup drain loop and LISTEN match arms for all three export job names; adds `run_export_job` dispatch helper
- Rewrites `schema.sql`: removes `CREATE EXTENSION IF NOT EXISTS pg_parquet`, all dead migration `DO` blocks, and the three PL/pgSQL export functions; replaces pg_parquet-conditional cron schedule blocks with unconditional `schedule_job()` calls at 21:05, 21:30, and 21:45 UTC; adds `-- noqa: PG01` suppressions to pre-existing `CREATE INDEX` statements (schema initialization is not live migration)
- Updates integration tests in `tests/test_database.rs` to cover the eight new query functions

## Context

Part of the Rust and data pipeline refactor tracked in #898. This wave moves Parquet export logic out of PostgreSQL PL/pgSQL (which required the `pg_parquet` native extension) into Rust async tasks inside `data_manager`. The pg_cron jobs now insert rows into `scheduled_jobs` via `schedule_job()`, which triggers the existing LISTEN/NOTIFY mechanism already used by `equity-bar-sync`.

S3 key paths:
- Equity quotes: `data/equity/quotes/year={Y}/month={M}/day={D}/data.parquet`
- Equity bars: `data/equity/bars/year={Y}/month={M}/day={D}/data.parquet`
- Trading history: `exports/equity/{rebalance-sessions,pairs,allocations,orders,portfolio-snapshots}/year={Y}/month={M}/day={D}/data.parquet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Parquet export functionality for equity quotes, equity bars, and trading history data to S3.
  * Export tasks are now scheduled as application jobs rather than direct database operations.

* **Refactor**
  * Removed legacy database migration blocks and in-database export functions.
  * Migrated export operations from the database layer to the application layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->