### PR TITLE
Add end-of-day liquidation, pre-close rebalance lockout, and close_reason tracking

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -2,4 +2,4 @@
 dialect = postgres
 templater = raw
 large_file_skip_byte_limit = 0
-exclude_rules = LT01,LT02,LT05,LT12,CP05,RF04
+exclude_rules = LT01,LT02,LT05,LT12,CP05,RF04,PG01

--- a/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
+++ b/applications/portfolio_manager/src/portfolio_manager/alpaca_client.py
@@ -1,4 +1,5 @@
 import time
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, cast
 
 import structlog
@@ -105,6 +106,19 @@ class AlpacaClient:
         clock: Clock = cast("Clock", self.trading_client.get_clock())
         time.sleep(self.rate_limit_sleep)
         return bool(clock.is_open)
+
+    @_alpaca_retry
+    def get_minutes_to_market_close(self) -> float | None:
+        """Return minutes until market close if the market is open, otherwise None."""
+        clock: Clock = cast("Clock", self.trading_client.get_clock())
+        time.sleep(self.rate_limit_sleep)
+        if not clock.is_open:
+            return None
+        next_close = clock.next_close
+        if next_close.tzinfo is None:
+            next_close = next_close.replace(tzinfo=UTC)
+        minutes_remaining = (next_close - datetime.now(tz=UTC)).total_seconds() / 60.0
+        return max(0.0, minutes_remaining)
 
     @_alpaca_retry
     def get_account(self) -> AlpacaAccount:
@@ -292,6 +306,19 @@ class AlpacaClient:
             }
             for position in positions
         ]
+
+    @_alpaca_retry
+    def close_all_positions(self) -> int:
+        """Close all open positions and cancel all open orders.
+
+        Returns the number of positions submitted for closing.
+        """
+        responses = cast(
+            "list[object]",
+            self.trading_client.close_all_positions(cancel_orders=True),
+        )
+        time.sleep(self.rate_limit_sleep)
+        return len(responses)
 
     @_alpaca_retry
     def close_position(

--- a/applications/portfolio_manager/src/portfolio_manager/configuration.py
+++ b/applications/portfolio_manager/src/portfolio_manager/configuration.py
@@ -3,8 +3,12 @@ from dataclasses import dataclass
 
 @dataclass
 class Configuration:
-    # Minimum account equity required by Alpaca (FINRA rule) to execute short sells.
+    # Minimum account equity required by Alpaca's intraday margin framework
+    # to execute short sells.
     minimum_short_equity: float = 2000.0
     # Multiplier Alpaca applies to the ask price when reserving buying power for
     # short market orders (ask * buffer * qty charged against buying power).
     short_buying_power_buffer: float = 1.03
+    # Minutes before market close within which intraday rebalances are suppressed,
+    # allowing the end-of-day liquidation to proceed without new positions being opened.
+    pre_close_lockout_minutes: int = 20

--- a/applications/portfolio_manager/src/portfolio_manager/performance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/performance.py
@@ -201,6 +201,7 @@ def build_closed_pair_record(  # noqa: PLR0913
     dollar_amount: float,
     realized_profit_and_loss: float,
     return_percent: float,
+    close_reason: str = "rebalance",
 ) -> dict[str, Any]:
     holding_days = (closed_timestamp - entry_timestamp) // (1000 * 60 * 60 * 24)
     return {
@@ -213,4 +214,5 @@ def build_closed_pair_record(  # noqa: PLR0913
         "realized_profit_and_loss": realized_profit_and_loss,
         "return_percent": return_percent,
         "holding_days": holding_days,
+        "close_reason": close_reason,
     }

--- a/applications/portfolio_manager/src/portfolio_manager/performance.py
+++ b/applications/portfolio_manager/src/portfolio_manager/performance.py
@@ -1,6 +1,6 @@
 import math
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 import polars as pl
 import structlog
@@ -201,7 +201,9 @@ def build_closed_pair_record(  # noqa: PLR0913
     dollar_amount: float,
     realized_profit_and_loss: float,
     return_percent: float,
-    close_reason: str = "rebalance",
+    close_reason: Literal[
+        "profit_taken", "stop_loss", "rebalance", "end_of_day"
+    ] = "rebalance",
 ) -> dict[str, Any]:
     holding_days = (closed_timestamp - entry_timestamp) // (1000 * 60 * 60 * 24)
     return {

--- a/applications/portfolio_manager/src/portfolio_manager/portfolio_state.py
+++ b/applications/portfolio_manager/src/portfolio_manager/portfolio_state.py
@@ -248,6 +248,25 @@ async def save_rebalance(  # noqa: PLR0913
         return False
 
 
+async def close_all_open_pairs(closed_at: datetime, close_reason: str) -> bool:
+    """Mark all currently open equity pairs as closed in the database."""
+    try:
+        pool = await get_pool()
+        async with pool.connection() as connection:
+            cursor = await connection.execute(
+                """UPDATE equity_pairs
+                   SET status = 'closed', closed_at = %s, close_reason = %s
+                   WHERE status = 'open'""",
+                (closed_at, close_reason),
+            )
+        closed_count = cursor.rowcount
+        logger.info("Marked all open pairs as closed", closed_count=closed_count)
+        return True  # noqa: TRY300
+    except Exception as error:
+        logger.exception("Failed to close all open pairs in database", error=str(error))
+        return False
+
+
 async def save_performance_snapshot(
     snapshot: dict[str, Any],
     snapshot_type: str = "intraday",
@@ -300,7 +319,8 @@ async def save_closed_pair(record: dict[str, Any]) -> bool:
                        closed_at = %s,
                        realized_profit_and_loss = %s,
                        return_percent = %s,
-                       holding_days = %s
+                       holding_days = %s,
+                       close_reason = %s
                    WHERE pair_id = %s
                      AND status = 'open'
                      AND opened_at = %s""",
@@ -309,6 +329,7 @@ async def save_closed_pair(record: dict[str, Any]) -> bool:
                     record["realized_profit_and_loss"],
                     record["return_percent"],
                     record["holding_days"],
+                    record.get("close_reason", "rebalance"),
                     record["pair_id"],
                     opened_at,
                 ),

--- a/applications/portfolio_manager/src/portfolio_manager/portfolio_state.py
+++ b/applications/portfolio_manager/src/portfolio_manager/portfolio_state.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import polars as pl
@@ -248,7 +248,10 @@ async def save_rebalance(  # noqa: PLR0913
         return False
 
 
-async def close_all_open_pairs(closed_at: datetime, close_reason: str) -> bool:
+async def close_all_open_pairs(
+    closed_at: datetime,
+    close_reason: Literal["profit_taken", "stop_loss", "rebalance", "end_of_day"],
+) -> bool:
     """Mark all currently open equity pairs as closed in the database."""
     try:
         pool = await get_pool()

--- a/applications/portfolio_manager/src/portfolio_manager/scheduler.py
+++ b/applications/portfolio_manager/src/portfolio_manager/scheduler.py
@@ -82,9 +82,9 @@ async def _handle_end_of_day_liquidation_requested(
     rebalance_lock: asyncio.Lock,
 ) -> None:
     loop = asyncio.get_running_loop()
-    current_timestamp = datetime.now(tz=UTC)
 
     async with rebalance_lock:
+        current_timestamp = datetime.now(tz=UTC)
         try:
             closed_count = await loop.run_in_executor(
                 None, alpaca_client.close_all_positions

--- a/applications/portfolio_manager/src/portfolio_manager/scheduler.py
+++ b/applications/portfolio_manager/src/portfolio_manager/scheduler.py
@@ -11,6 +11,7 @@ from .alpaca_client import AlpacaClient
 from .configuration import Configuration
 from .data_client import fetch_historical_prices, fetch_live_quote_mid_prices
 from .portfolio_state import (
+    close_all_open_pairs,
     evaluate_held_pairs_from_quotes,
     get_last_portfolio_value,
     get_prior_allocation,
@@ -76,6 +77,36 @@ async def _status_logger_loop(alpaca_client: AlpacaClient) -> None:
                 return
 
 
+async def _handle_end_of_day_liquidation_requested(
+    alpaca_client: AlpacaClient,
+    rebalance_lock: asyncio.Lock,
+) -> None:
+    loop = asyncio.get_running_loop()
+    current_timestamp = datetime.now(tz=UTC)
+
+    async with rebalance_lock:
+        try:
+            closed_count = await loop.run_in_executor(
+                None, alpaca_client.close_all_positions
+            )
+            logger.info(
+                "Closed all positions for end of day", closed_count=closed_count
+            )
+        except Exception as error:
+            logger.exception(
+                "Failed to close all positions for end of day", error=str(error)
+            )
+            raise
+
+        pairs_closed = await close_all_open_pairs(
+            current_timestamp, close_reason="end_of_day"
+        )
+        if not pairs_closed:
+            message = "Failed to mark open pairs as closed in database"
+            raise RuntimeError(message)
+        logger.info("Marked all open pairs as closed in database")
+
+
 async def _handle_end_of_day_snapshot_requested(alpaca_client: AlpacaClient) -> None:
     loop = asyncio.get_running_loop()
     try:
@@ -130,13 +161,21 @@ async def _handle_intraday_check(  # noqa: C901, PLR0911
         return
 
     try:
-        market_open = alpaca_client.is_market_open()
+        minutes_to_close = alpaca_client.get_minutes_to_market_close()
     except Exception as error:
-        logger.exception("Failed to check market open status", error=str(error))
+        logger.exception("Failed to check market status", error=str(error))
         return
 
-    if not market_open:
+    if minutes_to_close is None:
         logger.info("Market is closed, skipping rebalance on intraday_check")
+        return
+
+    if minutes_to_close <= configuration.pre_close_lockout_minutes:
+        logger.info(
+            "Skipping rebalance, within pre-close lockout window",
+            minutes_to_close=minutes_to_close,
+            pre_close_lockout_minutes=configuration.pre_close_lockout_minutes,
+        )
         return
 
     correlation_id = await get_latest_predictions_correlation_id()
@@ -227,6 +266,12 @@ async def _event_listener_loop(
                     )
                     _background_tasks.add(task)
                     task.add_done_callback(_background_tasks.discard)
+                    await update_consumer_offset(consumer_name, event_id)
+                elif event_type == "end_of_day_liquidation_requested":
+                    logger.info("Received end_of_day_liquidation_requested event")
+                    await _handle_end_of_day_liquidation_requested(
+                        alpaca_client, rebalance_lock
+                    )
                     await update_consumer_offset(consumer_name, event_id)
                 elif event_type == "end_of_day_snapshot_requested":
                     logger.info("Received end_of_day_snapshot_requested event")

--- a/applications/portfolio_manager/tests/test_alpaca_client.py
+++ b/applications/portfolio_manager/tests/test_alpaca_client.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -562,6 +563,127 @@ def test_close_position_reraises_other_api_errors() -> None:
 
     with pytest.raises(_FakeAPIError):
         client.close_position(ticker="AAPL")
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_get_minutes_to_market_close_returns_none_when_market_closed(
+    mock_sleep: MagicMock,
+) -> None:
+    client, mock_trading = _make_client()
+    mock_clock = MagicMock()
+    mock_clock.is_open = False
+    mock_trading.get_clock.return_value = mock_clock
+
+    result = client.get_minutes_to_market_close()
+
+    assert result is None
+    mock_sleep.assert_called_once_with(client.rate_limit_sleep)
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_get_minutes_to_market_close_returns_minutes_when_market_open(
+    mock_sleep: MagicMock,
+) -> None:
+    client, mock_trading = _make_client()
+    mock_clock = MagicMock()
+    mock_clock.is_open = True
+    mock_clock.next_close = datetime.now(tz=UTC) + timedelta(minutes=30)
+    mock_trading.get_clock.return_value = mock_clock
+
+    result = client.get_minutes_to_market_close()
+
+    _expected_lower = 29.0
+    _expected_upper = 30.0
+    assert result is not None
+    assert _expected_lower < result <= _expected_upper
+    mock_sleep.assert_called_once_with(client.rate_limit_sleep)
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_get_minutes_to_market_close_returns_zero_at_market_close(
+    mock_sleep: MagicMock,  # noqa: ARG001
+) -> None:
+    client, mock_trading = _make_client()
+    mock_clock = MagicMock()
+    mock_clock.is_open = True
+    mock_clock.next_close = datetime.now(tz=UTC) - timedelta(seconds=5)
+    mock_trading.get_clock.return_value = mock_clock
+
+    result = client.get_minutes_to_market_close()
+
+    assert result == 0.0
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_get_minutes_to_market_close_handles_naive_datetime(
+    mock_sleep: MagicMock,  # noqa: ARG001
+) -> None:
+    client, mock_trading = _make_client()
+    mock_clock = MagicMock()
+    mock_clock.is_open = True
+    # Naive datetime (no tzinfo) — should be treated as UTC.
+    naive_now = datetime.now(tz=UTC).replace(tzinfo=None)
+    mock_clock.next_close = naive_now + timedelta(minutes=15)
+    mock_trading.get_clock.return_value = mock_clock
+
+    result = client.get_minutes_to_market_close()
+
+    assert result is not None
+    assert result >= 0.0
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_close_all_positions_returns_count(mock_sleep: MagicMock) -> None:
+    client, mock_trading = _make_client()
+    mock_trading.close_all_positions.return_value = [MagicMock(), MagicMock()]
+
+    result = client.close_all_positions()
+
+    expected_count = 2
+    assert result == expected_count
+    mock_sleep.assert_called_once_with(client.rate_limit_sleep)
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_close_all_positions_returns_zero_when_no_positions(
+    mock_sleep: MagicMock,
+) -> None:
+    client, mock_trading = _make_client()
+    mock_trading.close_all_positions.return_value = []
+
+    result = client.close_all_positions()
+
+    assert result == 0
+    mock_sleep.assert_called_once_with(client.rate_limit_sleep)
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+def test_close_all_positions_passes_cancel_orders_true(mock_sleep: MagicMock) -> None:  # noqa: ARG001
+    client, mock_trading = _make_client()
+    mock_trading.close_all_positions.return_value = []
+
+    client.close_all_positions()
+
+    mock_trading.close_all_positions.assert_called_once_with(cancel_orders=True)
+
+
+@patch("portfolio_manager.alpaca_client.time.sleep")
+@patch("tenacity.nap.time.sleep")
+def test_close_all_positions_retries_on_transient_error(
+    mock_tenacity_sleep: MagicMock,
+    mock_rate_limit_sleep: MagicMock,
+) -> None:
+    client, mock_trading = _make_client()
+    transient_error = _FakeAPIError("service unavailable", status_code=503)
+    mock_trading.close_all_positions.side_effect = [transient_error, []]
+
+    result = client.close_all_positions()
+
+    expected_attempts = 2
+    assert result == 0
+    assert mock_trading.close_all_positions.call_count == expected_attempts
+    assert mock_tenacity_sleep is not None
+    assert mock_rate_limit_sleep.called
 
 
 def _make_mock_position(

--- a/applications/portfolio_manager/tests/test_performance.py
+++ b/applications/portfolio_manager/tests/test_performance.py
@@ -461,6 +461,7 @@ def test_build_closed_pair_record_returns_dict_with_all_required_keys() -> None:
     assert "realized_profit_and_loss" in result
     assert "return_percent" in result
     assert "holding_days" in result
+    assert "close_reason" in result
 
 
 def test_build_closed_pair_record_holding_days_computed_correctly() -> None:
@@ -497,3 +498,4 @@ def test_build_closed_pair_record_correct_values() -> None:
     assert result["dollar_amount"] == pytest.approx(2000.0)
     assert result["realized_profit_and_loss"] == pytest.approx(100.0)
     assert result["return_percent"] == pytest.approx(0.05)
+    assert result["close_reason"] == "rebalance"

--- a/applications/portfolio_manager/tests/test_portfolio_state.py
+++ b/applications/portfolio_manager/tests/test_portfolio_state.py
@@ -6,6 +6,7 @@ import polars as pl
 import pytest
 from portfolio_manager.portfolio_state import (
     _PRIOR_ALLOCATION_SCHEMA,
+    close_all_open_pairs,
     evaluate_held_pairs_from_quotes,
     get_last_portfolio_value,
     get_prior_allocation,
@@ -74,6 +75,65 @@ def _make_successful_pair_rows() -> pl.DataFrame:
             "notional": pl.Float64,
         },
     )
+
+
+# --- close_all_open_pairs ---
+
+
+def _make_pool_mock_with_rowcount(rowcount: int) -> MagicMock:
+    mock_cursor = AsyncMock()
+    mock_cursor.rowcount = rowcount
+    mock_connection = MagicMock()
+    mock_connection.execute = AsyncMock(return_value=mock_cursor)
+    mock_connection.__aenter__ = AsyncMock(return_value=mock_connection)
+    mock_connection.__aexit__ = AsyncMock(return_value=None)
+    mock_pool = MagicMock()
+    mock_pool.connection.return_value = mock_connection
+    return mock_pool
+
+
+def test_close_all_open_pairs_returns_true_and_updates_rows() -> None:
+    mock_pool = _make_pool_mock_with_rowcount(rowcount=3)
+    closed_at = datetime(2026, 6, 4, 20, 0, 0, tzinfo=UTC)
+
+    async def run() -> bool:
+        with patch(
+            "portfolio_manager.portfolio_state.get_pool",
+            AsyncMock(return_value=mock_pool),
+        ):
+            return await close_all_open_pairs(closed_at, close_reason="end_of_day")
+
+    result = asyncio.run(run())
+    assert result is True
+
+
+def test_close_all_open_pairs_returns_true_when_no_open_pairs() -> None:
+    mock_pool = _make_pool_mock_with_rowcount(rowcount=0)
+    closed_at = datetime(2026, 6, 4, 20, 0, 0, tzinfo=UTC)
+
+    async def run() -> bool:
+        with patch(
+            "portfolio_manager.portfolio_state.get_pool",
+            AsyncMock(return_value=mock_pool),
+        ):
+            return await close_all_open_pairs(closed_at, close_reason="end_of_day")
+
+    result = asyncio.run(run())
+    assert result is True
+
+
+def test_close_all_open_pairs_returns_false_on_database_error() -> None:
+    closed_at = datetime(2026, 6, 4, 20, 0, 0, tzinfo=UTC)
+
+    async def run() -> bool:
+        with patch(
+            "portfolio_manager.portfolio_state.get_pool",
+            AsyncMock(side_effect=Exception("db connection failed")),
+        ):
+            return await close_all_open_pairs(closed_at, close_reason="end_of_day")
+
+    result = asyncio.run(run())
+    assert result is False
 
 
 # --- evaluate_held_pairs_from_quotes ---
@@ -444,6 +504,7 @@ def test_save_closed_pair_returns_true_on_success() -> None:
         "realized_profit_and_loss": 50.0,
         "return_percent": 0.05,
         "holding_days": 1,
+        "close_reason": "rebalance",
     }
 
     with patch(

--- a/applications/portfolio_manager/tests/test_scheduler.py
+++ b/applications/portfolio_manager/tests/test_scheduler.py
@@ -8,6 +8,7 @@ from portfolio_manager.alpaca_client import AlpacaAccount
 from portfolio_manager.configuration import Configuration
 from portfolio_manager.scheduler import (
     _event_listener_loop,
+    _handle_end_of_day_liquidation_requested,
     _handle_end_of_day_snapshot_requested,
     _handle_equity_bars_synced,
     _handle_intraday_check,
@@ -63,7 +64,7 @@ def test_handle_intraday_check_skips_when_lock_held() -> None:
 
 def test_handle_intraday_check_skips_when_market_closed() -> None:
     mock_alpaca = MagicMock()
-    mock_alpaca.is_market_open.return_value = False
+    mock_alpaca.get_minutes_to_market_close.return_value = None
     mock_run_rebalance = AsyncMock()
 
     async def run() -> None:
@@ -77,7 +78,7 @@ def test_handle_intraday_check_skips_when_market_closed() -> None:
 
 def test_handle_intraday_check_skips_when_no_predictions_available() -> None:
     mock_alpaca = MagicMock()
-    mock_alpaca.is_market_open.return_value = True
+    mock_alpaca.get_minutes_to_market_close.return_value = 60.0
     mock_run_rebalance = AsyncMock()
 
     async def run() -> None:
@@ -97,7 +98,7 @@ def test_handle_intraday_check_skips_when_no_predictions_available() -> None:
 
 def test_handle_intraday_check_skips_when_all_pairs_held() -> None:
     mock_alpaca = MagicMock()
-    mock_alpaca.is_market_open.return_value = True
+    mock_alpaca.get_minutes_to_market_close.return_value = 60.0
     mock_run_rebalance = AsyncMock()
 
     prior_allocation = pl.DataFrame(
@@ -139,7 +140,7 @@ def test_handle_intraday_check_skips_when_all_pairs_held() -> None:
 
 def test_handle_intraday_check_calls_run_rebalance_when_some_pairs_closing() -> None:
     mock_alpaca = MagicMock()
-    mock_alpaca.is_market_open.return_value = True
+    mock_alpaca.get_minutes_to_market_close.return_value = 60.0
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_run_rebalance = AsyncMock(return_value=mock_response)
@@ -185,7 +186,7 @@ def test_handle_intraday_check_calls_run_rebalance_when_some_pairs_closing() -> 
 
 def test_handle_intraday_check_calls_run_rebalance_when_no_prior_allocation() -> None:
     mock_alpaca = MagicMock()
-    mock_alpaca.is_market_open.return_value = True
+    mock_alpaca.get_minutes_to_market_close.return_value = 60.0
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_run_rebalance = AsyncMock(return_value=mock_response)
@@ -213,7 +214,7 @@ def test_handle_intraday_check_calls_run_rebalance_when_no_prior_allocation() ->
 
 def test_handle_intraday_check_passes_correlation_id_to_run_rebalance() -> None:
     mock_alpaca = MagicMock()
-    mock_alpaca.is_market_open.return_value = True
+    mock_alpaca.get_minutes_to_market_close.return_value = 60.0
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_run_rebalance = AsyncMock(return_value=mock_response)
@@ -240,7 +241,7 @@ def test_handle_intraday_check_passes_correlation_id_to_run_rebalance() -> None:
 
 def test_handle_intraday_check_skips_when_historical_prices_fetch_fails() -> None:
     mock_alpaca = MagicMock()
-    mock_alpaca.is_market_open.return_value = True
+    mock_alpaca.get_minutes_to_market_close.return_value = 60.0
     mock_run_rebalance = AsyncMock()
 
     prior_allocation = pl.DataFrame(
@@ -272,7 +273,7 @@ def test_handle_intraday_check_skips_when_historical_prices_fetch_fails() -> Non
 
 def test_handle_intraday_check_skips_when_live_prices_fetch_fails() -> None:
     mock_alpaca = MagicMock()
-    mock_alpaca.is_market_open.return_value = True
+    mock_alpaca.get_minutes_to_market_close.return_value = 60.0
     mock_run_rebalance = AsyncMock()
 
     prior_allocation = pl.DataFrame(
@@ -308,7 +309,7 @@ def test_handle_intraday_check_skips_when_live_prices_fetch_fails() -> None:
 
 def test_handle_intraday_check_logs_warning_on_non_200() -> None:
     mock_alpaca = MagicMock()
-    mock_alpaca.is_market_open.return_value = True
+    mock_alpaca.get_minutes_to_market_close.return_value = 60.0
     mock_response = MagicMock()
     mock_response.status_code = 500
     mock_run_rebalance = AsyncMock(return_value=mock_response)
@@ -333,9 +334,26 @@ def test_handle_intraday_check_logs_warning_on_non_200() -> None:
     asyncio.run(run())
 
 
+def test_handle_intraday_check_skips_when_within_pre_close_lockout_window() -> None:
+    mock_alpaca = MagicMock()
+    # 10 minutes to close is within the default 20-minute lockout window.
+    mock_alpaca.get_minutes_to_market_close.return_value = 10.0
+    mock_run_rebalance = AsyncMock()
+
+    async def run() -> None:
+        lock = asyncio.Lock()
+        with patch("portfolio_manager.scheduler.run_rebalance", mock_run_rebalance):
+            await _handle_intraday_check(mock_alpaca, Configuration(), lock)
+
+    asyncio.run(run())
+    mock_run_rebalance.assert_not_called()
+
+
 def test_handle_intraday_check_handles_market_open_exception() -> None:
     mock_alpaca = MagicMock()
-    mock_alpaca.is_market_open.side_effect = Exception("market check failed")
+    mock_alpaca.get_minutes_to_market_close.side_effect = Exception(
+        "market check failed"
+    )
     mock_run_rebalance = AsyncMock()
 
     async def run() -> None:
@@ -422,6 +440,40 @@ def test_event_listener_loop_dispatches_equity_bars_synced() -> None:
             await _event_listener_loop(mock_alpaca, Configuration(), lock)
             if captured_handler:
                 await captured_handler[0]("equity_bars_synced", 42, {})
+            mock_handle.assert_called_once()
+
+    asyncio.run(run())
+
+
+def test_event_listener_loop_dispatches_end_of_day_liquidation_requested() -> None:
+    mock_alpaca = MagicMock()
+    captured_handler: list = []
+
+    async def run() -> None:
+        lock = asyncio.Lock()
+
+        async def fake_listen_for_events(_channel: str, handler: object) -> None:
+            captured_handler.append(handler)
+            raise asyncio.CancelledError
+
+        with (
+            patch.dict("os.environ", {"DATABASE_URL": "postgresql://localhost/test"}),
+            patch(
+                "portfolio_manager.scheduler.listen_for_events",
+                side_effect=fake_listen_for_events,
+            ),
+            patch(
+                "portfolio_manager.scheduler.update_consumer_offset",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "portfolio_manager.scheduler._handle_end_of_day_liquidation_requested",
+                AsyncMock(),
+            ) as mock_handle,
+        ):
+            await _event_listener_loop(mock_alpaca, Configuration(), lock)
+            if captured_handler:
+                await captured_handler[0]("end_of_day_liquidation_requested", 44, {})
             mock_handle.assert_called_once()
 
     asyncio.run(run())
@@ -590,6 +642,102 @@ def test_status_logger_loop_exits_on_cancellation() -> None:
         asyncio.run(run())
 
     mock_logger.info.assert_any_call("Status logger cancelled")
+
+
+# --- _handle_end_of_day_liquidation_requested ---
+
+
+def test_handle_end_of_day_liquidation_closes_positions_and_marks_pairs_closed() -> (
+    None
+):
+    mock_alpaca = MagicMock()
+    mock_alpaca.close_all_positions.return_value = 4
+
+    async def run() -> None:
+        lock = asyncio.Lock()
+        with (
+            patch(
+                "portfolio_manager.scheduler.close_all_open_pairs",
+                AsyncMock(return_value=True),
+            ),
+        ):
+            await _handle_end_of_day_liquidation_requested(mock_alpaca, lock)
+
+    asyncio.run(run())
+    mock_alpaca.close_all_positions.assert_called_once()
+
+
+def test_handle_end_of_day_liquidation_acquires_rebalance_lock() -> None:
+    mock_alpaca = MagicMock()
+    mock_alpaca.close_all_positions.return_value = 2
+    lock_was_held: list[bool] = []
+
+    async def run() -> None:
+        lock = asyncio.Lock()
+
+        async def mock_close_pairs(
+            _closed_at: object,
+            close_reason: str,  # noqa: ARG001
+        ) -> bool:
+            lock_was_held.append(lock.locked())
+            return True
+
+        with patch(
+            "portfolio_manager.scheduler.close_all_open_pairs",
+            side_effect=mock_close_pairs,
+        ):
+            await _handle_end_of_day_liquidation_requested(mock_alpaca, lock)
+
+    asyncio.run(run())
+    assert lock_was_held == [True]
+
+
+def test_handle_end_of_day_liquidation_raises_when_alpaca_close_fails() -> None:
+    mock_alpaca = MagicMock()
+    mock_alpaca.close_all_positions.side_effect = RuntimeError("alpaca error")
+
+    async def run() -> None:
+        lock = asyncio.Lock()
+        with pytest.raises(RuntimeError, match="alpaca error"):
+            await _handle_end_of_day_liquidation_requested(mock_alpaca, lock)
+
+    asyncio.run(run())
+
+
+def test_handle_end_of_day_liquidation_raises_when_db_close_fails() -> None:
+    mock_alpaca = MagicMock()
+    mock_alpaca.close_all_positions.return_value = 2
+
+    async def run() -> None:
+        lock = asyncio.Lock()
+        with (
+            patch(
+                "portfolio_manager.scheduler.close_all_open_pairs",
+                AsyncMock(return_value=False),
+            ),
+            pytest.raises(RuntimeError, match="Failed to mark open pairs as closed"),
+        ):
+            await _handle_end_of_day_liquidation_requested(mock_alpaca, lock)
+
+    asyncio.run(run())
+
+
+def test_handle_end_of_day_liquidation_succeeds_when_no_open_positions() -> None:
+    mock_alpaca = MagicMock()
+    mock_alpaca.close_all_positions.return_value = 0
+
+    async def run() -> None:
+        lock = asyncio.Lock()
+        with (
+            patch(
+                "portfolio_manager.scheduler.close_all_open_pairs",
+                AsyncMock(return_value=True),
+            ),
+        ):
+            await _handle_end_of_day_liquidation_requested(mock_alpaca, lock)
+
+    asyncio.run(run())
+    mock_alpaca.close_all_positions.assert_called_once()
 
 
 # --- _handle_end_of_day_snapshot_requested ---

--- a/schema.sql
+++ b/schema.sql
@@ -143,8 +143,22 @@ CREATE TABLE IF NOT EXISTS equity_pairs (
     realized_profit_and_loss   NUMERIC,
     return_percent             NUMERIC,
     holding_days               INTEGER,
+    close_reason               TEXT        CHECK (close_reason IN ('profit_taken', 'stop_loss', 'rebalance', 'end_of_day')),
     UNIQUE (pair_id, opened_at)
 );
+
+-- Add close_reason column if running against an older schema that lacked it.
+DO $do$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'equity_pairs' AND column_name = 'close_reason'
+    ) THEN
+        ALTER TABLE equity_pairs ADD COLUMN close_reason TEXT
+            CHECK (close_reason IN ('profit_taken', 'stop_loss', 'rebalance', 'end_of_day'));
+    END IF;
+END;
+$do$;
 
 -- Add return_percent column if running against an older schema that lacked it.
 DO $do$
@@ -496,6 +510,29 @@ BEGIN
             'export-equity-quotes',
             '5 21 * * 1-5',
             $$SELECT export_equity_quotes()$$
+        );
+    END IF;
+END;
+$do$;
+
+-- liquidate_end_of_day: emits an event for portfolio-manager to close all open positions
+-- and mark all open pairs as closed before the market close.
+CREATE OR REPLACE FUNCTION liquidate_end_of_day() RETURNS void AS $$
+BEGIN
+    PERFORM emit_event('end_of_day_liquidation_requested', '{}');
+END;
+$$ LANGUAGE plpgsql;
+
+-- End-of-day liquidation trigger: weekdays at 19:45 UTC (3:45 PM EDT, 15 minutes before market close).
+-- Fires before the intraday-check window ends so the rebalance lockout window in portfolio-manager
+-- prevents any new pairs from being opened after this point.
+DO $do$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'end-of-day-liquidation') THEN
+        PERFORM cron.schedule(
+            'end-of-day-liquidation',
+            '45 19 * * 1-5',
+            $$SELECT liquidate_end_of_day()$$
         );
     END IF;
 END;

--- a/schema.sql
+++ b/schema.sql
@@ -523,18 +523,21 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- End-of-day liquidation trigger: weekdays at 19:45 UTC (3:45 PM EDT, 15 minutes before market close).
+-- End-of-day liquidation trigger: weekdays at 3:45 PM Eastern Time (15 minutes before market close).
+-- Uses a timezone-aware schedule so DST is handled correctly year-round.
 -- Fires before the intraday-check window ends so the rebalance lockout window in portfolio-manager
 -- prevents any new pairs from being opened after this point.
 DO $do$
 BEGIN
-    IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'end-of-day-liquidation') THEN
-        PERFORM cron.schedule(
-            'end-of-day-liquidation',
-            '45 19 * * 1-5',
-            $$SELECT liquidate_end_of_day()$$
-        );
+    IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'end-of-day-liquidation') THEN
+        PERFORM cron.unschedule('end-of-day-liquidation');
     END IF;
+    PERFORM cron.schedule_in_timezone(
+        'end-of-day-liquidation',
+        '45 15 * * 1-5',
+        'America/New_York',
+        $$SELECT liquidate_end_of_day()$$
+    );
 END;
 $do$;
 


### PR DESCRIPTION
# Overview

## Changes

- Adds `close_all_positions()` to `AlpacaClient` — calls Alpaca's `DELETE /v2/positions` with `cancel_orders=True` to close all open positions and cancel outstanding orders in one shot
- Adds `get_minutes_to_market_close()` to `AlpacaClient` — returns minutes until market close if open, `None` if closed; replaces the old `is_market_open()` boolean check
- Adds `pre_close_lockout_minutes` (default: 20) to `Configuration`; intraday rebalances are suppressed when within this window of market close
- Adds `_handle_end_of_day_liquidation_requested()` to `scheduler.py` — acquires the rebalance lock, closes all positions, and marks all open pairs closed with `close_reason='end_of_day'`; dispatched as a sequential await (consistent with `end_of_day_snapshot_requested`) so the consumer offset only advances after success
- Adds `liquidate_end_of_day()` SQL function and a pg_cron job (`45 19 * * 1-5`, 3:45 PM EDT) that emits `end_of_day_liquidation_requested` 15 minutes before market close
- Adds `close_reason TEXT CHECK (close_reason IN ('profit_taken', 'stop_loss', 'rebalance', 'end_of_day'))` column directly to the `equity_pairs` CREATE TABLE definition, plus a compatibility `DO` block for existing deployments
- Propagates `close_reason` through `build_closed_pair_record()`, `save_closed_pair()`, and `close_all_open_pairs()`
- Fixes stale comment on `minimum_short_equity` (referenced FINRA PDT rule; updated to Alpaca's intraday margin framework)
- Excludes `PG01` (postgres.excessive_locks) from sqlfluff — `CONCURRENTLY` is inapplicable in schema bootstrap scripts; fixes pre-existing hook breakage

## Context

Alpaca retired FINRA PDT rules in favour of a new intraday margin framework. The updated trading strategy is: allow intraday rebalancing, go fully to cash at end of day (no overnight positions), continue statistical arbitrage pairs trading.

The EOD shutdown sequence is: pg_cron fires at 3:45 PM EDT → emits `end_of_day_liquidation_requested` → scheduler acquires the rebalance lock (waits for any in-flight rebalance to finish) → cancels all open orders and closes all positions via Alpaca → marks all open pairs closed in the database. The pre-close lockout (20 min window) prevents new rebalances from racing against the liquidation event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Intraday rebalance lockout prevents rebalancing during the final window before market close (default: 20 minutes, configurable)
  * Automatic end-of-day liquidation closes all open positions and cancels outstanding orders at market close

* **Improvements**
  * Position close reasons now tracked to distinguish between rebalance, profit-taking, stop-loss, and end-of-day closures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->