### PR TITLE
[Wave 3, Part 10] `data_manager`: consolidate nightly trading history export

### DIFF
--- a/applications/data_manager/src/database.rs
+++ b/applications/data_manager/src/database.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Days, NaiveDate, Utc};
 use internal::market::{EquityBar, EquityDetails, EquityQuote};
+use internal::predictions::{EquityPrediction, ModelRun};
 use internal::trading::{
     EquityAllocation, EquityOrder, EquityPair, EquityPortfolioSnapshot, EquityRebalanceSession,
 };
@@ -351,6 +352,44 @@ pub async fn query_equity_portfolio_snapshots(
     .await
 }
 
+pub async fn query_equity_predictions_for_date(
+    pool: &PgPool,
+    date: NaiveDate,
+) -> Result<Vec<EquityPrediction>, sqlx::Error> {
+    let (date_start, date_end) = date_to_utc_range(date);
+
+    let predictions = sqlx::query_as::<_, EquityPrediction>(
+        "SELECT correlation_id, model_run_id, ticker, timestamp, quantile_10, quantile_50,
+         quantile_90, created_at
+         FROM equity_predictions
+         WHERE timestamp >= $1 AND timestamp < $2
+         ORDER BY ticker ASC, timestamp ASC",
+    )
+    .bind(date_start)
+    .bind(date_end)
+    .fetch_all(pool)
+    .await?;
+
+    debug!(
+        "Queried {} equity predictions for {}",
+        predictions.len(),
+        date
+    );
+    Ok(predictions)
+}
+
+pub async fn query_model_runs(pool: &PgPool) -> Result<Vec<ModelRun>, sqlx::Error> {
+    sqlx::query_as::<_, ModelRun>(
+        "SELECT id, run_id, model_name, artifact_key, training_data_key, start_date, end_date,
+         lookback_days, status, continuous_ranked_probability_score, directional_accuracy,
+         quantile_coverage, drift_status, stage_counts, started_at, completed_at
+         FROM model_runs
+         ORDER BY started_at ASC",
+    )
+    .fetch_all(pool)
+    .await
+}
+
 pub async fn requeue_stale_claimed_jobs(
     pool: &PgPool,
     job_name: &str,
@@ -606,6 +645,36 @@ mod tests {
             let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
                 .expect("lazy pool creation should not fail");
             let result = query_equity_portfolio_snapshots(&pool).await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_query_equity_predictions_for_date_compiles() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            use chrono::NaiveDate;
+            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
+                .expect("lazy pool creation should not fail");
+            let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+            let result = query_equity_predictions_for_date(&pool, date).await;
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_query_model_runs_compiles() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
+                .expect("lazy pool creation should not fail");
+            let result = query_model_runs(&pool).await;
             assert!(result.is_err());
         });
     }

--- a/applications/data_manager/src/export.rs
+++ b/applications/data_manager/src/export.rs
@@ -48,9 +48,9 @@ pub async fn export_equity_bars(state: &State, date: NaiveDate) -> Result<usize,
 
 /// Exports all trading history tables to S3 Parquet.
 ///
-/// Exports equity_quotes, equity_rebalance_sessions, equity_pairs, equity_allocations,
-/// equity_orders, equity_portfolio_snapshots, and model_runs. Deletes the exported
-/// equity_quotes rows from the database after a successful S3 write.
+/// Exports equity_quotes, equity_predictions, equity_rebalance_sessions, equity_pairs,
+/// equity_allocations, equity_orders, equity_portfolio_snapshots, and model_runs. Deletes the
+/// exported equity_quotes rows from the database after a successful S3 write.
 pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<usize, String> {
     let pool = state
         .database
@@ -383,22 +383,22 @@ fn create_equity_prediction_dataframe(
 
 fn create_model_run_dataframe(model_runs: &[ModelRun]) -> Result<DataFrame, String> {
     df!(
-        "id" => model_runs.iter().map(|run| run.id).collect::<Vec<i64>>(),
-        "run_id" => model_runs.iter().map(|run| run.run_id.as_str()).collect::<Vec<&str>>(),
-        "model_name" => model_runs.iter().map(|run| run.model_name.as_str()).collect::<Vec<&str>>(),
-        "artifact_key" => model_runs.iter().map(|run| run.artifact_key.as_deref()).collect::<Vec<Option<&str>>>(),
-        "training_data_key" => model_runs.iter().map(|run| run.training_data_key.as_deref()).collect::<Vec<Option<&str>>>(),
-        "start_date" => model_runs.iter().map(|run| run.start_date.map(|date| date.to_string())).collect::<Vec<Option<String>>>(),
-        "end_date" => model_runs.iter().map(|run| run.end_date.map(|date| date.to_string())).collect::<Vec<Option<String>>>(),
-        "lookback_days" => model_runs.iter().map(|run| run.lookback_days).collect::<Vec<Option<i32>>>(),
-        "status" => model_runs.iter().map(|run| run.status.as_str()).collect::<Vec<&str>>(),
-        "continuous_ranked_probability_score" => model_runs.iter().map(|run| run.continuous_ranked_probability_score).collect::<Vec<Option<f64>>>(),
-        "directional_accuracy" => model_runs.iter().map(|run| run.directional_accuracy).collect::<Vec<Option<f64>>>(),
-        "quantile_coverage" => model_runs.iter().map(|run| run.quantile_coverage).collect::<Vec<Option<f64>>>(),
-        "drift_status" => model_runs.iter().map(|run| run.drift_status.as_deref()).collect::<Vec<Option<&str>>>(),
-        "stage_counts" => model_runs.iter().map(|run| run.stage_counts.as_ref().map(|value| value.to_string())).collect::<Vec<Option<String>>>(),
-        "started_at" => model_runs.iter().map(|run| run.started_at.timestamp_millis()).collect::<Vec<i64>>(),
-        "completed_at" => model_runs.iter().map(|run| run.completed_at.map(|timestamp| timestamp.timestamp_millis())).collect::<Vec<Option<i64>>>(),
+        "id" => model_runs.iter().map(|model_run| model_run.id).collect::<Vec<i64>>(),
+        "run_id" => model_runs.iter().map(|model_run| model_run.run_id.as_str()).collect::<Vec<&str>>(),
+        "model_name" => model_runs.iter().map(|model_run| model_run.model_name.as_str()).collect::<Vec<&str>>(),
+        "artifact_key" => model_runs.iter().map(|model_run| model_run.artifact_key.as_deref()).collect::<Vec<Option<&str>>>(),
+        "training_data_key" => model_runs.iter().map(|model_run| model_run.training_data_key.as_deref()).collect::<Vec<Option<&str>>>(),
+        "start_date" => model_runs.iter().map(|model_run| model_run.start_date.map(|date| date.to_string())).collect::<Vec<Option<String>>>(),
+        "end_date" => model_runs.iter().map(|model_run| model_run.end_date.map(|date| date.to_string())).collect::<Vec<Option<String>>>(),
+        "lookback_days" => model_runs.iter().map(|model_run| model_run.lookback_days).collect::<Vec<Option<i32>>>(),
+        "status" => model_runs.iter().map(|model_run| model_run.status.as_str()).collect::<Vec<&str>>(),
+        "continuous_ranked_probability_score" => model_runs.iter().map(|model_run| model_run.continuous_ranked_probability_score).collect::<Vec<Option<f64>>>(),
+        "directional_accuracy" => model_runs.iter().map(|model_run| model_run.directional_accuracy).collect::<Vec<Option<f64>>>(),
+        "quantile_coverage" => model_runs.iter().map(|model_run| model_run.quantile_coverage).collect::<Vec<Option<f64>>>(),
+        "drift_status" => model_runs.iter().map(|model_run| model_run.drift_status.as_deref()).collect::<Vec<Option<&str>>>(),
+        "stage_counts" => model_runs.iter().map(|model_run| model_run.stage_counts.as_ref().map(|value| value.to_string())).collect::<Vec<Option<String>>>(),
+        "started_at" => model_runs.iter().map(|model_run| model_run.started_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "completed_at" => model_runs.iter().map(|model_run| model_run.completed_at.map(|timestamp| timestamp.timestamp_millis())).collect::<Vec<Option<i64>>>(),
     )
     .map_err(|error| format!("Failed to create model run DataFrame: {}", error))
 }

--- a/applications/data_manager/src/export.rs
+++ b/applications/data_manager/src/export.rs
@@ -8,47 +8,12 @@ use crate::{database, state::State};
 use aws_sdk_s3::primitives::ByteStream;
 use chrono::{Datelike, NaiveDate};
 use internal::market::{EquityBar, EquityQuote};
+use internal::predictions::{EquityPrediction, ModelRun};
 use internal::trading::{
     EquityAllocation, EquityOrder, EquityPair, EquityPortfolioSnapshot, EquityRebalanceSession,
 };
 use polars::prelude::*;
 use tracing::info;
-
-/// Exports equity quotes for the given date to S3 Parquet and deletes
-/// the exported rows from the database.
-pub async fn export_equity_quotes(state: &State, date: NaiveDate) -> Result<usize, String> {
-    let pool = state
-        .database
-        .pool()
-        .ok_or_else(|| "database not connected".to_string())?;
-
-    let quotes = database::query_equity_quotes_for_date(pool, date)
-        .await
-        .map_err(|error| format!("Failed to query equity quotes: {}", error))?;
-
-    let count = quotes.len();
-
-    if count == 0 {
-        info!("No equity quotes to export for {}", date);
-        return Ok(0);
-    }
-
-    let mut dataframe = create_equity_quote_dataframe(&quotes)?;
-    let key = format!(
-        "data/equity/quotes/year={}/month={:02}/day={:02}/data.parquet",
-        date.year(),
-        date.month(),
-        date.day()
-    );
-    write_dataframe_to_s3(state, &mut dataframe, &key).await?;
-    info!("Exported {} equity quotes to S3: {}", count, key);
-
-    database::delete_equity_quotes_for_date(pool, date)
-        .await
-        .map_err(|error| format!("Failed to delete equity quotes: {}", error))?;
-
-    Ok(count)
-}
 
 /// Exports equity bars for the given date to S3 Parquet.
 pub async fn export_equity_bars(state: &State, date: NaiveDate) -> Result<usize, String> {
@@ -82,11 +47,60 @@ pub async fn export_equity_bars(state: &State, date: NaiveDate) -> Result<usize,
 }
 
 /// Exports all trading history tables to S3 Parquet.
+///
+/// Exports equity_quotes, equity_rebalance_sessions, equity_pairs, equity_allocations,
+/// equity_orders, equity_portfolio_snapshots, and model_runs. Deletes the exported
+/// equity_quotes rows from the database after a successful S3 write.
 pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<usize, String> {
     let pool = state
         .database
         .pool()
         .ok_or_else(|| "database not connected".to_string())?;
+
+    let quotes = database::query_equity_quotes_for_date(pool, date)
+        .await
+        .map_err(|error| format!("Failed to query equity quotes: {}", error))?;
+    let quote_count = quotes.len();
+    if quote_count > 0 {
+        let mut quote_dataframe = create_equity_quote_dataframe(&quotes)?;
+        write_dataframe_to_s3(
+            state,
+            &mut quote_dataframe,
+            &format!(
+                "data/equity/quotes/year={}/month={:02}/day={:02}/data.parquet",
+                date.year(),
+                date.month(),
+                date.day()
+            ),
+        )
+        .await?;
+        database::delete_equity_quotes_for_date(pool, date)
+            .await
+            .map_err(|error| format!("Failed to delete equity quotes: {}", error))?;
+    } else {
+        info!("No equity quotes to export for {}", date);
+    }
+
+    let predictions = database::query_equity_predictions_for_date(pool, date)
+        .await
+        .map_err(|error| format!("Failed to query equity predictions: {}", error))?;
+    let prediction_count = predictions.len();
+    if prediction_count > 0 {
+        let mut prediction_dataframe = create_equity_prediction_dataframe(&predictions)?;
+        write_dataframe_to_s3(
+            state,
+            &mut prediction_dataframe,
+            &format!(
+                "exports/equity/predictions/year={}/month={:02}/day={:02}/data.parquet",
+                date.year(),
+                date.month(),
+                date.day()
+            ),
+        )
+        .await?;
+    } else {
+        info!("No equity predictions to export for {}", date);
+    }
 
     let sessions = database::query_equity_rebalance_sessions(pool)
         .await
@@ -173,12 +187,36 @@ pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<us
     )
     .await?;
 
+    let model_runs = database::query_model_runs(pool)
+        .await
+        .map_err(|error| format!("Failed to query model runs: {}", error))?;
+    let model_run_count = model_runs.len();
+    let mut model_run_dataframe = create_model_run_dataframe(&model_runs)?;
+    write_dataframe_to_s3(
+        state,
+        &mut model_run_dataframe,
+        &format!(
+            "exports/model-runs/year={}/month={:02}/day={:02}/data.parquet",
+            date.year(),
+            date.month(),
+            date.day()
+        ),
+    )
+    .await?;
+
     info!(
-        "Exported trading history to S3: {} sessions, {} pairs, {} allocations, {} orders, {} snapshots",
-        session_count, pair_count, allocation_count, order_count, snapshot_count
+        "Exported trading history to S3: {} quotes, {} predictions, {} sessions, {} pairs, {} allocations, {} orders, {} snapshots, {} model runs",
+        quote_count, prediction_count, session_count, pair_count, allocation_count, order_count, snapshot_count, model_run_count
     );
 
-    Ok(session_count + pair_count + allocation_count + order_count + snapshot_count)
+    Ok(quote_count
+        + prediction_count
+        + session_count
+        + pair_count
+        + allocation_count
+        + order_count
+        + snapshot_count
+        + model_run_count)
 }
 
 async fn write_dataframe_to_s3(
@@ -327,11 +365,50 @@ fn create_equity_portfolio_snapshot_dataframe(
     })
 }
 
+fn create_equity_prediction_dataframe(
+    predictions: &[EquityPrediction],
+) -> Result<DataFrame, String> {
+    df!(
+        "correlation_id" => predictions.iter().map(|prediction| prediction.correlation_id.to_string()).collect::<Vec<String>>(),
+        "model_run_id" => predictions.iter().map(|prediction| prediction.model_run_id.as_str()).collect::<Vec<&str>>(),
+        "ticker" => predictions.iter().map(|prediction| prediction.ticker.as_str()).collect::<Vec<&str>>(),
+        "timestamp" => predictions.iter().map(|prediction| prediction.timestamp.timestamp_millis()).collect::<Vec<i64>>(),
+        "quantile_10" => predictions.iter().map(|prediction| prediction.quantile_10).collect::<Vec<f64>>(),
+        "quantile_50" => predictions.iter().map(|prediction| prediction.quantile_50).collect::<Vec<f64>>(),
+        "quantile_90" => predictions.iter().map(|prediction| prediction.quantile_90).collect::<Vec<f64>>(),
+        "created_at" => predictions.iter().map(|prediction| prediction.created_at.timestamp_millis()).collect::<Vec<i64>>(),
+    )
+    .map_err(|error| format!("Failed to create equity prediction DataFrame: {}", error))
+}
+
+fn create_model_run_dataframe(model_runs: &[ModelRun]) -> Result<DataFrame, String> {
+    df!(
+        "id" => model_runs.iter().map(|run| run.id).collect::<Vec<i64>>(),
+        "run_id" => model_runs.iter().map(|run| run.run_id.as_str()).collect::<Vec<&str>>(),
+        "model_name" => model_runs.iter().map(|run| run.model_name.as_str()).collect::<Vec<&str>>(),
+        "artifact_key" => model_runs.iter().map(|run| run.artifact_key.as_deref()).collect::<Vec<Option<&str>>>(),
+        "training_data_key" => model_runs.iter().map(|run| run.training_data_key.as_deref()).collect::<Vec<Option<&str>>>(),
+        "start_date" => model_runs.iter().map(|run| run.start_date.map(|date| date.to_string())).collect::<Vec<Option<String>>>(),
+        "end_date" => model_runs.iter().map(|run| run.end_date.map(|date| date.to_string())).collect::<Vec<Option<String>>>(),
+        "lookback_days" => model_runs.iter().map(|run| run.lookback_days).collect::<Vec<Option<i32>>>(),
+        "status" => model_runs.iter().map(|run| run.status.as_str()).collect::<Vec<&str>>(),
+        "continuous_ranked_probability_score" => model_runs.iter().map(|run| run.continuous_ranked_probability_score).collect::<Vec<Option<f64>>>(),
+        "directional_accuracy" => model_runs.iter().map(|run| run.directional_accuracy).collect::<Vec<Option<f64>>>(),
+        "quantile_coverage" => model_runs.iter().map(|run| run.quantile_coverage).collect::<Vec<Option<f64>>>(),
+        "drift_status" => model_runs.iter().map(|run| run.drift_status.as_deref()).collect::<Vec<Option<&str>>>(),
+        "stage_counts" => model_runs.iter().map(|run| run.stage_counts.as_ref().map(|value| value.to_string())).collect::<Vec<Option<String>>>(),
+        "started_at" => model_runs.iter().map(|run| run.started_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "completed_at" => model_runs.iter().map(|run| run.completed_at.map(|timestamp| timestamp.timestamp_millis())).collect::<Vec<Option<i64>>>(),
+    )
+    .map_err(|error| format!("Failed to create model run DataFrame: {}", error))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::Utc;
     use internal::market::Ticker;
+    use serde_json::json;
 
     fn sample_quotes() -> Vec<EquityQuote> {
         let now = Utc::now();
@@ -595,46 +672,135 @@ mod tests {
         assert_eq!(amount_series.dtype(), &DataType::String);
     }
 
+    fn sample_predictions() -> Vec<EquityPrediction> {
+        let now = Utc::now();
+        vec![
+            EquityPrediction {
+                correlation_id: "550e8400-e29b-41d4-a716-446655440010".parse().unwrap(),
+                model_run_id: "run-tide-001".to_string(),
+                ticker: "AAPL".to_string(),
+                timestamp: now,
+                quantile_10: -0.02,
+                quantile_50: 0.01,
+                quantile_90: 0.04,
+                created_at: now,
+            },
+            EquityPrediction {
+                correlation_id: "550e8400-e29b-41d4-a716-446655440011".parse().unwrap(),
+                model_run_id: "run-tide-001".to_string(),
+                ticker: "MSFT".to_string(),
+                timestamp: now,
+                quantile_10: -0.01,
+                quantile_50: 0.005,
+                quantile_90: 0.02,
+                created_at: now,
+            },
+        ]
+    }
+
     #[test]
-    fn test_export_equity_quotes_returns_error_when_no_database() {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        runtime.block_on(async {
-            use crate::state::{DatabaseState, MassiveSecrets, State};
-            use aws_credential_types::Credentials;
-            use aws_sdk_s3::config::Region;
-            use chrono::NaiveDate;
+    fn test_create_equity_prediction_dataframe_columns_and_rows() {
+        let predictions = sample_predictions();
+        let dataframe = create_equity_prediction_dataframe(&predictions).unwrap();
+        assert_eq!(dataframe.height(), 2);
+        assert_eq!(dataframe.width(), 8);
+        assert!(dataframe.column("correlation_id").is_ok());
+        assert!(dataframe.column("model_run_id").is_ok());
+        assert!(dataframe.column("ticker").is_ok());
+        assert!(dataframe.column("timestamp").is_ok());
+        assert!(dataframe.column("quantile_10").is_ok());
+        assert!(dataframe.column("quantile_50").is_ok());
+        assert!(dataframe.column("quantile_90").is_ok());
+        assert!(dataframe.column("created_at").is_ok());
+    }
 
-            let credentials =
-                Credentials::new("test-access-key", "test-secret-key", None, None, "tests");
-            let shared_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-                .region(Region::new("us-east-1"))
-                .credentials_provider(credentials)
-                .endpoint_url("http://127.0.0.1:9")
-                .load()
-                .await;
-            let s3_config = aws_sdk_s3::config::Builder::from(&shared_config)
-                .force_path_style(true)
-                .build();
-            let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
-            let state = State::new(
-                reqwest::Client::new(),
-                MassiveSecrets {
-                    base: "http://127.0.0.1:1".to_string(),
-                    key: "test-api-key".to_string(),
-                },
-                s3_client,
-                "test-bucket".to_string(),
-            );
-            assert!(matches!(state.database, DatabaseState::NotConfigured));
+    #[test]
+    fn test_create_equity_prediction_dataframe_empty() {
+        let dataframe = create_equity_prediction_dataframe(&[]).unwrap();
+        assert_eq!(dataframe.height(), 0);
+        assert_eq!(dataframe.width(), 8);
+    }
 
-            let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
-            let result = export_equity_quotes(&state, date).await;
-            assert!(result.is_err());
-            assert!(result.unwrap_err().contains("database not connected"));
-        });
+    fn sample_model_runs() -> Vec<ModelRun> {
+        vec![
+            ModelRun {
+                id: 1,
+                run_id: "run-tide-001".to_string(),
+                model_name: "tide".to_string(),
+                artifact_key: Some("artifacts/tide/run-001/weights.safetensors".to_string()),
+                training_data_key: Some("data/equity/bars/training.parquet".to_string()),
+                start_date: Some(chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()),
+                end_date: Some(chrono::NaiveDate::from_ymd_opt(2026, 5, 1).unwrap()),
+                lookback_days: Some(70),
+                status: "completed".to_string(),
+                continuous_ranked_probability_score: Some(0.42),
+                directional_accuracy: Some(0.55),
+                quantile_coverage: Some(0.88),
+                drift_status: Some("stable".to_string()),
+                stage_counts: Some(json!({"stage_1": 100})),
+                started_at: Utc::now(),
+                completed_at: Some(Utc::now()),
+            },
+            ModelRun {
+                id: 2,
+                run_id: "run-tide-002".to_string(),
+                model_name: "tide".to_string(),
+                artifact_key: None,
+                training_data_key: None,
+                start_date: None,
+                end_date: None,
+                lookback_days: None,
+                status: "started".to_string(),
+                continuous_ranked_probability_score: None,
+                directional_accuracy: None,
+                quantile_coverage: None,
+                drift_status: None,
+                stage_counts: None,
+                started_at: Utc::now(),
+                completed_at: None,
+            },
+        ]
+    }
+
+    #[test]
+    fn test_create_model_run_dataframe_columns_and_rows() {
+        let model_runs = sample_model_runs();
+        let dataframe = create_model_run_dataframe(&model_runs).unwrap();
+        assert_eq!(dataframe.height(), 2);
+        assert_eq!(dataframe.width(), 16);
+        assert!(dataframe.column("id").is_ok());
+        assert!(dataframe.column("run_id").is_ok());
+        assert!(dataframe.column("model_name").is_ok());
+        assert!(dataframe.column("artifact_key").is_ok());
+        assert!(dataframe.column("training_data_key").is_ok());
+        assert!(dataframe.column("start_date").is_ok());
+        assert!(dataframe.column("end_date").is_ok());
+        assert!(dataframe.column("lookback_days").is_ok());
+        assert!(dataframe.column("status").is_ok());
+        assert!(dataframe
+            .column("continuous_ranked_probability_score")
+            .is_ok());
+        assert!(dataframe.column("directional_accuracy").is_ok());
+        assert!(dataframe.column("quantile_coverage").is_ok());
+        assert!(dataframe.column("drift_status").is_ok());
+        assert!(dataframe.column("stage_counts").is_ok());
+        assert!(dataframe.column("started_at").is_ok());
+        assert!(dataframe.column("completed_at").is_ok());
+    }
+
+    #[test]
+    fn test_create_model_run_dataframe_empty() {
+        let dataframe = create_model_run_dataframe(&[]).unwrap();
+        assert_eq!(dataframe.height(), 0);
+        assert_eq!(dataframe.width(), 16);
+    }
+
+    #[test]
+    fn test_create_model_run_dataframe_serializes_stage_counts_as_string() {
+        let model_runs = sample_model_runs();
+        let dataframe = create_model_run_dataframe(&model_runs).unwrap();
+        let stage_counts_series = dataframe.column("stage_counts").unwrap();
+        assert_eq!(stage_counts_series.dtype(), &DataType::String);
     }
 
     #[test]

--- a/applications/data_manager/src/scheduler.rs
+++ b/applications/data_manager/src/scheduler.rs
@@ -194,11 +194,7 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
         }
     }
 
-    for export_job in &[
-        "export-equity-quotes",
-        "export-equity-bars",
-        "export-trading-history",
-    ] {
+    for export_job in &["export-equity-bars", "export-trading-history"] {
         match database::requeue_stale_claimed_jobs(
             pool,
             export_job,
@@ -305,7 +301,7 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
                     }
                 }
             }
-            "export-equity-quotes" | "export-equity-bars" | "export-trading-history" => {
+            "export-equity-bars" | "export-trading-history" => {
                 info!("Received NOTIFY for {}", payload);
 
                 let (job_id, scheduled_at) = match database::claim_pending_job(pool, payload).await
@@ -350,7 +346,6 @@ async fn run_export_job(
     export_date: NaiveDate,
 ) -> Result<usize, String> {
     match job_name {
-        "export-equity-quotes" => export::export_equity_quotes(state, export_date).await,
         "export-equity-bars" => export::export_equity_bars(state, export_date).await,
         "export-trading-history" => export::export_trading_history(state, export_date).await,
         _ => {

--- a/schema.sql
+++ b/schema.sql
@@ -413,8 +413,8 @@ $do$;
 
 -- Nightly trading history export: weekdays at 21:45 UTC (after record-end-of-day-snapshot at 21:15
 -- so today's snapshot is included).
--- Exports equity_quotes, equity_rebalance_sessions, equity_pairs, equity_allocations,
--- equity_orders, equity_portfolio_snapshots, and model_runs; deletes exported equity_quotes rows.
+-- Exports equity_quotes, equity_predictions, equity_rebalance_sessions, equity_pairs,
+-- equity_allocations, equity_orders, equity_portfolio_snapshots, and model_runs; deletes exported equity_quotes rows.
 -- Triggers a Rust export task in data_manager via the jobs channel.
 DO $do$
 BEGIN

--- a/schema.sql
+++ b/schema.sql
@@ -397,21 +397,6 @@ BEGIN
 END;
 $do$;
 
--- Daily equity quotes export: weekdays at 21:05 UTC (after intraday-check window ends at 20:55 UTC
--- and after 4 PM Eastern market close in both EDT and EST).
--- Triggers a Rust export task in data_manager via the jobs channel.
-DO $do$
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'export-equity-quotes') THEN
-        PERFORM cron.schedule(
-            'export-equity-quotes',
-            '5 21 * * 1-5',
-            $$SELECT schedule_job('export-equity-quotes')$$
-        );
-    END IF;
-END;
-$do$;
-
 -- Nightly equity bars export: weekdays at 21:30 UTC.
 -- Triggers a Rust export task in data_manager via the jobs channel.
 DO $do$
@@ -428,6 +413,8 @@ $do$;
 
 -- Nightly trading history export: weekdays at 21:45 UTC (after record-end-of-day-snapshot at 21:15
 -- so today's snapshot is included).
+-- Exports equity_quotes, equity_rebalance_sessions, equity_pairs, equity_allocations,
+-- equity_orders, equity_portfolio_snapshots, and model_runs; deletes exported equity_quotes rows.
 -- Triggers a Rust export task in data_manager via the jobs channel.
 DO $do$
 BEGIN


### PR DESCRIPTION
## Summary

Closes #924.

- Removes the separate `export-equity-quotes` pg_cron entry (21:05 UTC) and standalone Rust task; equity quotes are now exported (and deleted from PostgreSQL) as the first step of `export-trading-history` at 21:45 UTC
- Adds `equity_predictions` to the export (date-filtered, no delete — the 7-day retention policy handles cleanup; predictions must remain available for inference)
- Adds `model_runs` to the export (full-table snapshot; co-exported with rebalance sessions and allocations that reference `model_run_id` for referential completeness)
- Removes `export-equity-quotes` from the scheduler drain list, NOTIFY match arm, and `run_export_job` dispatch in `scheduler.rs`
- Adds `query_equity_predictions_for_date` and `query_model_runs` to `database.rs`
- Adds `create_equity_prediction_dataframe` (8 columns) and `create_model_run_dataframe` (16 columns) with unit tests

The nightly `export-trading-history` job at 21:45 UTC now covers: equity quotes (export + delete), equity predictions (export only), rebalance sessions, pairs, allocations, orders, portfolio snapshots, and model runs.

## Test plan

- [x] Confirm `export-equity-quotes` pg_cron entry is gone from `schema.sql`
- [x] Confirm `export-trading-history` cron comment lists all exported tables
- [x] Confirm `export_equity_quotes` no longer exists as a public function in `export.rs`
- [x] Confirm `export_trading_history` exports quotes, predictions, sessions, pairs, allocations, orders, snapshots, and model runs
- [x] Confirm equity quotes are deleted from PostgreSQL after export; equity predictions are not
- [x] Confirm scheduler no longer handles `export-equity-quotes` NOTIFY or drain
- [x] Run `devenv tasks run checks:rust` — all checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added export capabilities for equity predictions and model-run metadata
  * Enhanced the trading-history export pipeline to include prediction and model-run data alongside existing export flows

* **Changes**
  * Consolidated equity quotes export into the main trading-history pipeline, removing the separate scheduled export job

<!-- end of auto-generated comment: release notes by coderabbit.ai -->