### PR TITLE
[Wave 3, Part 12] `libraries/rust`, `data_manager`: private fields and boundary morphism on internal types

### DIFF
--- a/applications/data_manager/src/data.rs
+++ b/applications/data_manager/src/data.rs
@@ -3,7 +3,7 @@ use chrono::{Datelike, NaiveDate, Weekday};
 use polars::prelude::*;
 use tracing::{debug, info};
 
-pub use internal::market::{EquityBar, EquityDetails, EquityQuote, Ticker};
+pub use internal::market::{EquityBar, EquityDetail, EquityQuote, Ticker};
 
 /// A validated US market trading date (Monday through Friday).
 ///
@@ -38,16 +38,16 @@ pub fn create_equity_bar_dataframe(equity_bars_rows: &[EquityBar]) -> Result<Dat
 
     // Ticker values are already normalized (trimmed and uppercased) by Ticker::new.
     let equity_bars_dataframe = df!(
-        "ticker" => equity_bars_rows.iter().map(|b| b.ticker.as_str()).collect::<Vec<_>>(),
-        "timestamp" => equity_bars_rows.iter().map(|b| b.timestamp.timestamp_millis()).collect::<Vec<_>>(),
-        "open_price" => equity_bars_rows.iter().map(|b| b.open_price).collect::<Vec<f64>>(),
-        "high_price" => equity_bars_rows.iter().map(|b| b.high_price).collect::<Vec<f64>>(),
-        "low_price" => equity_bars_rows.iter().map(|b| b.low_price).collect::<Vec<f64>>(),
-        "close_price" => equity_bars_rows.iter().map(|b| b.close_price).collect::<Vec<f64>>(),
-        "volume" => equity_bars_rows.iter().map(|b| b.volume).collect::<Vec<i64>>(),
-        "volume_weighted_average_price" => equity_bars_rows.iter().map(|b| b.volume_weighted_average_price).collect::<Vec<_>>(),
-        "transactions" => equity_bars_rows.iter().map(|b| b.transactions).collect::<Vec<_>>(),
-        "inserted_at" => equity_bars_rows.iter().map(|b| b.inserted_at.timestamp_millis()).collect::<Vec<_>>(),
+        "ticker" => equity_bars_rows.iter().map(|b| b.ticker().as_str()).collect::<Vec<_>>(),
+        "timestamp" => equity_bars_rows.iter().map(|b| b.timestamp().timestamp_millis()).collect::<Vec<_>>(),
+        "open_price" => equity_bars_rows.iter().map(|b| b.open_price()).collect::<Vec<f64>>(),
+        "high_price" => equity_bars_rows.iter().map(|b| b.high_price()).collect::<Vec<f64>>(),
+        "low_price" => equity_bars_rows.iter().map(|b| b.low_price()).collect::<Vec<f64>>(),
+        "close_price" => equity_bars_rows.iter().map(|b| b.close_price()).collect::<Vec<f64>>(),
+        "volume" => equity_bars_rows.iter().map(|b| b.volume()).collect::<Vec<i64>>(),
+        "volume_weighted_average_price" => equity_bars_rows.iter().map(|b| b.volume_weighted_average_price()).collect::<Vec<_>>(),
+        "transactions" => equity_bars_rows.iter().map(|b| b.transactions()).collect::<Vec<_>>(),
+        "inserted_at" => equity_bars_rows.iter().map(|b| b.inserted_at().timestamp_millis()).collect::<Vec<_>>(),
     )
     .map_err(|e| Error::Other(format!("Failed to create equity bar DataFrame: {}", e)))?;
 

--- a/applications/data_manager/src/database.rs
+++ b/applications/data_manager/src/database.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Days, NaiveDate, Utc};
-use internal::market::{EquityBar, EquityDetails, EquityQuote};
+use internal::market::{EquityBar, EquityDetail, EquityQuote, Ticker};
 use internal::predictions::{EquityPrediction, ModelRun};
 use internal::trading::{
     EquityAllocation, EquityOrder, EquityPair, EquityPortfolioSnapshot, EquityRebalanceSession,
@@ -21,16 +21,16 @@ pub async fn insert_equity_bars(pool: &PgPool, bars: &[EquityBar]) -> Result<u64
 
         query_builder.push_values(chunk, |mut builder, bar| {
             builder
-                .push_bind(&bar.ticker)
-                .push_bind(bar.timestamp)
-                .push_bind(bar.open_price)
-                .push_bind(bar.high_price)
-                .push_bind(bar.low_price)
-                .push_bind(bar.close_price)
-                .push_bind(bar.volume)
-                .push_bind(bar.volume_weighted_average_price)
-                .push_bind(bar.transactions)
-                .push_bind(bar.inserted_at);
+                .push_bind(bar.ticker())
+                .push_bind(bar.timestamp())
+                .push_bind(bar.open_price())
+                .push_bind(bar.high_price())
+                .push_bind(bar.low_price())
+                .push_bind(bar.close_price())
+                .push_bind(bar.volume())
+                .push_bind(bar.volume_weighted_average_price())
+                .push_bind(bar.transactions())
+                .push_bind(bar.inserted_at());
         });
 
         query_builder.push(
@@ -126,12 +126,12 @@ pub async fn insert_equity_quotes(
 
         query_builder.push_values(chunk, |mut builder, quote| {
             builder
-                .push_bind(quote.timestamp)
-                .push_bind(&quote.ticker)
-                .push_bind(quote.bid_price)
-                .push_bind(quote.ask_price)
-                .push_bind(quote.bid_size)
-                .push_bind(quote.ask_size);
+                .push_bind(quote.timestamp())
+                .push_bind(quote.ticker())
+                .push_bind(quote.bid_price())
+                .push_bind(quote.ask_price())
+                .push_bind(quote.bid_size())
+                .push_bind(quote.ask_size());
         });
 
         let result = query_builder.build().execute(pool).await?;
@@ -142,7 +142,7 @@ pub async fn insert_equity_quotes(
     Ok(rows_affected)
 }
 
-pub async fn get_active_tickers(pool: &PgPool) -> Result<Vec<String>, sqlx::Error> {
+pub async fn get_active_tickers(pool: &PgPool) -> Result<Vec<Ticker>, sqlx::Error> {
     let rows: Vec<(String,)> = sqlx::query_as(
         r#"SELECT DISTINCT ea.ticker
            FROM equity_allocations ea
@@ -153,7 +153,10 @@ pub async fn get_active_tickers(pool: &PgPool) -> Result<Vec<String>, sqlx::Erro
     .fetch_all(pool)
     .await?;
 
-    let tickers: Vec<String> = rows.into_iter().map(|(ticker,)| ticker).collect();
+    let tickers: Vec<Ticker> = rows
+        .into_iter()
+        .filter_map(|(ticker,)| Ticker::new(&ticker))
+        .collect();
     debug!("Queried {} active tickers from PostgreSQL", tickers.len());
     Ok(tickers)
 }
@@ -168,26 +171,13 @@ pub async fn emit_equity_bars_synced(pool: &PgPool) -> Result<(), sqlx::Error> {
     Ok(())
 }
 
-pub async fn populate_equity_details_if_empty(
-    pool: &PgPool,
-    rows: &[EquityDetails],
-) -> Result<u64, sqlx::Error> {
-    let mut transaction = pool.begin().await?;
-
-    let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM equity_details")
-        .fetch_one(&mut *transaction)
-        .await?;
-
-    if count.0 > 0 {
-        info!(
-            "equity_details already populated with {} rows, skipping migration",
-            count.0
-        );
-        return Ok(0);
-    }
-
+/// Seeds `equity_details` from the provided rows using an idempotent upsert.
+///
+/// Assumes a blank database on first startup. Subsequent runs are safe because
+/// `ON CONFLICT (ticker) DO NOTHING` skips rows that already exist.
+pub async fn seed_equity_details(pool: &PgPool, rows: &[EquityDetail]) -> Result<u64, sqlx::Error> {
     if rows.is_empty() {
-        warn!("equity_details is empty and no rows provided; skipping migration");
+        warn!("No equity details rows provided for seeding; skipping");
         return Ok(0);
     }
 
@@ -197,25 +187,20 @@ pub async fn populate_equity_details_if_empty(
         let mut query_builder =
             sqlx::QueryBuilder::new("INSERT INTO equity_details (ticker, sector, industry) ");
 
-        query_builder.push_values(chunk, |mut builder, details| {
+        query_builder.push_values(chunk, |mut builder, detail| {
             builder
-                .push_bind(&details.ticker)
-                .push_bind(&details.sector)
-                .push_bind(&details.industry);
+                .push_bind(detail.ticker())
+                .push_bind(detail.sector())
+                .push_bind(detail.industry());
         });
 
         query_builder.push(" ON CONFLICT (ticker) DO NOTHING");
 
-        let result = query_builder.build().execute(&mut *transaction).await?;
+        let result = query_builder.build().execute(pool).await?;
         rows_affected += result.rows_affected();
     }
 
-    transaction.commit().await?;
-
-    info!(
-        "Populated equity_details with {} rows from S3 migration",
-        rows_affected
-    );
+    info!("Seeded equity_details with {} rows from S3", rows_affected);
     Ok(rows_affected)
 }
 
@@ -416,33 +401,38 @@ mod tests {
     use chrono::Utc;
     use internal::market::{EquityBar, Ticker};
 
+    fn test_pool() -> PgPool {
+        PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
+            .expect("lazy pool creation should not fail")
+    }
+
     fn sample_bars() -> Vec<EquityBar> {
         let now = Utc::now();
         vec![
-            EquityBar {
-                ticker: Ticker::new("AAPL").unwrap(),
-                timestamp: now,
-                open_price: 150.0,
-                high_price: 155.0,
-                low_price: 149.0,
-                close_price: 153.0,
-                volume: 1_000_000,
-                volume_weighted_average_price: Some(152.0),
-                transactions: Some(50_000),
-                inserted_at: now,
-            },
-            EquityBar {
-                ticker: Ticker::new("MSFT").unwrap(),
-                timestamp: now,
-                open_price: 350.0,
-                high_price: 355.0,
-                low_price: 349.0,
-                close_price: 353.0,
-                volume: 500_000,
-                volume_weighted_average_price: Some(352.0),
-                transactions: Some(25_000),
-                inserted_at: now,
-            },
+            EquityBar::new(
+                Ticker::new("AAPL").unwrap(),
+                now,
+                150.0,
+                155.0,
+                149.0,
+                153.0,
+                1_000_000,
+                Some(152.0),
+                Some(50_000),
+                now,
+            ),
+            EquityBar::new(
+                Ticker::new("MSFT").unwrap(),
+                now,
+                350.0,
+                355.0,
+                349.0,
+                353.0,
+                500_000,
+                Some(352.0),
+                Some(25_000),
+                now,
+            ),
         ]
     }
 
@@ -450,8 +440,8 @@ mod tests {
     fn test_sample_bars_are_valid() {
         let bars = sample_bars();
         assert_eq!(bars.len(), 2);
-        assert_eq!(bars[0].ticker, "AAPL");
-        assert_eq!(bars[1].ticker, "MSFT");
+        assert_eq!(bars[0].ticker(), "AAPL");
+        assert_eq!(bars[1].ticker(), "MSFT");
     }
 
     #[test]
@@ -461,8 +451,7 @@ mod tests {
             .build()
             .unwrap();
         runtime.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let result = insert_equity_bars(&pool, &[]).await;
             assert!(result.is_ok());
             assert_eq!(result.unwrap(), 0);
@@ -476,8 +465,7 @@ mod tests {
             .build()
             .unwrap();
         runtime.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let result = insert_equity_quotes(&pool, &[]).await;
             assert!(result.is_ok());
             assert_eq!(result.unwrap(), 0);
@@ -491,8 +479,7 @@ mod tests {
             .build()
             .unwrap();
         runtime.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let result = get_active_tickers(&pool).await;
             assert!(result.is_err());
         });
@@ -505,8 +492,7 @@ mod tests {
             .build()
             .unwrap();
         runtime.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let result = requeue_stale_claimed_jobs(
                 &pool,
                 "equity-bar-sync",
@@ -524,8 +510,7 @@ mod tests {
             .build()
             .unwrap();
         runtime.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let result = emit_equity_bars_synced(&pool).await;
             assert!(result.is_err());
         });
@@ -539,8 +524,7 @@ mod tests {
             .unwrap();
         runtime.block_on(async {
             use chrono::NaiveDate;
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
             let result = query_equity_quotes_for_date(&pool, date).await;
             assert!(result.is_err());
@@ -555,8 +539,7 @@ mod tests {
             .unwrap();
         runtime.block_on(async {
             use chrono::NaiveDate;
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
             let result = delete_equity_quotes_for_date(&pool, date).await;
             assert!(result.is_err());
@@ -571,8 +554,7 @@ mod tests {
             .unwrap();
         runtime.block_on(async {
             use chrono::NaiveDate;
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
             let result = query_equity_bars_for_date(&pool, date).await;
             assert!(result.is_err());
@@ -586,8 +568,7 @@ mod tests {
             .build()
             .unwrap();
         runtime.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let result = query_equity_rebalance_sessions(&pool).await;
             assert!(result.is_err());
         });
@@ -600,8 +581,7 @@ mod tests {
             .build()
             .unwrap();
         runtime.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let result = query_equity_pairs(&pool).await;
             assert!(result.is_err());
         });
@@ -614,8 +594,7 @@ mod tests {
             .build()
             .unwrap();
         runtime.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let result = query_equity_allocations(&pool).await;
             assert!(result.is_err());
         });
@@ -628,8 +607,7 @@ mod tests {
             .build()
             .unwrap();
         runtime.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let result = query_equity_orders(&pool).await;
             assert!(result.is_err());
         });
@@ -642,8 +620,7 @@ mod tests {
             .build()
             .unwrap();
         runtime.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let result = query_equity_portfolio_snapshots(&pool).await;
             assert!(result.is_err());
         });
@@ -657,8 +634,7 @@ mod tests {
             .unwrap();
         runtime.block_on(async {
             use chrono::NaiveDate;
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
             let result = query_equity_predictions_for_date(&pool, date).await;
             assert!(result.is_err());
@@ -672,8 +648,7 @@ mod tests {
             .build()
             .unwrap();
         runtime.block_on(async {
-            let pool = PgPool::connect_lazy("postgresql://localhost:5432/fund_test_nonexistent")
-                .expect("lazy pool creation should not fail");
+            let pool = test_pool();
             let result = query_model_runs(&pool).await;
             assert!(result.is_err());
         });

--- a/applications/data_manager/src/equity_bars.rs
+++ b/applications/data_manager/src/equity_bars.rs
@@ -68,7 +68,7 @@ fn parse_equity_bar(result: &EquityBarResult, inserted_at: DateTime<Utc>) -> Opt
             }
         })?;
 
-    Some(EquityBar {
+    Some(EquityBar::new(
         ticker,
         timestamp,
         open_price,
@@ -76,10 +76,10 @@ fn parse_equity_bar(result: &EquityBarResult, inserted_at: DateTime<Utc>) -> Opt
         low_price,
         close_price,
         volume,
-        volume_weighted_average_price: result.vw,
-        transactions: result.n.and_then(|n| i64::try_from(n).ok()),
+        result.vw,
+        result.n.and_then(|n| i64::try_from(n).ok()),
         inserted_at,
-    })
+    ))
 }
 
 async fn write_equity_bars_to_s3(
@@ -272,12 +272,12 @@ mod tests {
     fn test_parse_equity_bar_valid() {
         let result = make_valid_result();
         let bar = parse_equity_bar(&result, Utc::now()).unwrap();
-        assert_eq!(bar.ticker, "AAPL");
-        assert_eq!(bar.open_price, 100.0);
-        assert_eq!(bar.close_price, 105.0);
-        assert_eq!(bar.volume, 2_000_000);
+        assert_eq!(bar.ticker(), "AAPL");
+        assert_eq!(bar.open_price(), 100.0);
+        assert_eq!(bar.close_price(), 105.0);
+        assert_eq!(bar.volume(), 2_000_000);
         let expected_timestamp = DateTime::from_timestamp_millis(1_735_689_600_000).unwrap();
-        assert_eq!(bar.timestamp, expected_timestamp);
+        assert_eq!(bar.timestamp(), expected_timestamp);
     }
 
     #[test]
@@ -285,7 +285,7 @@ mod tests {
         let mut result = make_valid_result();
         result.ticker = "  aapl  ".to_string();
         let bar = parse_equity_bar(&result, Utc::now()).unwrap();
-        assert_eq!(bar.ticker, "AAPL");
+        assert_eq!(bar.ticker(), "AAPL");
     }
 
     #[test]
@@ -350,8 +350,8 @@ mod tests {
         result.vw = None;
         result.n = None;
         let bar = parse_equity_bar(&result, Utc::now()).unwrap();
-        assert!(bar.volume_weighted_average_price.is_none());
-        assert!(bar.transactions.is_none());
+        assert!(bar.volume_weighted_average_price().is_none());
+        assert!(bar.transactions().is_none());
     }
 
     #[test]
@@ -360,6 +360,6 @@ mod tests {
         let mut result = make_valid_result();
         result.ticker = "BRK.B".to_string();
         let bar = parse_equity_bar(&result, Utc::now()).unwrap();
-        assert_eq!(bar.ticker, "BRK.B");
+        assert_eq!(bar.ticker(), "BRK.B");
     }
 }

--- a/applications/data_manager/src/equity_details.rs
+++ b/applications/data_manager/src/equity_details.rs
@@ -1,6 +1,6 @@
 use crate::errors::Error;
 use crate::state::State;
-use internal::market::{EquityDetails, Ticker};
+use internal::market::{EquityDetail, Ticker};
 use tracing::{info, warn};
 
 const EQUITY_DETAILS_KEY: &str = "data/equity/details/details.csv";
@@ -35,7 +35,7 @@ async fn read_equity_details_csv_from_s3(state: &State) -> Result<String, Error>
     Ok(csv_content)
 }
 
-fn parse_equity_details_csv(csv_content: &str) -> Result<Vec<EquityDetails>, Error> {
+fn parse_equity_details_csv(csv_content: &str) -> Result<Vec<EquityDetail>, Error> {
     let mut lines = csv_content.lines();
 
     let header_line = match lines.next() {
@@ -93,11 +93,7 @@ fn parse_equity_details_csv(csv_content: &str) -> Result<Vec<EquityDetails>, Err
             industry_raw
         };
 
-        details.push(EquityDetails {
-            ticker,
-            sector,
-            industry,
-        });
+        details.push(EquityDetail::new(ticker, sector, industry));
     }
 
     if rejected_rows > 0 {
@@ -110,7 +106,7 @@ fn parse_equity_details_csv(csv_content: &str) -> Result<Vec<EquityDetails>, Err
     Ok(details)
 }
 
-pub async fn read_equity_details_from_s3(state: &State) -> Result<Vec<EquityDetails>, Error> {
+pub async fn read_equity_details_from_s3(state: &State) -> Result<Vec<EquityDetail>, Error> {
     let csv_content = read_equity_details_csv_from_s3(state).await?;
     let details = parse_equity_details_csv(&csv_content)?;
     info!("Successfully parsed {} equity details rows", details.len());
@@ -126,10 +122,10 @@ mod tests {
         let csv = "ticker,sector,industry\nAAPL,Technology,Consumer Electronics\nGOOGL,Technology,Internet Services\n";
         let details = parse_equity_details_csv(csv).unwrap();
         assert_eq!(details.len(), 2);
-        assert_eq!(details[0].ticker, "AAPL");
-        assert_eq!(details[0].sector, "TECHNOLOGY");
-        assert_eq!(details[0].industry, "CONSUMER ELECTRONICS");
-        assert_eq!(details[1].ticker, "GOOGL");
+        assert_eq!(details[0].ticker(), "AAPL");
+        assert_eq!(details[0].sector(), "TECHNOLOGY");
+        assert_eq!(details[0].industry(), "CONSUMER ELECTRONICS");
+        assert_eq!(details[1].ticker(), "GOOGL");
     }
 
     #[test]
@@ -138,9 +134,9 @@ mod tests {
             "ticker,sector,industry\nECC           ,  Technology  ,  Consumer Electronics  \n";
         let details = parse_equity_details_csv(csv).unwrap();
         assert_eq!(details.len(), 1);
-        assert_eq!(details[0].ticker, "ECC");
-        assert_eq!(details[0].sector, "TECHNOLOGY");
-        assert_eq!(details[0].industry, "CONSUMER ELECTRONICS");
+        assert_eq!(details[0].ticker(), "ECC");
+        assert_eq!(details[0].sector(), "TECHNOLOGY");
+        assert_eq!(details[0].industry(), "CONSUMER ELECTRONICS");
     }
 
     #[test]
@@ -148,9 +144,9 @@ mod tests {
         let csv = "ticker,sector,industry\naapl,technology,consumer electronics\n";
         let details = parse_equity_details_csv(csv).unwrap();
         assert_eq!(details.len(), 1);
-        assert_eq!(details[0].ticker, "AAPL");
-        assert_eq!(details[0].sector, "TECHNOLOGY");
-        assert_eq!(details[0].industry, "CONSUMER ELECTRONICS");
+        assert_eq!(details[0].ticker(), "AAPL");
+        assert_eq!(details[0].sector(), "TECHNOLOGY");
+        assert_eq!(details[0].industry(), "CONSUMER ELECTRONICS");
     }
 
     #[test]
@@ -158,8 +154,8 @@ mod tests {
         let csv = "ticker,sector,industry\nAAPL,,\n";
         let details = parse_equity_details_csv(csv).unwrap();
         assert_eq!(details.len(), 1);
-        assert_eq!(details[0].sector, "NOT AVAILABLE");
-        assert_eq!(details[0].industry, "NOT AVAILABLE");
+        assert_eq!(details[0].sector(), "NOT AVAILABLE");
+        assert_eq!(details[0].industry(), "NOT AVAILABLE");
     }
 
     #[test]
@@ -168,7 +164,7 @@ mod tests {
             "ticker,sector,industry,extra_column\nAAPL,Technology,Consumer Electronics,Extra\n";
         let details = parse_equity_details_csv(csv).unwrap();
         assert_eq!(details.len(), 1);
-        assert_eq!(details[0].ticker, "AAPL");
+        assert_eq!(details[0].ticker(), "AAPL");
     }
 
     #[test]

--- a/applications/data_manager/src/equity_quotes.rs
+++ b/applications/data_manager/src/equity_quotes.rs
@@ -56,10 +56,7 @@ async fn quote_stream_supervisor(state: State) {
 async fn refresh_active_symbols(state: &State, pool: &sqlx::PgPool) {
     match database::get_active_tickers(pool).await {
         Ok(tickers) => {
-            let symbol_set: HashSet<Ticker> = tickers
-                .into_iter()
-                .filter_map(|t| Ticker::new(&t))
-                .collect();
+            let symbol_set: HashSet<Ticker> = tickers.into_iter().collect();
             info!("Refreshed active symbols, count: {}", symbol_set.len());
             let mut guard = state.active_symbols.write().await;
             *guard = symbol_set;
@@ -278,14 +275,9 @@ pub fn parse_quote_messages(text: &str) -> Vec<EquityQuote> {
             let timestamp_str = message.get("t").and_then(|v| v.as_str())?;
             let timestamp = timestamp_str.parse::<DateTime<Utc>>().ok()?;
 
-            Some(EquityQuote {
-                timestamp,
-                ticker,
-                bid_price,
-                ask_price,
-                bid_size,
-                ask_size,
-            })
+            Some(EquityQuote::new(
+                timestamp, ticker, bid_price, ask_price, bid_size, ask_size,
+            ))
         })
         .collect()
 }
@@ -303,12 +295,12 @@ mod tests {
 
         let quotes = parse_quote_messages(text);
         assert_eq!(quotes.len(), 2);
-        assert_eq!(quotes[0].ticker, "AAPL");
-        assert_eq!(quotes[0].bid_price, 150.50);
-        assert_eq!(quotes[0].ask_price, 150.55);
-        assert_eq!(quotes[0].bid_size, 5);
-        assert_eq!(quotes[0].ask_size, 3);
-        assert_eq!(quotes[1].ticker, "MSFT");
+        assert_eq!(quotes[0].ticker(), "AAPL");
+        assert_eq!(quotes[0].bid_price(), 150.50);
+        assert_eq!(quotes[0].ask_price(), 150.55);
+        assert_eq!(quotes[0].bid_size(), 5);
+        assert_eq!(quotes[0].ask_size(), 3);
+        assert_eq!(quotes[1].ticker(), "MSFT");
     }
 
     #[test]
@@ -322,7 +314,7 @@ mod tests {
 
         let quotes = parse_quote_messages(text);
         assert_eq!(quotes.len(), 1);
-        assert_eq!(quotes[0].ticker, "AAPL");
+        assert_eq!(quotes[0].ticker(), "AAPL");
     }
 
     #[test]

--- a/applications/data_manager/src/export.rs
+++ b/applications/data_manager/src/export.rs
@@ -34,12 +34,7 @@ pub async fn export_equity_bars(state: &State, date: NaiveDate) -> Result<usize,
     }
 
     let mut dataframe = create_equity_bar_export_dataframe(&bars)?;
-    let key = format!(
-        "data/equity/bars/year={}/month={:02}/day={:02}/data.parquet",
-        date.year(),
-        date.month(),
-        date.day()
-    );
+    let key = date_partitioned_key("data/equity/bars", date);
     write_dataframe_to_s3(state, &mut dataframe, &key).await?;
     info!("Exported {} equity bars to S3: {}", count, key);
 
@@ -51,7 +46,10 @@ pub async fn export_equity_bars(state: &State, date: NaiveDate) -> Result<usize,
 /// Exports equity_quotes, equity_predictions, equity_rebalance_sessions, equity_pairs,
 /// equity_allocations, equity_orders, equity_portfolio_snapshots, and model_runs. Deletes the
 /// exported equity_quotes rows from the database after a successful S3 write.
-pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<usize, String> {
+pub async fn export_equity_trading_history(
+    state: &State,
+    date: NaiveDate,
+) -> Result<usize, String> {
     let pool = state
         .database
         .pool()
@@ -66,12 +64,7 @@ pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<us
         write_dataframe_to_s3(
             state,
             &mut quote_dataframe,
-            &format!(
-                "data/equity/quotes/year={}/month={:02}/day={:02}/data.parquet",
-                date.year(),
-                date.month(),
-                date.day()
-            ),
+            &date_partitioned_key("data/equity/quotes", date),
         )
         .await?;
         database::delete_equity_quotes_for_date(pool, date)
@@ -90,12 +83,7 @@ pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<us
         write_dataframe_to_s3(
             state,
             &mut prediction_dataframe,
-            &format!(
-                "exports/equity/predictions/year={}/month={:02}/day={:02}/data.parquet",
-                date.year(),
-                date.month(),
-                date.day()
-            ),
+            &date_partitioned_key("exports/equity/predictions", date),
         )
         .await?;
     } else {
@@ -110,12 +98,7 @@ pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<us
     write_dataframe_to_s3(
         state,
         &mut session_dataframe,
-        &format!(
-            "exports/equity/rebalance-sessions/year={}/month={:02}/day={:02}/data.parquet",
-            date.year(),
-            date.month(),
-            date.day()
-        ),
+        &date_partitioned_key("exports/equity/rebalance-sessions", date),
     )
     .await?;
 
@@ -127,12 +110,7 @@ pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<us
     write_dataframe_to_s3(
         state,
         &mut pair_dataframe,
-        &format!(
-            "exports/equity/pairs/year={}/month={:02}/day={:02}/data.parquet",
-            date.year(),
-            date.month(),
-            date.day()
-        ),
+        &date_partitioned_key("exports/equity/pairs", date),
     )
     .await?;
 
@@ -144,12 +122,7 @@ pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<us
     write_dataframe_to_s3(
         state,
         &mut allocation_dataframe,
-        &format!(
-            "exports/equity/allocations/year={}/month={:02}/day={:02}/data.parquet",
-            date.year(),
-            date.month(),
-            date.day()
-        ),
+        &date_partitioned_key("exports/equity/allocations", date),
     )
     .await?;
 
@@ -161,12 +134,7 @@ pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<us
     write_dataframe_to_s3(
         state,
         &mut order_dataframe,
-        &format!(
-            "exports/equity/orders/year={}/month={:02}/day={:02}/data.parquet",
-            date.year(),
-            date.month(),
-            date.day()
-        ),
+        &date_partitioned_key("exports/equity/orders", date),
     )
     .await?;
 
@@ -178,12 +146,7 @@ pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<us
     write_dataframe_to_s3(
         state,
         &mut snapshot_dataframe,
-        &format!(
-            "exports/equity/portfolio-snapshots/year={}/month={:02}/day={:02}/data.parquet",
-            date.year(),
-            date.month(),
-            date.day()
-        ),
+        &date_partitioned_key("exports/equity/portfolio-snapshots", date),
     )
     .await?;
 
@@ -195,12 +158,7 @@ pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<us
     write_dataframe_to_s3(
         state,
         &mut model_run_dataframe,
-        &format!(
-            "exports/model-runs/year={}/month={:02}/day={:02}/data.parquet",
-            date.year(),
-            date.month(),
-            date.day()
-        ),
+        &date_partitioned_key("exports/model-runs", date),
     )
     .await?;
 
@@ -217,6 +175,16 @@ pub async fn export_trading_history(state: &State, date: NaiveDate) -> Result<us
         + order_count
         + snapshot_count
         + model_run_count)
+}
+
+fn date_partitioned_key(prefix: &str, date: NaiveDate) -> String {
+    format!(
+        "{}/year={}/month={:02}/day={:02}/data.parquet",
+        prefix,
+        date.year(),
+        date.month(),
+        date.day()
+    )
 }
 
 async fn write_dataframe_to_s3(
@@ -244,28 +212,28 @@ async fn write_dataframe_to_s3(
 
 fn create_equity_quote_dataframe(quotes: &[EquityQuote]) -> Result<DataFrame, String> {
     df!(
-        "timestamp" => quotes.iter().map(|quote| quote.timestamp.timestamp_millis()).collect::<Vec<i64>>(),
-        "ticker" => quotes.iter().map(|quote| quote.ticker.as_str()).collect::<Vec<&str>>(),
-        "bid_price" => quotes.iter().map(|quote| quote.bid_price).collect::<Vec<f64>>(),
-        "ask_price" => quotes.iter().map(|quote| quote.ask_price).collect::<Vec<f64>>(),
-        "bid_size" => quotes.iter().map(|quote| quote.bid_size).collect::<Vec<i32>>(),
-        "ask_size" => quotes.iter().map(|quote| quote.ask_size).collect::<Vec<i32>>(),
+        "timestamp" => quotes.iter().map(|quote| quote.timestamp().timestamp_millis()).collect::<Vec<i64>>(),
+        "ticker" => quotes.iter().map(|quote| quote.ticker().as_str()).collect::<Vec<&str>>(),
+        "bid_price" => quotes.iter().map(|quote| quote.bid_price()).collect::<Vec<f64>>(),
+        "ask_price" => quotes.iter().map(|quote| quote.ask_price()).collect::<Vec<f64>>(),
+        "bid_size" => quotes.iter().map(|quote| quote.bid_size()).collect::<Vec<i32>>(),
+        "ask_size" => quotes.iter().map(|quote| quote.ask_size()).collect::<Vec<i32>>(),
     )
     .map_err(|error| format!("Failed to create equity quote DataFrame: {}", error))
 }
 
 fn create_equity_bar_export_dataframe(bars: &[EquityBar]) -> Result<DataFrame, String> {
     df!(
-        "ticker" => bars.iter().map(|bar| bar.ticker.as_str()).collect::<Vec<&str>>(),
-        "timestamp" => bars.iter().map(|bar| bar.timestamp.timestamp_millis()).collect::<Vec<i64>>(),
-        "open_price" => bars.iter().map(|bar| bar.open_price).collect::<Vec<f64>>(),
-        "high_price" => bars.iter().map(|bar| bar.high_price).collect::<Vec<f64>>(),
-        "low_price" => bars.iter().map(|bar| bar.low_price).collect::<Vec<f64>>(),
-        "close_price" => bars.iter().map(|bar| bar.close_price).collect::<Vec<f64>>(),
-        "volume" => bars.iter().map(|bar| bar.volume).collect::<Vec<i64>>(),
-        "volume_weighted_average_price" => bars.iter().map(|bar| bar.volume_weighted_average_price).collect::<Vec<Option<f64>>>(),
-        "transactions" => bars.iter().map(|bar| bar.transactions).collect::<Vec<Option<i64>>>(),
-        "inserted_at" => bars.iter().map(|bar| bar.inserted_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "ticker" => bars.iter().map(|bar| bar.ticker().as_str()).collect::<Vec<&str>>(),
+        "timestamp" => bars.iter().map(|bar| bar.timestamp().timestamp_millis()).collect::<Vec<i64>>(),
+        "open_price" => bars.iter().map(|bar| bar.open_price()).collect::<Vec<f64>>(),
+        "high_price" => bars.iter().map(|bar| bar.high_price()).collect::<Vec<f64>>(),
+        "low_price" => bars.iter().map(|bar| bar.low_price()).collect::<Vec<f64>>(),
+        "close_price" => bars.iter().map(|bar| bar.close_price()).collect::<Vec<f64>>(),
+        "volume" => bars.iter().map(|bar| bar.volume()).collect::<Vec<i64>>(),
+        "volume_weighted_average_price" => bars.iter().map(|bar| bar.volume_weighted_average_price()).collect::<Vec<Option<f64>>>(),
+        "transactions" => bars.iter().map(|bar| bar.transactions()).collect::<Vec<Option<i64>>>(),
+        "inserted_at" => bars.iter().map(|bar| bar.inserted_at().timestamp_millis()).collect::<Vec<i64>>(),
     )
     .map_err(|error| format!("Failed to create equity bar export DataFrame: {}", error))
 }
@@ -274,12 +242,12 @@ fn create_equity_rebalance_session_dataframe(
     sessions: &[EquityRebalanceSession],
 ) -> Result<DataFrame, String> {
     df!(
-        "id" => sessions.iter().map(|session| session.id.to_string()).collect::<Vec<String>>(),
-        "triggered_at" => sessions.iter().map(|session| session.triggered_at.timestamp_millis()).collect::<Vec<i64>>(),
-        "trigger_reason" => sessions.iter().map(|session| session.trigger_reason.as_str()).collect::<Vec<&str>>(),
-        "model_run_id" => sessions.iter().map(|session| session.model_run_id.as_deref()).collect::<Vec<Option<&str>>>(),
-        "completed_at" => sessions.iter().map(|session| session.completed_at.map(|timestamp| timestamp.timestamp_millis())).collect::<Vec<Option<i64>>>(),
-        "status" => sessions.iter().map(|session| session.status.as_str()).collect::<Vec<&str>>(),
+        "id" => sessions.iter().map(|session| session.id().to_string()).collect::<Vec<String>>(),
+        "triggered_at" => sessions.iter().map(|session| session.triggered_at().timestamp_millis()).collect::<Vec<i64>>(),
+        "trigger_reason" => sessions.iter().map(|session| session.trigger_reason()).collect::<Vec<&str>>(),
+        "model_run_id" => sessions.iter().map(|session| session.model_run_id()).collect::<Vec<Option<&str>>>(),
+        "completed_at" => sessions.iter().map(|session| session.completed_at().map(|timestamp| timestamp.timestamp_millis())).collect::<Vec<Option<i64>>>(),
+        "status" => sessions.iter().map(|session| session.status().as_str()).collect::<Vec<&str>>(),
     )
     .map_err(|error| {
         format!(
@@ -291,20 +259,20 @@ fn create_equity_rebalance_session_dataframe(
 
 fn create_equity_pair_dataframe(pairs: &[EquityPair]) -> Result<DataFrame, String> {
     df!(
-        "id" => pairs.iter().map(|pair| pair.id.to_string()).collect::<Vec<String>>(),
-        "rebalance_id" => pairs.iter().map(|pair| pair.rebalance_id.to_string()).collect::<Vec<String>>(),
-        "pair_id" => pairs.iter().map(|pair| pair.pair_id.as_str()).collect::<Vec<&str>>(),
-        "long_ticker" => pairs.iter().map(|pair| pair.long_ticker.as_str()).collect::<Vec<&str>>(),
-        "short_ticker" => pairs.iter().map(|pair| pair.short_ticker.as_str()).collect::<Vec<&str>>(),
-        "z_score" => pairs.iter().map(|pair| pair.z_score.to_string()).collect::<Vec<String>>(),
-        "hedge_ratio" => pairs.iter().map(|pair| pair.hedge_ratio.to_string()).collect::<Vec<String>>(),
-        "signal_strength" => pairs.iter().map(|pair| pair.signal_strength.to_string()).collect::<Vec<String>>(),
-        "status" => pairs.iter().map(|pair| pair.status.as_str()).collect::<Vec<&str>>(),
-        "opened_at" => pairs.iter().map(|pair| pair.opened_at.timestamp_millis()).collect::<Vec<i64>>(),
-        "closed_at" => pairs.iter().map(|pair| pair.closed_at.map(|timestamp| timestamp.timestamp_millis())).collect::<Vec<Option<i64>>>(),
-        "realized_profit_and_loss" => pairs.iter().map(|pair| pair.realized_profit_and_loss.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
-        "return_percent" => pairs.iter().map(|pair| pair.return_percent.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
-        "holding_days" => pairs.iter().map(|pair| pair.holding_days).collect::<Vec<Option<i32>>>(),
+        "id" => pairs.iter().map(|pair| pair.id().to_string()).collect::<Vec<String>>(),
+        "rebalance_id" => pairs.iter().map(|pair| pair.rebalance_id().to_string()).collect::<Vec<String>>(),
+        "pair_id" => pairs.iter().map(|pair| pair.pair_id()).collect::<Vec<&str>>(),
+        "long_ticker" => pairs.iter().map(|pair| pair.long_ticker().as_str()).collect::<Vec<&str>>(),
+        "short_ticker" => pairs.iter().map(|pair| pair.short_ticker().as_str()).collect::<Vec<&str>>(),
+        "z_score" => pairs.iter().map(|pair| pair.z_score().to_string()).collect::<Vec<String>>(),
+        "hedge_ratio" => pairs.iter().map(|pair| pair.hedge_ratio().to_string()).collect::<Vec<String>>(),
+        "signal_strength" => pairs.iter().map(|pair| pair.signal_strength().to_string()).collect::<Vec<String>>(),
+        "status" => pairs.iter().map(|pair| pair.status().as_str()).collect::<Vec<&str>>(),
+        "opened_at" => pairs.iter().map(|pair| pair.opened_at().timestamp_millis()).collect::<Vec<i64>>(),
+        "closed_at" => pairs.iter().map(|pair| pair.closed_at().map(|timestamp| timestamp.timestamp_millis())).collect::<Vec<Option<i64>>>(),
+        "realized_profit_and_loss" => pairs.iter().map(|pair| pair.realized_profit_and_loss().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "return_percent" => pairs.iter().map(|pair| pair.return_percent().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "holding_days" => pairs.iter().map(|pair| pair.holding_days()).collect::<Vec<Option<i32>>>(),
     )
     .map_err(|error| format!("Failed to create equity pair DataFrame: {}", error))
 }
@@ -313,33 +281,33 @@ fn create_equity_allocation_dataframe(
     allocations: &[EquityAllocation],
 ) -> Result<DataFrame, String> {
     df!(
-        "id" => allocations.iter().map(|allocation| allocation.id.to_string()).collect::<Vec<String>>(),
-        "rebalance_id" => allocations.iter().map(|allocation| allocation.rebalance_id.to_string()).collect::<Vec<String>>(),
-        "equity_pair_id" => allocations.iter().map(|allocation| allocation.equity_pair_id.to_string()).collect::<Vec<String>>(),
-        "generated_at" => allocations.iter().map(|allocation| allocation.generated_at.timestamp_millis()).collect::<Vec<i64>>(),
-        "model_run_id" => allocations.iter().map(|allocation| allocation.model_run_id.as_deref()).collect::<Vec<Option<&str>>>(),
-        "ticker" => allocations.iter().map(|allocation| allocation.ticker.as_str()).collect::<Vec<&str>>(),
-        "side" => allocations.iter().map(|allocation| allocation.side.as_str()).collect::<Vec<&str>>(),
-        "action" => allocations.iter().map(|allocation| allocation.action.as_str()).collect::<Vec<&str>>(),
-        "dollar_amount" => allocations.iter().map(|allocation| allocation.dollar_amount.to_string()).collect::<Vec<String>>(),
-        "entry_price" => allocations.iter().map(|allocation| allocation.entry_price.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
-        "quantity" => allocations.iter().map(|allocation| allocation.quantity.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
-        "notional" => allocations.iter().map(|allocation| allocation.notional.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "id" => allocations.iter().map(|allocation| allocation.id().to_string()).collect::<Vec<String>>(),
+        "rebalance_id" => allocations.iter().map(|allocation| allocation.rebalance_id().to_string()).collect::<Vec<String>>(),
+        "equity_pair_id" => allocations.iter().map(|allocation| allocation.equity_pair_id().to_string()).collect::<Vec<String>>(),
+        "generated_at" => allocations.iter().map(|allocation| allocation.generated_at().timestamp_millis()).collect::<Vec<i64>>(),
+        "model_run_id" => allocations.iter().map(|allocation| allocation.model_run_id()).collect::<Vec<Option<&str>>>(),
+        "ticker" => allocations.iter().map(|allocation| allocation.ticker().as_str()).collect::<Vec<&str>>(),
+        "side" => allocations.iter().map(|allocation| allocation.side().as_str()).collect::<Vec<&str>>(),
+        "action" => allocations.iter().map(|allocation| allocation.action().as_str()).collect::<Vec<&str>>(),
+        "dollar_amount" => allocations.iter().map(|allocation| allocation.dollar_amount().to_string()).collect::<Vec<String>>(),
+        "entry_price" => allocations.iter().map(|allocation| allocation.entry_price().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "quantity" => allocations.iter().map(|allocation| allocation.quantity().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "notional" => allocations.iter().map(|allocation| allocation.notional().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
     )
     .map_err(|error| format!("Failed to create equity allocation DataFrame: {}", error))
 }
 
 fn create_equity_order_dataframe(orders: &[EquityOrder]) -> Result<DataFrame, String> {
     df!(
-        "id" => orders.iter().map(|order| order.id.to_string()).collect::<Vec<String>>(),
-        "allocation_id" => orders.iter().map(|order| order.allocation_id.to_string()).collect::<Vec<String>>(),
-        "submitted_at" => orders.iter().map(|order| order.submitted_at.timestamp_millis()).collect::<Vec<i64>>(),
-        "ticker" => orders.iter().map(|order| order.ticker.as_str()).collect::<Vec<&str>>(),
-        "side" => orders.iter().map(|order| order.side.as_str()).collect::<Vec<&str>>(),
-        "quantity" => orders.iter().map(|order| order.quantity.to_string()).collect::<Vec<String>>(),
-        "order_type" => orders.iter().map(|order| order.order_type.as_str()).collect::<Vec<&str>>(),
-        "limit_price" => orders.iter().map(|order| order.limit_price.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
-        "alpaca_order_id" => orders.iter().map(|order| order.alpaca_order_id.as_str()).collect::<Vec<&str>>(),
+        "id" => orders.iter().map(|order| order.id().to_string()).collect::<Vec<String>>(),
+        "allocation_id" => orders.iter().map(|order| order.allocation_id().to_string()).collect::<Vec<String>>(),
+        "submitted_at" => orders.iter().map(|order| order.submitted_at().timestamp_millis()).collect::<Vec<i64>>(),
+        "ticker" => orders.iter().map(|order| order.ticker().as_str()).collect::<Vec<&str>>(),
+        "side" => orders.iter().map(|order| order.side().as_str()).collect::<Vec<&str>>(),
+        "quantity" => orders.iter().map(|order| order.quantity().to_string()).collect::<Vec<String>>(),
+        "order_type" => orders.iter().map(|order| order.order_type()).collect::<Vec<&str>>(),
+        "limit_price" => orders.iter().map(|order| order.limit_price().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "alpaca_order_id" => orders.iter().map(|order| order.alpaca_order_id()).collect::<Vec<&str>>(),
     )
     .map_err(|error| format!("Failed to create equity order DataFrame: {}", error))
 }
@@ -348,14 +316,14 @@ fn create_equity_portfolio_snapshot_dataframe(
     snapshots: &[EquityPortfolioSnapshot],
 ) -> Result<DataFrame, String> {
     df!(
-        "id" => snapshots.iter().map(|snapshot| snapshot.id).collect::<Vec<i64>>(),
-        "snapshot_timestamp" => snapshots.iter().map(|snapshot| snapshot.snapshot_timestamp.timestamp_millis()).collect::<Vec<i64>>(),
-        "snapshot_type" => snapshots.iter().map(|snapshot| snapshot.snapshot_type.as_str()).collect::<Vec<&str>>(),
-        "net_asset_value" => snapshots.iter().map(|snapshot| snapshot.net_asset_value.to_string()).collect::<Vec<String>>(),
-        "gross_return" => snapshots.iter().map(|snapshot| snapshot.gross_return.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
-        "net_return" => snapshots.iter().map(|snapshot| snapshot.net_return.as_ref().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
-        "total_slippage_cost" => snapshots.iter().map(|snapshot| snapshot.total_slippage_cost.to_string()).collect::<Vec<String>>(),
-        "created_at" => snapshots.iter().map(|snapshot| snapshot.created_at.timestamp_millis()).collect::<Vec<i64>>(),
+        "id" => snapshots.iter().map(|snapshot| snapshot.id()).collect::<Vec<i64>>(),
+        "snapshot_timestamp" => snapshots.iter().map(|snapshot| snapshot.snapshot_timestamp().timestamp_millis()).collect::<Vec<i64>>(),
+        "snapshot_type" => snapshots.iter().map(|snapshot| snapshot.snapshot_type().as_str()).collect::<Vec<&str>>(),
+        "net_asset_value" => snapshots.iter().map(|snapshot| snapshot.net_asset_value().to_string()).collect::<Vec<String>>(),
+        "gross_return" => snapshots.iter().map(|snapshot| snapshot.gross_return().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "net_return" => snapshots.iter().map(|snapshot| snapshot.net_return().map(|decimal| decimal.to_string())).collect::<Vec<Option<String>>>(),
+        "total_slippage_cost" => snapshots.iter().map(|snapshot| snapshot.total_slippage_cost().to_string()).collect::<Vec<String>>(),
+        "created_at" => snapshots.iter().map(|snapshot| snapshot.created_at().timestamp_millis()).collect::<Vec<i64>>(),
     )
     .map_err(|error| {
         format!(
@@ -408,122 +376,107 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use internal::market::Ticker;
+    use internal::trading::{
+        AllocationAction, AllocationSide, EquityPairStatus, RebalanceSessionStatus, SnapshotType,
+    };
     use serde_json::json;
 
     fn sample_quotes() -> Vec<EquityQuote> {
         let now = Utc::now();
         vec![
-            EquityQuote {
-                timestamp: now,
-                ticker: Ticker::new("AAPL").unwrap(),
-                bid_price: 150.50,
-                ask_price: 150.55,
-                bid_size: 10,
-                ask_size: 5,
-            },
-            EquityQuote {
-                timestamp: now,
-                ticker: Ticker::new("MSFT").unwrap(),
-                bid_price: 420.10,
-                ask_price: 420.20,
-                bid_size: 2,
-                ask_size: 4,
-            },
+            EquityQuote::new(now, Ticker::new("AAPL").unwrap(), 150.50, 150.55, 10, 5),
+            EquityQuote::new(now, Ticker::new("MSFT").unwrap(), 420.10, 420.20, 2, 4),
         ]
     }
 
     fn sample_bars() -> Vec<EquityBar> {
         let now = Utc::now();
-        vec![EquityBar {
-            ticker: Ticker::new("AAPL").unwrap(),
-            timestamp: now,
-            open_price: 150.0,
-            high_price: 155.0,
-            low_price: 149.0,
-            close_price: 153.0,
-            volume: 1_000_000,
-            volume_weighted_average_price: Some(152.0),
-            transactions: Some(50_000),
-            inserted_at: now,
-        }]
+        vec![EquityBar::new(
+            Ticker::new("AAPL").unwrap(),
+            now,
+            150.0,
+            155.0,
+            149.0,
+            153.0,
+            1_000_000,
+            Some(152.0),
+            Some(50_000),
+            now,
+        )]
     }
 
-    // Construct EquityRebalanceSession without importing uuid directly;
-    // the id field type (Uuid) is inferred from the struct definition.
     fn sample_sessions() -> Vec<EquityRebalanceSession> {
-        vec![EquityRebalanceSession {
-            id: "550e8400-e29b-41d4-a716-446655440001".parse().unwrap(),
-            triggered_at: Utc::now(),
-            trigger_reason: "intraday_check".to_string(),
-            model_run_id: Some("run-abc123".to_string()),
-            completed_at: None,
-            status: "completed".to_string(),
-        }]
+        vec![EquityRebalanceSession::new(
+            "550e8400-e29b-41d4-a716-446655440001".parse().unwrap(),
+            Utc::now(),
+            "intraday_check".to_string(),
+            Some("run-abc123".to_string()),
+            None,
+            RebalanceSessionStatus::Completed,
+        )]
     }
 
-    // Construct EquityPair without importing rust_decimal directly;
-    // Decimal fields are inferred from the struct definition.
     fn sample_pairs() -> Vec<EquityPair> {
-        vec![EquityPair {
-            id: "550e8400-e29b-41d4-a716-446655440002".parse().unwrap(),
-            rebalance_id: "550e8400-e29b-41d4-a716-446655440001".parse().unwrap(),
-            pair_id: "AAPL-MSFT".to_string(),
-            long_ticker: "AAPL".to_string(),
-            short_ticker: "MSFT".to_string(),
-            z_score: "2".parse().unwrap(),
-            hedge_ratio: "1".parse().unwrap(),
-            signal_strength: "0.75".parse().unwrap(),
-            status: "open".to_string(),
-            opened_at: Utc::now(),
-            closed_at: None,
-            realized_profit_and_loss: None,
-            return_percent: None,
-            holding_days: None,
-        }]
+        vec![EquityPair::new(
+            "550e8400-e29b-41d4-a716-446655440002".parse().unwrap(),
+            "550e8400-e29b-41d4-a716-446655440001".parse().unwrap(),
+            "AAPL-MSFT".to_string(),
+            Ticker::new("AAPL").unwrap(),
+            Ticker::new("MSFT").unwrap(),
+            "2".parse().unwrap(),
+            "1".parse().unwrap(),
+            "0.75".parse().unwrap(),
+            EquityPairStatus::Open,
+            Utc::now(),
+            None,
+            None,
+            None,
+            None,
+        )]
     }
 
     fn sample_allocations() -> Vec<EquityAllocation> {
-        vec![EquityAllocation {
-            id: "550e8400-e29b-41d4-a716-446655440003".parse().unwrap(),
-            rebalance_id: "550e8400-e29b-41d4-a716-446655440001".parse().unwrap(),
-            equity_pair_id: "550e8400-e29b-41d4-a716-446655440002".parse().unwrap(),
-            generated_at: Utc::now(),
-            model_run_id: None,
-            ticker: "AAPL".to_string(),
-            side: "LONG".to_string(),
-            action: "OPEN_POSITION".to_string(),
-            dollar_amount: "10000".parse().unwrap(),
-            entry_price: Some("150".parse().unwrap()),
-            quantity: None,
-            notional: Some("10000".parse().unwrap()),
-        }]
+        vec![EquityAllocation::new(
+            "550e8400-e29b-41d4-a716-446655440003".parse().unwrap(),
+            "550e8400-e29b-41d4-a716-446655440001".parse().unwrap(),
+            "550e8400-e29b-41d4-a716-446655440002".parse().unwrap(),
+            Utc::now(),
+            None,
+            Ticker::new("AAPL").unwrap(),
+            AllocationSide::Long,
+            AllocationAction::OpenPosition,
+            "10000".parse().unwrap(),
+            Some("150".parse().unwrap()),
+            None,
+            Some("10000".parse().unwrap()),
+        )]
     }
 
     fn sample_orders() -> Vec<EquityOrder> {
-        vec![EquityOrder {
-            id: "550e8400-e29b-41d4-a716-446655440004".parse().unwrap(),
-            allocation_id: "550e8400-e29b-41d4-a716-446655440003".parse().unwrap(),
-            submitted_at: Utc::now(),
-            ticker: "MSFT".to_string(),
-            side: "SHORT".to_string(),
-            quantity: "25".parse().unwrap(),
-            order_type: "market".to_string(),
-            limit_price: None,
-            alpaca_order_id: "alpaca-order-xyz".to_string(),
-        }]
+        vec![EquityOrder::new(
+            "550e8400-e29b-41d4-a716-446655440004".parse().unwrap(),
+            "550e8400-e29b-41d4-a716-446655440003".parse().unwrap(),
+            Utc::now(),
+            Ticker::new("MSFT").unwrap(),
+            AllocationSide::Short,
+            "25".parse().unwrap(),
+            "market".to_string(),
+            None,
+            "alpaca-order-xyz".to_string(),
+        )]
     }
 
     fn sample_snapshots() -> Vec<EquityPortfolioSnapshot> {
-        vec![EquityPortfolioSnapshot {
-            id: 1,
-            snapshot_timestamp: Utc::now(),
-            snapshot_type: "end_of_day".to_string(),
-            net_asset_value: "100000".parse().unwrap(),
-            gross_return: Some("0.02".parse().unwrap()),
-            net_return: Some("0.018".parse().unwrap()),
-            total_slippage_cost: "50".parse().unwrap(),
-            created_at: Utc::now(),
-        }]
+        vec![EquityPortfolioSnapshot::new(
+            1,
+            Utc::now(),
+            SnapshotType::EndOfDay,
+            "100000".parse().unwrap(),
+            Some("0.02".parse().unwrap()),
+            Some("0.018".parse().unwrap()),
+            "50".parse().unwrap(),
+            Utc::now(),
+        )]
     }
 
     #[test]
@@ -846,7 +799,7 @@ mod tests {
     }
 
     #[test]
-    fn test_export_trading_history_returns_error_when_no_database() {
+    fn test_export_equity_trading_history_returns_error_when_no_database() {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -881,7 +834,7 @@ mod tests {
             assert!(matches!(state.database, DatabaseState::NotConfigured));
 
             let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
-            let result = export_trading_history(&state, date).await;
+            let result = export_equity_trading_history(&state, date).await;
             assert!(result.is_err());
             assert!(result.unwrap_err().contains("database not connected"));
         });

--- a/applications/data_manager/src/scheduler.rs
+++ b/applications/data_manager/src/scheduler.rs
@@ -347,7 +347,7 @@ async fn run_export_job(
 ) -> Result<usize, String> {
     match job_name {
         "export-equity-bars" => export::export_equity_bars(state, export_date).await,
-        "export-trading-history" => export::export_trading_history(state, export_date).await,
+        "export-trading-history" => export::export_equity_trading_history(state, export_date).await,
         _ => {
             let message = format!("Unknown export job: {}", job_name);
             Err(message)

--- a/applications/data_manager/src/startup.rs
+++ b/applications/data_manager/src/startup.rs
@@ -1,4 +1,4 @@
-use crate::database::populate_equity_details_if_empty;
+use crate::database::seed_equity_details;
 use crate::equity_details::read_equity_details_from_s3;
 use crate::equity_quotes::spawn_quote_stream;
 use crate::router::create_app_with_state;
@@ -57,7 +57,7 @@ async fn migrate_equity_details(state: &State) {
     };
 
     match read_equity_details_from_s3(state).await {
-        Ok(details) => match populate_equity_details_if_empty(pool, &details).await {
+        Ok(details) => match seed_equity_details(pool, &details).await {
             Ok(count) if count > 0 => {
                 tracing::info!("Seeded equity_details from S3 ({} rows)", count);
             }

--- a/applications/data_manager/tests/test_data.rs
+++ b/applications/data_manager/tests/test_data.rs
@@ -6,34 +6,34 @@ use polars::prelude::*;
 
 fn sample_equity_bar() -> EquityBar {
     let timestamp = chrono::DateTime::from_timestamp(1_234_567_890, 0).unwrap();
-    EquityBar {
-        ticker: Ticker::new("AAPL").unwrap(),
+    EquityBar::new(
+        Ticker::new("AAPL").unwrap(),
         timestamp,
-        open_price: 100.0,
-        high_price: 105.0,
-        low_price: 99.0,
-        close_price: 103.0,
-        volume: 1_000_000,
-        volume_weighted_average_price: Some(102.0),
-        transactions: Some(5_000),
-        inserted_at: timestamp,
-    }
+        100.0,
+        105.0,
+        99.0,
+        103.0,
+        1_000_000,
+        Some(102.0),
+        Some(5_000),
+        timestamp,
+    )
 }
 
 fn sample_equity_bar_lowercase() -> EquityBar {
     let timestamp = chrono::DateTime::from_timestamp(1_234_567_890, 0).unwrap();
-    EquityBar {
-        ticker: Ticker::new("googl").unwrap(),
+    EquityBar::new(
+        Ticker::new("googl").unwrap(),
         timestamp,
-        open_price: 2000.0,
-        high_price: 2050.0,
-        low_price: 1990.0,
-        close_price: 2030.0,
-        volume: 500_000,
-        volume_weighted_average_price: Some(2020.0),
-        transactions: Some(2_500),
-        inserted_at: timestamp,
-    }
+        2000.0,
+        2050.0,
+        1990.0,
+        2030.0,
+        500_000,
+        Some(2020.0),
+        Some(2_500),
+        timestamp,
+    )
 }
 
 #[test]
@@ -79,18 +79,18 @@ fn test_create_equity_bar_dataframe_uppercase_normalization() {
 fn test_create_equity_bar_dataframe_whitespace_trimming() {
     initialize_test_tracing();
     let timestamp = chrono::DateTime::from_timestamp(1_234_567_890, 0).unwrap();
-    let bars = vec![EquityBar {
-        ticker: Ticker::new("  ECC           ").unwrap(),
+    let bars = vec![EquityBar::new(
+        Ticker::new("  ECC           ").unwrap(),
         timestamp,
-        open_price: 10.0,
-        high_price: 11.0,
-        low_price: 9.0,
-        close_price: 10.5,
-        volume: 100_000,
-        volume_weighted_average_price: Some(10.2),
-        transactions: Some(500),
-        inserted_at: timestamp,
-    }];
+        10.0,
+        11.0,
+        9.0,
+        10.5,
+        100_000,
+        Some(10.2),
+        Some(500),
+        timestamp,
+    )];
 
     let dataframe = create_equity_bar_dataframe(&bars).unwrap();
 

--- a/applications/data_manager/tests/test_database.rs
+++ b/applications/data_manager/tests/test_database.rs
@@ -89,30 +89,30 @@ async fn get_pg_pool() -> PgPool {
 fn sample_bars() -> Vec<EquityBar> {
     let now = Utc::now();
     vec![
-        EquityBar {
-            ticker: Ticker::new("AAPL").unwrap(),
-            timestamp: now,
-            open_price: 150.0,
-            high_price: 155.0,
-            low_price: 149.0,
-            close_price: 153.0,
-            volume: 1_000_000,
-            volume_weighted_average_price: Some(152.0),
-            transactions: Some(50_000),
-            inserted_at: now,
-        },
-        EquityBar {
-            ticker: Ticker::new("MSFT").unwrap(),
-            timestamp: now,
-            open_price: 350.0,
-            high_price: 355.0,
-            low_price: 349.0,
-            close_price: 353.0,
-            volume: 500_000,
-            volume_weighted_average_price: Some(352.0),
-            transactions: Some(25_000),
-            inserted_at: now,
-        },
+        EquityBar::new(
+            Ticker::new("AAPL").unwrap(),
+            now,
+            150.0,
+            155.0,
+            149.0,
+            153.0,
+            1_000_000,
+            Some(152.0),
+            Some(50_000),
+            now,
+        ),
+        EquityBar::new(
+            Ticker::new("MSFT").unwrap(),
+            now,
+            350.0,
+            355.0,
+            349.0,
+            353.0,
+            500_000,
+            Some(352.0),
+            Some(25_000),
+            now,
+        ),
     ]
 }
 
@@ -145,15 +145,18 @@ async fn test_insert_and_query_equity_bars() {
 
     assert_eq!(result.len(), 2);
 
-    let tickers: Vec<&str> = result.iter().map(|b| b.ticker.as_str()).collect();
+    let tickers: Vec<&str> = result.iter().map(|b| b.ticker().as_str()).collect();
     assert!(tickers.contains(&"AAPL"));
     assert!(tickers.contains(&"MSFT"));
 
-    let aapl = result.iter().find(|b| b.ticker == "AAPL").unwrap();
-    assert_eq!(aapl.open_price, 150.0);
-    assert_eq!(aapl.close_price, 153.0);
-    assert_eq!(aapl.volume, 1_000_000);
-    assert_eq!(aapl.transactions, Some(50_000));
+    let aapl = result
+        .iter()
+        .find(|b| b.ticker().as_str() == "AAPL")
+        .unwrap();
+    assert_eq!(aapl.open_price(), 150.0);
+    assert_eq!(aapl.close_price(), 153.0);
+    assert_eq!(aapl.volume(), 1_000_000);
+    assert_eq!(aapl.transactions(), Some(50_000));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -176,7 +179,7 @@ async fn test_query_with_ticker_filter() {
     .unwrap();
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].ticker, "AAPL");
+    assert_eq!(result[0].ticker().as_str(), "AAPL");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -186,18 +189,18 @@ async fn test_query_old_bars_excluded() {
     clean_tables(&pool).await;
 
     let old_timestamp = Utc::now() - chrono::Duration::days(15);
-    let old_bars = vec![EquityBar {
-        ticker: Ticker::new("OLD").unwrap(),
-        timestamp: old_timestamp,
-        open_price: 100.0,
-        high_price: 105.0,
-        low_price: 99.0,
-        close_price: 102.0,
-        volume: 10_000,
-        volume_weighted_average_price: Some(101.0),
-        transactions: Some(500),
-        inserted_at: old_timestamp,
-    }];
+    let old_bars = vec![EquityBar::new(
+        Ticker::new("OLD").unwrap(),
+        old_timestamp,
+        100.0,
+        105.0,
+        99.0,
+        102.0,
+        10_000,
+        Some(101.0),
+        Some(500),
+        old_timestamp,
+    )];
 
     insert_equity_bars(&pool, &old_bars).await.unwrap();
 
@@ -226,8 +229,22 @@ async fn test_upsert_updates_existing_bar() {
     let bars = sample_bars();
     insert_equity_bars(&pool, &bars).await.unwrap();
 
-    let mut updated = bars.clone();
-    updated[0].close_price = 160.0;
+    let original = &bars[0];
+    let updated = vec![
+        EquityBar::new(
+            original.ticker().clone(),
+            original.timestamp(),
+            original.open_price(),
+            original.high_price(),
+            original.low_price(),
+            160.0,
+            original.volume(),
+            original.volume_weighted_average_price(),
+            original.transactions(),
+            original.inserted_at(),
+        ),
+        bars[1].clone(),
+    ];
     insert_equity_bars(&pool, &updated).await.unwrap();
 
     let result: Vec<EquityBar> = sqlx::query_as(
@@ -239,9 +256,13 @@ async fn test_upsert_updates_existing_bar() {
     .await
     .unwrap();
 
-    let aapl = result.iter().find(|b| b.ticker == "AAPL").unwrap();
+    let aapl = result
+        .iter()
+        .find(|b| b.ticker().as_str() == "AAPL")
+        .unwrap();
     assert_eq!(
-        aapl.close_price, 160.0,
+        aapl.close_price(),
+        160.0,
         "Upsert should have updated close_price"
     );
 }

--- a/applications/data_manager/tests/test_handlers.rs
+++ b/applications/data_manager/tests/test_handlers.rs
@@ -313,5 +313,5 @@ async fn test_equity_details_csv_can_be_read_from_s3() {
     let result = data_manager::equity_details::read_equity_details_from_s3(&state).await;
     assert!(result.is_ok());
     let details = result.unwrap();
-    assert!(details.iter().any(|d| d.ticker == "AAPL"));
+    assert!(details.iter().any(|d| d.ticker().as_str() == "AAPL"));
 }

--- a/libraries/rust/src/market.rs
+++ b/libraries/rust/src/market.rs
@@ -94,38 +94,261 @@ fn is_valid_suffix(s: &str) -> bool {
 /// is set by the caller at ingest time and explicitly bound in the upsert query.
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct EquityBar {
-    pub ticker: Ticker,
+    ticker: Ticker,
     /// UTC timestamp for the trading day this bar covers.
-    pub timestamp: DateTime<Utc>,
-    pub open_price: f64,
-    pub high_price: f64,
-    pub low_price: f64,
-    pub close_price: f64,
+    timestamp: DateTime<Utc>,
+    open_price: f64,
+    high_price: f64,
+    low_price: f64,
+    close_price: f64,
     /// Whole share units. Fractional values from the source API are rounded on ingest.
-    pub volume: i64,
-    pub volume_weighted_average_price: Option<f64>,
-    pub transactions: Option<i64>,
+    volume: i64,
+    volume_weighted_average_price: Option<f64>,
+    transactions: Option<i64>,
     /// Set by the database at insert time.
-    pub inserted_at: DateTime<Utc>,
+    inserted_at: DateTime<Utc>,
+}
+
+impl EquityBar {
+    /// Constructs an `EquityBar` from validated field values.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        ticker: Ticker,
+        timestamp: DateTime<Utc>,
+        open_price: f64,
+        high_price: f64,
+        low_price: f64,
+        close_price: f64,
+        volume: i64,
+        volume_weighted_average_price: Option<f64>,
+        transactions: Option<i64>,
+        inserted_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            ticker,
+            timestamp,
+            open_price,
+            high_price,
+            low_price,
+            close_price,
+            volume,
+            volume_weighted_average_price,
+            transactions,
+            inserted_at,
+        }
+    }
+
+    pub fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
+    }
+
+    pub fn open_price(&self) -> f64 {
+        self.open_price
+    }
+
+    pub fn high_price(&self) -> f64 {
+        self.high_price
+    }
+
+    pub fn low_price(&self) -> f64 {
+        self.low_price
+    }
+
+    pub fn close_price(&self) -> f64 {
+        self.close_price
+    }
+
+    pub fn volume(&self) -> i64 {
+        self.volume
+    }
+
+    pub fn volume_weighted_average_price(&self) -> Option<f64> {
+        self.volume_weighted_average_price
+    }
+
+    pub fn transactions(&self) -> Option<i64> {
+        self.transactions
+    }
+
+    pub fn inserted_at(&self) -> DateTime<Utc> {
+        self.inserted_at
+    }
 }
 
 /// Intraday bid/ask quote record from the Alpaca WebSocket stream.
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct EquityQuote {
-    pub timestamp: DateTime<Utc>,
-    pub ticker: Ticker,
-    pub bid_price: f64,
-    pub ask_price: f64,
-    pub bid_size: i32,
-    pub ask_size: i32,
+    timestamp: DateTime<Utc>,
+    ticker: Ticker,
+    bid_price: f64,
+    ask_price: f64,
+    bid_size: i32,
+    ask_size: i32,
+}
+
+impl EquityQuote {
+    /// Constructs an `EquityQuote` from validated field values.
+    pub fn new(
+        timestamp: DateTime<Utc>,
+        ticker: Ticker,
+        bid_price: f64,
+        ask_price: f64,
+        bid_size: i32,
+        ask_size: i32,
+    ) -> Self {
+        Self {
+            timestamp,
+            ticker,
+            bid_price,
+            ask_price,
+            bid_size,
+            ask_size,
+        }
+    }
+
+    pub fn timestamp(&self) -> DateTime<Utc> {
+        self.timestamp
+    }
+
+    pub fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    pub fn bid_price(&self) -> f64 {
+        self.bid_price
+    }
+
+    pub fn ask_price(&self) -> f64 {
+        self.ask_price
+    }
+
+    pub fn bid_size(&self) -> i32 {
+        self.bid_size
+    }
+
+    pub fn ask_size(&self) -> i32 {
+        self.ask_size
+    }
 }
 
 /// Ticker metadata record seeded from the S3 details CSV.
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
-pub struct EquityDetails {
-    pub ticker: Ticker,
-    pub sector: String,
-    pub industry: String,
+pub struct EquityDetail {
+    ticker: Ticker,
+    sector: String,
+    industry: String,
+}
+
+impl EquityDetail {
+    /// Constructs an `EquityDetail` from validated field values.
+    pub fn new(ticker: Ticker, sector: String, industry: String) -> Self {
+        Self {
+            ticker,
+            sector,
+            industry,
+        }
+    }
+
+    pub fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    pub fn sector(&self) -> &str {
+        &self.sector
+    }
+
+    pub fn industry(&self) -> &str {
+        &self.industry
+    }
+}
+
+/// A non-empty collection of [`EquityBar`] records.
+///
+/// The `Option`-returning constructor enforces that a value in scope always
+/// contains at least one bar. Callers that receive `None` know immediately that
+/// there is nothing to process or store.
+#[derive(Debug, Clone)]
+pub struct EquityBars(Vec<EquityBar>);
+
+impl EquityBars {
+    /// Returns `None` if `bars` is empty.
+    pub fn new(bars: Vec<EquityBar>) -> Option<Self> {
+        if bars.is_empty() {
+            None
+        } else {
+            Some(Self(bars))
+        }
+    }
+
+    pub fn as_slice(&self) -> &[EquityBar] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// A non-empty collection of [`EquityQuote`] records.
+#[derive(Debug, Clone)]
+pub struct EquityQuotes(Vec<EquityQuote>);
+
+impl EquityQuotes {
+    /// Returns `None` if `quotes` is empty.
+    pub fn new(quotes: Vec<EquityQuote>) -> Option<Self> {
+        if quotes.is_empty() {
+            None
+        } else {
+            Some(Self(quotes))
+        }
+    }
+
+    pub fn as_slice(&self) -> &[EquityQuote] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// A non-empty collection of [`EquityDetail`] records.
+#[derive(Debug, Clone)]
+pub struct EquityDetails(Vec<EquityDetail>);
+
+impl EquityDetails {
+    /// Returns `None` if `details` is empty.
+    pub fn new(details: Vec<EquityDetail>) -> Option<Self> {
+        if details.is_empty() {
+            None
+        } else {
+            Some(Self(details))
+        }
+    }
+
+    pub fn as_slice(&self) -> &[EquityDetail] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 #[cfg(test)]
@@ -245,95 +468,150 @@ mod tests {
     #[test]
     fn test_equity_bar_construction_with_all_fields() {
         let now = Utc::now();
-        let bar = EquityBar {
-            ticker: Ticker::new("AAPL").unwrap(),
-            timestamp: now,
-            open_price: 150.0,
-            high_price: 155.0,
-            low_price: 149.0,
-            close_price: 153.0,
-            volume: 1_000_000,
-            volume_weighted_average_price: Some(152.0),
-            transactions: Some(50_000),
-            inserted_at: now,
-        };
-        assert_eq!(bar.ticker.as_str(), "AAPL");
-        assert_eq!(bar.open_price, 150.0);
-        assert_eq!(bar.volume, 1_000_000);
+        let bar = EquityBar::new(
+            Ticker::new("AAPL").unwrap(),
+            now,
+            150.0,
+            155.0,
+            149.0,
+            153.0,
+            1_000_000,
+            Some(152.0),
+            Some(50_000),
+            now,
+        );
+        assert_eq!(bar.ticker().as_str(), "AAPL");
+        assert_eq!(bar.open_price(), 150.0);
+        assert_eq!(bar.volume(), 1_000_000);
     }
 
     #[test]
     fn test_equity_bar_clone() {
         let now = Utc::now();
-        let bar = EquityBar {
-            ticker: Ticker::new("GOOG").unwrap(),
-            timestamp: now,
-            open_price: 100.0,
-            high_price: 105.0,
-            low_price: 99.0,
-            close_price: 103.0,
-            volume: 500_000,
-            volume_weighted_average_price: Some(102.0),
-            transactions: Some(25_000),
-            inserted_at: now,
-        };
+        let bar = EquityBar::new(
+            Ticker::new("GOOG").unwrap(),
+            now,
+            100.0,
+            105.0,
+            99.0,
+            103.0,
+            500_000,
+            Some(102.0),
+            Some(25_000),
+            now,
+        );
         let cloned = bar.clone();
-        assert_eq!(cloned.ticker.as_str(), "GOOG");
-        assert_eq!(cloned.close_price, 103.0);
+        assert_eq!(cloned.ticker().as_str(), "GOOG");
+        assert_eq!(cloned.close_price(), 103.0);
     }
 
     #[test]
     fn test_equity_quote_construction() {
-        let quote = EquityQuote {
-            timestamp: Utc::now(),
-            ticker: Ticker::new("AAPL").unwrap(),
-            bid_price: 150.50,
-            ask_price: 150.55,
-            bid_size: 10,
-            ask_size: 5,
-        };
-        assert_eq!(quote.ticker.as_str(), "AAPL");
-        assert_eq!(quote.bid_price, 150.50);
-        assert_eq!(quote.ask_price, 150.55);
-        assert_eq!(quote.bid_size, 10);
-        assert_eq!(quote.ask_size, 5);
+        let quote = EquityQuote::new(
+            Utc::now(),
+            Ticker::new("AAPL").unwrap(),
+            150.50,
+            150.55,
+            10,
+            5,
+        );
+        assert_eq!(quote.ticker().as_str(), "AAPL");
+        assert_eq!(quote.bid_price(), 150.50);
+        assert_eq!(quote.ask_price(), 150.55);
+        assert_eq!(quote.bid_size(), 10);
+        assert_eq!(quote.ask_size(), 5);
     }
 
     #[test]
     fn test_equity_quote_clone() {
-        let quote = EquityQuote {
-            timestamp: Utc::now(),
-            ticker: Ticker::new("MSFT").unwrap(),
-            bid_price: 420.10,
-            ask_price: 420.20,
-            bid_size: 2,
-            ask_size: 4,
-        };
+        let quote = EquityQuote::new(
+            Utc::now(),
+            Ticker::new("MSFT").unwrap(),
+            420.10,
+            420.20,
+            2,
+            4,
+        );
         let cloned = quote.clone();
-        assert_eq!(cloned.ticker.as_str(), "MSFT");
-        assert_eq!(cloned.bid_price, 420.10);
+        assert_eq!(cloned.ticker().as_str(), "MSFT");
+        assert_eq!(cloned.bid_price(), 420.10);
     }
 
     #[test]
-    fn test_equity_details_construction() {
-        let details = EquityDetails {
-            ticker: Ticker::new("AAPL").unwrap(),
-            sector: "TECHNOLOGY".to_string(),
-            industry: "SOFTWARE".to_string(),
-        };
-        assert_eq!(details.ticker.as_str(), "AAPL");
-        assert_eq!(details.sector, "TECHNOLOGY");
-        assert_eq!(details.industry, "SOFTWARE");
+    fn test_equity_detail_construction() {
+        let detail = EquityDetail::new(
+            Ticker::new("AAPL").unwrap(),
+            "TECHNOLOGY".to_string(),
+            "SOFTWARE".to_string(),
+        );
+        assert_eq!(detail.ticker().as_str(), "AAPL");
+        assert_eq!(detail.sector(), "TECHNOLOGY");
+        assert_eq!(detail.industry(), "SOFTWARE");
     }
 
     #[test]
-    fn test_equity_details_clone() {
-        let details = EquityDetails {
-            ticker: Ticker::new("NVDA").unwrap(),
-            sector: "TECHNOLOGY".to_string(),
-            industry: "SEMICONDUCTORS".to_string(),
-        };
-        let cloned = details.clone();
-        assert_eq!(cloned.ticker.as_str(), "NVDA");
+    fn test_equity_detail_clone() {
+        let detail = EquityDetail::new(
+            Ticker::new("NVDA").unwrap(),
+            "TECHNOLOGY".to_string(),
+            "SEMICONDUCTORS".to_string(),
+        );
+        let cloned = detail.clone();
+        assert_eq!(cloned.ticker().as_str(), "NVDA");
+    }
+
+    #[test]
+    fn test_equity_bars_new_returns_some_for_nonempty() {
+        let now = Utc::now();
+        let bar = EquityBar::new(
+            Ticker::new("AAPL").unwrap(),
+            now,
+            150.0,
+            155.0,
+            149.0,
+            153.0,
+            1_000_000,
+            None,
+            None,
+            now,
+        );
+        let bars = EquityBars::new(vec![bar]);
+        assert!(bars.is_some());
+        assert_eq!(bars.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_equity_bars_new_returns_none_for_empty() {
+        assert!(EquityBars::new(vec![]).is_none());
+    }
+
+    #[test]
+    fn test_equity_quotes_new_returns_some_for_nonempty() {
+        let quote = EquityQuote::new(Utc::now(), Ticker::new("AAPL").unwrap(), 150.0, 150.5, 1, 1);
+        let quotes = EquityQuotes::new(vec![quote]);
+        assert!(quotes.is_some());
+        assert_eq!(quotes.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_equity_quotes_new_returns_none_for_empty() {
+        assert!(EquityQuotes::new(vec![]).is_none());
+    }
+
+    #[test]
+    fn test_equity_details_new_returns_some_for_nonempty() {
+        let detail = EquityDetail::new(
+            Ticker::new("AAPL").unwrap(),
+            "TECHNOLOGY".to_string(),
+            "SOFTWARE".to_string(),
+        );
+        let details = EquityDetails::new(vec![detail]);
+        assert!(details.is_some());
+        assert_eq!(details.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_equity_details_new_returns_none_for_empty() {
+        assert!(EquityDetails::new(vec![]).is_none());
     }
 }

--- a/libraries/rust/src/trading.rs
+++ b/libraries/rust/src/trading.rs
@@ -6,16 +6,158 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use uuid::Uuid;
 
+use crate::market::Ticker;
+
+/// Status of an equity rebalance session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum RebalanceSessionStatus {
+    Completed,
+    Failed,
+}
+
+impl RebalanceSessionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// Open/closed status of an equity pair position.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum EquityPairStatus {
+    Open,
+    Closed,
+}
+
+impl EquityPairStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Closed => "closed",
+        }
+    }
+}
+
+/// Long or short side of an allocation or order.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "text", rename_all = "SCREAMING_SNAKE_CASE")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AllocationSide {
+    Long,
+    Short,
+}
+
+impl AllocationSide {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Long => "LONG",
+            Self::Short => "SHORT",
+        }
+    }
+}
+
+/// Intended action for an allocation leg.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "text", rename_all = "SCREAMING_SNAKE_CASE")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AllocationAction {
+    OpenPosition,
+    ClosePosition,
+    Unspecified,
+}
+
+impl AllocationAction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::OpenPosition => "OPEN_POSITION",
+            Self::ClosePosition => "CLOSE_POSITION",
+            Self::Unspecified => "UNSPECIFIED",
+        }
+    }
+}
+
+/// Intraday or end-of-day portfolio snapshot type.
+///
+/// The `EndOfDay` variant maps to the database value `"end_of_day"` which
+/// matches the `snapshot_type` CHECK constraint in `equity_portfolio_snapshots`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum SnapshotType {
+    Intraday,
+    EndOfDay,
+}
+
+impl SnapshotType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Intraday => "intraday",
+            Self::EndOfDay => "end_of_day",
+        }
+    }
+}
+
 /// Groups one full rebalance cycle from allocation through order submission.
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct EquityRebalanceSession {
-    pub id: Uuid,
-    pub triggered_at: DateTime<Utc>,
-    pub trigger_reason: String,
+    id: Uuid,
+    triggered_at: DateTime<Utc>,
+    trigger_reason: String,
     /// References `model_runs.run_id`; nullable when the model run is unavailable.
-    pub model_run_id: Option<String>,
-    pub completed_at: Option<DateTime<Utc>>,
-    pub status: String,
+    model_run_id: Option<String>,
+    completed_at: Option<DateTime<Utc>>,
+    status: RebalanceSessionStatus,
+}
+
+impl EquityRebalanceSession {
+    /// Constructs an `EquityRebalanceSession` from validated field values.
+    pub fn new(
+        id: Uuid,
+        triggered_at: DateTime<Utc>,
+        trigger_reason: String,
+        model_run_id: Option<String>,
+        completed_at: Option<DateTime<Utc>>,
+        status: RebalanceSessionStatus,
+    ) -> Self {
+        Self {
+            id,
+            triggered_at,
+            trigger_reason,
+            model_run_id,
+            completed_at,
+            status,
+        }
+    }
+
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    pub fn triggered_at(&self) -> DateTime<Utc> {
+        self.triggered_at
+    }
+
+    pub fn trigger_reason(&self) -> &str {
+        &self.trigger_reason
+    }
+
+    pub fn model_run_id(&self) -> Option<&str> {
+        self.model_run_id.as_deref()
+    }
+
+    pub fn completed_at(&self) -> Option<DateTime<Utc>> {
+        self.completed_at
+    }
+
+    pub fn status(&self) -> &RebalanceSessionStatus {
+        &self.status
+    }
 }
 
 /// One cointegrated long-short pair within a rebalance session.
@@ -24,75 +166,504 @@ pub struct EquityRebalanceSession {
 /// at the time the pair is opened.
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct EquityPair {
-    pub id: Uuid,
-    pub rebalance_id: Uuid,
-    pub pair_id: String,
-    pub long_ticker: String,
-    pub short_ticker: String,
-    pub z_score: Decimal,
-    pub hedge_ratio: Decimal,
-    pub signal_strength: Decimal,
-    /// Either `"open"` or `"closed"`.
-    pub status: String,
-    pub opened_at: DateTime<Utc>,
-    pub closed_at: Option<DateTime<Utc>>,
-    pub realized_profit_and_loss: Option<Decimal>,
-    pub return_percent: Option<Decimal>,
-    pub holding_days: Option<i32>,
+    id: Uuid,
+    rebalance_id: Uuid,
+    pair_id: String,
+    long_ticker: Ticker,
+    short_ticker: Ticker,
+    z_score: Decimal,
+    hedge_ratio: Decimal,
+    signal_strength: Decimal,
+    status: EquityPairStatus,
+    opened_at: DateTime<Utc>,
+    closed_at: Option<DateTime<Utc>>,
+    realized_profit_and_loss: Option<Decimal>,
+    return_percent: Option<Decimal>,
+    holding_days: Option<i32>,
+}
+
+impl EquityPair {
+    /// Constructs an `EquityPair` from validated field values.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: Uuid,
+        rebalance_id: Uuid,
+        pair_id: String,
+        long_ticker: Ticker,
+        short_ticker: Ticker,
+        z_score: Decimal,
+        hedge_ratio: Decimal,
+        signal_strength: Decimal,
+        status: EquityPairStatus,
+        opened_at: DateTime<Utc>,
+        closed_at: Option<DateTime<Utc>>,
+        realized_profit_and_loss: Option<Decimal>,
+        return_percent: Option<Decimal>,
+        holding_days: Option<i32>,
+    ) -> Self {
+        Self {
+            id,
+            rebalance_id,
+            pair_id,
+            long_ticker,
+            short_ticker,
+            z_score,
+            hedge_ratio,
+            signal_strength,
+            status,
+            opened_at,
+            closed_at,
+            realized_profit_and_loss,
+            return_percent,
+            holding_days,
+        }
+    }
+
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    pub fn rebalance_id(&self) -> Uuid {
+        self.rebalance_id
+    }
+
+    pub fn pair_id(&self) -> &str {
+        &self.pair_id
+    }
+
+    pub fn long_ticker(&self) -> &Ticker {
+        &self.long_ticker
+    }
+
+    pub fn short_ticker(&self) -> &Ticker {
+        &self.short_ticker
+    }
+
+    pub fn z_score(&self) -> &Decimal {
+        &self.z_score
+    }
+
+    pub fn hedge_ratio(&self) -> &Decimal {
+        &self.hedge_ratio
+    }
+
+    pub fn signal_strength(&self) -> &Decimal {
+        &self.signal_strength
+    }
+
+    pub fn status(&self) -> &EquityPairStatus {
+        &self.status
+    }
+
+    pub fn opened_at(&self) -> DateTime<Utc> {
+        self.opened_at
+    }
+
+    pub fn closed_at(&self) -> Option<DateTime<Utc>> {
+        self.closed_at
+    }
+
+    pub fn realized_profit_and_loss(&self) -> Option<&Decimal> {
+        self.realized_profit_and_loss.as_ref()
+    }
+
+    pub fn return_percent(&self) -> Option<&Decimal> {
+        self.return_percent.as_ref()
+    }
+
+    pub fn holding_days(&self) -> Option<i32> {
+        self.holding_days
+    }
 }
 
 /// One ticker leg of an allocation within a rebalance session.
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct EquityAllocation {
-    pub id: Uuid,
-    pub rebalance_id: Uuid,
-    pub equity_pair_id: Uuid,
-    pub generated_at: DateTime<Utc>,
+    id: Uuid,
+    rebalance_id: Uuid,
+    equity_pair_id: Uuid,
+    generated_at: DateTime<Utc>,
     /// References `model_runs.run_id`; nullable when unavailable.
-    pub model_run_id: Option<String>,
-    pub ticker: String,
-    /// Either `"LONG"` or `"SHORT"`.
-    pub side: String,
-    /// Either `"OPEN_POSITION"`, `"CLOSE_POSITION"`, or `"UNSPECIFIED"`.
-    pub action: String,
-    pub dollar_amount: Decimal,
-    pub entry_price: Option<Decimal>,
+    model_run_id: Option<String>,
+    ticker: Ticker,
+    side: AllocationSide,
+    action: AllocationAction,
+    dollar_amount: Decimal,
+    entry_price: Option<Decimal>,
     /// Non-null for `SHORT` legs (whole-share count for Alpaca SELL).
-    pub quantity: Option<Decimal>,
+    quantity: Option<Decimal>,
     /// Non-null for `LONG` legs (dollar amount for Alpaca BUY).
-    pub notional: Option<Decimal>,
+    notional: Option<Decimal>,
+}
+
+impl EquityAllocation {
+    /// Constructs an `EquityAllocation` from validated field values.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: Uuid,
+        rebalance_id: Uuid,
+        equity_pair_id: Uuid,
+        generated_at: DateTime<Utc>,
+        model_run_id: Option<String>,
+        ticker: Ticker,
+        side: AllocationSide,
+        action: AllocationAction,
+        dollar_amount: Decimal,
+        entry_price: Option<Decimal>,
+        quantity: Option<Decimal>,
+        notional: Option<Decimal>,
+    ) -> Self {
+        Self {
+            id,
+            rebalance_id,
+            equity_pair_id,
+            generated_at,
+            model_run_id,
+            ticker,
+            side,
+            action,
+            dollar_amount,
+            entry_price,
+            quantity,
+            notional,
+        }
+    }
+
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    pub fn rebalance_id(&self) -> Uuid {
+        self.rebalance_id
+    }
+
+    pub fn equity_pair_id(&self) -> Uuid {
+        self.equity_pair_id
+    }
+
+    pub fn generated_at(&self) -> DateTime<Utc> {
+        self.generated_at
+    }
+
+    pub fn model_run_id(&self) -> Option<&str> {
+        self.model_run_id.as_deref()
+    }
+
+    pub fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    pub fn side(&self) -> &AllocationSide {
+        &self.side
+    }
+
+    pub fn action(&self) -> &AllocationAction {
+        &self.action
+    }
+
+    pub fn dollar_amount(&self) -> &Decimal {
+        &self.dollar_amount
+    }
+
+    pub fn entry_price(&self) -> Option<&Decimal> {
+        self.entry_price.as_ref()
+    }
+
+    pub fn quantity(&self) -> Option<&Decimal> {
+        self.quantity.as_ref()
+    }
+
+    pub fn notional(&self) -> Option<&Decimal> {
+        self.notional.as_ref()
+    }
 }
 
 /// An order submitted to Alpaca, linked to an allocation.
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct EquityOrder {
-    pub id: Uuid,
-    pub allocation_id: Uuid,
-    pub submitted_at: DateTime<Utc>,
-    pub ticker: String,
-    pub side: String,
-    pub quantity: Decimal,
-    pub order_type: String,
-    pub limit_price: Option<Decimal>,
-    pub alpaca_order_id: String,
+    id: Uuid,
+    allocation_id: Uuid,
+    submitted_at: DateTime<Utc>,
+    ticker: Ticker,
+    side: AllocationSide,
+    quantity: Decimal,
+    order_type: String,
+    limit_price: Option<Decimal>,
+    alpaca_order_id: String,
+}
+
+impl EquityOrder {
+    /// Constructs an `EquityOrder` from validated field values.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: Uuid,
+        allocation_id: Uuid,
+        submitted_at: DateTime<Utc>,
+        ticker: Ticker,
+        side: AllocationSide,
+        quantity: Decimal,
+        order_type: String,
+        limit_price: Option<Decimal>,
+        alpaca_order_id: String,
+    ) -> Self {
+        Self {
+            id,
+            allocation_id,
+            submitted_at,
+            ticker,
+            side,
+            quantity,
+            order_type,
+            limit_price,
+            alpaca_order_id,
+        }
+    }
+
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    pub fn allocation_id(&self) -> Uuid {
+        self.allocation_id
+    }
+
+    pub fn submitted_at(&self) -> DateTime<Utc> {
+        self.submitted_at
+    }
+
+    pub fn ticker(&self) -> &Ticker {
+        &self.ticker
+    }
+
+    pub fn side(&self) -> &AllocationSide {
+        &self.side
+    }
+
+    pub fn quantity(&self) -> &Decimal {
+        &self.quantity
+    }
+
+    pub fn order_type(&self) -> &str {
+        &self.order_type
+    }
+
+    pub fn limit_price(&self) -> Option<&Decimal> {
+        self.limit_price.as_ref()
+    }
+
+    pub fn alpaca_order_id(&self) -> &str {
+        &self.alpaca_order_id
+    }
 }
 
 /// Per-rebalance portfolio state snapshot.
 ///
-/// `"intraday"` rows are recorded after each live rebalance; `gross_return` and
-/// `net_return` are `None`. `"eod"` rows are recorded once per trading day at
-/// market close; all columns are populated.
+/// `Intraday` rows are recorded after each live rebalance; `gross_return` and
+/// `net_return` are `None`. `EndOfDay` rows are recorded once per trading day
+/// at market close; all columns are populated.
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct EquityPortfolioSnapshot {
-    pub id: i64,
-    pub snapshot_timestamp: DateTime<Utc>,
-    /// Either `"intraday"` or `"eod"`.
-    pub snapshot_type: String,
-    pub net_asset_value: Decimal,
-    pub gross_return: Option<Decimal>,
-    pub net_return: Option<Decimal>,
-    pub total_slippage_cost: Decimal,
-    pub created_at: DateTime<Utc>,
+    id: i64,
+    snapshot_timestamp: DateTime<Utc>,
+    snapshot_type: SnapshotType,
+    net_asset_value: Decimal,
+    gross_return: Option<Decimal>,
+    net_return: Option<Decimal>,
+    total_slippage_cost: Decimal,
+    created_at: DateTime<Utc>,
+}
+
+impl EquityPortfolioSnapshot {
+    /// Constructs an `EquityPortfolioSnapshot` from validated field values.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: i64,
+        snapshot_timestamp: DateTime<Utc>,
+        snapshot_type: SnapshotType,
+        net_asset_value: Decimal,
+        gross_return: Option<Decimal>,
+        net_return: Option<Decimal>,
+        total_slippage_cost: Decimal,
+        created_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            id,
+            snapshot_timestamp,
+            snapshot_type,
+            net_asset_value,
+            gross_return,
+            net_return,
+            total_slippage_cost,
+            created_at,
+        }
+    }
+
+    pub fn id(&self) -> i64 {
+        self.id
+    }
+
+    pub fn snapshot_timestamp(&self) -> DateTime<Utc> {
+        self.snapshot_timestamp
+    }
+
+    pub fn snapshot_type(&self) -> &SnapshotType {
+        &self.snapshot_type
+    }
+
+    pub fn net_asset_value(&self) -> &Decimal {
+        &self.net_asset_value
+    }
+
+    pub fn gross_return(&self) -> Option<&Decimal> {
+        self.gross_return.as_ref()
+    }
+
+    pub fn net_return(&self) -> Option<&Decimal> {
+        self.net_return.as_ref()
+    }
+
+    pub fn total_slippage_cost(&self) -> &Decimal {
+        &self.total_slippage_cost
+    }
+
+    pub fn created_at(&self) -> DateTime<Utc> {
+        self.created_at
+    }
+}
+
+/// A non-empty collection of [`EquityRebalanceSession`] records.
+#[derive(Debug, Clone)]
+pub struct RebalanceSessions(Vec<EquityRebalanceSession>);
+
+impl RebalanceSessions {
+    /// Returns `None` if `sessions` is empty.
+    pub fn new(sessions: Vec<EquityRebalanceSession>) -> Option<Self> {
+        if sessions.is_empty() {
+            None
+        } else {
+            Some(Self(sessions))
+        }
+    }
+
+    pub fn as_slice(&self) -> &[EquityRebalanceSession] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// A non-empty collection of [`EquityPair`] records.
+#[derive(Debug, Clone)]
+pub struct EquityPairs(Vec<EquityPair>);
+
+impl EquityPairs {
+    /// Returns `None` if `pairs` is empty.
+    pub fn new(pairs: Vec<EquityPair>) -> Option<Self> {
+        if pairs.is_empty() {
+            None
+        } else {
+            Some(Self(pairs))
+        }
+    }
+
+    pub fn as_slice(&self) -> &[EquityPair] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// A non-empty collection of [`EquityAllocation`] records.
+#[derive(Debug, Clone)]
+pub struct EquityAllocations(Vec<EquityAllocation>);
+
+impl EquityAllocations {
+    /// Returns `None` if `allocations` is empty.
+    pub fn new(allocations: Vec<EquityAllocation>) -> Option<Self> {
+        if allocations.is_empty() {
+            None
+        } else {
+            Some(Self(allocations))
+        }
+    }
+
+    pub fn as_slice(&self) -> &[EquityAllocation] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// A non-empty collection of [`EquityOrder`] records.
+#[derive(Debug, Clone)]
+pub struct EquityOrders(Vec<EquityOrder>);
+
+impl EquityOrders {
+    /// Returns `None` if `orders` is empty.
+    pub fn new(orders: Vec<EquityOrder>) -> Option<Self> {
+        if orders.is_empty() {
+            None
+        } else {
+            Some(Self(orders))
+        }
+    }
+
+    pub fn as_slice(&self) -> &[EquityOrder] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// A non-empty collection of [`EquityPortfolioSnapshot`] records.
+#[derive(Debug, Clone)]
+pub struct PortfolioSnapshots(Vec<EquityPortfolioSnapshot>);
+
+impl PortfolioSnapshots {
+    /// Returns `None` if `snapshots` is empty.
+    pub fn new(snapshots: Vec<EquityPortfolioSnapshot>) -> Option<Self> {
+        if snapshots.is_empty() {
+            None
+        } else {
+            Some(Self(snapshots))
+        }
+    }
+
+    pub fn as_slice(&self) -> &[EquityPortfolioSnapshot] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 #[cfg(test)]
@@ -104,125 +675,125 @@ mod tests {
 
     #[test]
     fn test_equity_rebalance_session_construction() {
-        let session = EquityRebalanceSession {
-            id: Uuid::new_v4(),
-            triggered_at: Utc::now(),
-            trigger_reason: "intraday_check".to_string(),
-            model_run_id: Some("run-abc123".to_string()),
-            completed_at: None,
-            status: "completed".to_string(),
-        };
-        assert_eq!(session.trigger_reason, "intraday_check");
-        assert_eq!(session.status, "completed");
-        assert!(session.completed_at.is_none());
+        let session = EquityRebalanceSession::new(
+            Uuid::new_v4(),
+            Utc::now(),
+            "intraday_check".to_string(),
+            Some("run-abc123".to_string()),
+            None,
+            RebalanceSessionStatus::Completed,
+        );
+        assert_eq!(session.trigger_reason(), "intraday_check");
+        assert_eq!(session.status(), &RebalanceSessionStatus::Completed);
+        assert!(session.completed_at().is_none());
     }
 
     #[test]
     fn test_equity_rebalance_session_clone() {
-        let session = EquityRebalanceSession {
-            id: Uuid::new_v4(),
-            triggered_at: Utc::now(),
-            trigger_reason: "eod_snapshot_requested".to_string(),
-            model_run_id: None,
-            completed_at: Some(Utc::now()),
-            status: "completed".to_string(),
-        };
+        let session = EquityRebalanceSession::new(
+            Uuid::new_v4(),
+            Utc::now(),
+            "eod_snapshot_requested".to_string(),
+            None,
+            Some(Utc::now()),
+            RebalanceSessionStatus::Completed,
+        );
         let cloned = session.clone();
-        assert_eq!(cloned.trigger_reason, "eod_snapshot_requested");
+        assert_eq!(cloned.trigger_reason(), "eod_snapshot_requested");
     }
 
     #[test]
     fn test_equity_pair_construction() {
-        let pair = EquityPair {
-            id: Uuid::new_v4(),
-            rebalance_id: Uuid::new_v4(),
-            pair_id: "AAPL-MSFT".to_string(),
-            long_ticker: "AAPL".to_string(),
-            short_ticker: "MSFT".to_string(),
-            z_score: Decimal::from(2),
-            hedge_ratio: Decimal::from(1),
-            signal_strength: Decimal::new(75, 2),
-            status: "open".to_string(),
-            opened_at: Utc::now(),
-            closed_at: None,
-            realized_profit_and_loss: None,
-            return_percent: None,
-            holding_days: None,
-        };
-        assert_eq!(pair.long_ticker, "AAPL");
-        assert_eq!(pair.short_ticker, "MSFT");
-        assert_eq!(pair.status, "open");
+        let pair = EquityPair::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "AAPL-MSFT".to_string(),
+            Ticker::new("AAPL").unwrap(),
+            Ticker::new("MSFT").unwrap(),
+            Decimal::from(2),
+            Decimal::from(1),
+            Decimal::new(75, 2),
+            EquityPairStatus::Open,
+            Utc::now(),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(pair.long_ticker().as_str(), "AAPL");
+        assert_eq!(pair.short_ticker().as_str(), "MSFT");
+        assert_eq!(pair.status(), &EquityPairStatus::Open);
     }
 
     #[test]
     fn test_equity_allocation_construction() {
-        let allocation = EquityAllocation {
-            id: Uuid::new_v4(),
-            rebalance_id: Uuid::new_v4(),
-            equity_pair_id: Uuid::new_v4(),
-            generated_at: Utc::now(),
-            model_run_id: None,
-            ticker: "AAPL".to_string(),
-            side: "LONG".to_string(),
-            action: "OPEN_POSITION".to_string(),
-            dollar_amount: Decimal::from(10_000),
-            entry_price: Some(Decimal::from(150)),
-            quantity: None,
-            notional: Some(Decimal::from(10_000)),
-        };
-        assert_eq!(allocation.ticker, "AAPL");
-        assert_eq!(allocation.side, "LONG");
-        assert_eq!(allocation.dollar_amount, Decimal::from(10_000));
+        let allocation = EquityAllocation::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Utc::now(),
+            None,
+            Ticker::new("AAPL").unwrap(),
+            AllocationSide::Long,
+            AllocationAction::OpenPosition,
+            Decimal::from(10_000),
+            Some(Decimal::from(150)),
+            None,
+            Some(Decimal::from(10_000)),
+        );
+        assert_eq!(allocation.ticker().as_str(), "AAPL");
+        assert_eq!(allocation.side(), &AllocationSide::Long);
+        assert_eq!(allocation.dollar_amount(), &Decimal::from(10_000));
     }
 
     #[test]
     fn test_equity_order_construction() {
-        let order = EquityOrder {
-            id: Uuid::new_v4(),
-            allocation_id: Uuid::new_v4(),
-            submitted_at: Utc::now(),
-            ticker: "MSFT".to_string(),
-            side: "SHORT".to_string(),
-            quantity: Decimal::from(25),
-            order_type: "market".to_string(),
-            limit_price: None,
-            alpaca_order_id: "alpaca-order-xyz".to_string(),
-        };
-        assert_eq!(order.ticker, "MSFT");
-        assert_eq!(order.side, "SHORT");
-        assert_eq!(order.quantity, Decimal::from(25));
+        let order = EquityOrder::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Utc::now(),
+            Ticker::new("MSFT").unwrap(),
+            AllocationSide::Short,
+            Decimal::from(25),
+            "market".to_string(),
+            None,
+            "alpaca-order-xyz".to_string(),
+        );
+        assert_eq!(order.ticker().as_str(), "MSFT");
+        assert_eq!(order.side(), &AllocationSide::Short);
+        assert_eq!(order.quantity(), &Decimal::from(25));
     }
 
     #[test]
     fn test_equity_portfolio_snapshot_construction() {
-        let snapshot = EquityPortfolioSnapshot {
-            id: 1,
-            snapshot_timestamp: Utc::now(),
-            snapshot_type: "intraday".to_string(),
-            net_asset_value: Decimal::from(100_000),
-            gross_return: None,
-            net_return: None,
-            total_slippage_cost: Decimal::from(50),
-            created_at: Utc::now(),
-        };
-        assert_eq!(snapshot.snapshot_type, "intraday");
-        assert_eq!(snapshot.net_asset_value, Decimal::from(100_000));
-        assert!(snapshot.gross_return.is_none());
+        let snapshot = EquityPortfolioSnapshot::new(
+            1,
+            Utc::now(),
+            SnapshotType::Intraday,
+            Decimal::from(100_000),
+            None,
+            None,
+            Decimal::from(50),
+            Utc::now(),
+        );
+        assert_eq!(snapshot.snapshot_type(), &SnapshotType::Intraday);
+        assert_eq!(snapshot.net_asset_value(), &Decimal::from(100_000));
+        assert!(snapshot.gross_return().is_none());
     }
 
     #[test]
-    fn test_equity_portfolio_snapshot_eod() {
-        let snapshot = EquityPortfolioSnapshot {
-            id: 2,
-            snapshot_timestamp: Utc::now(),
-            snapshot_type: "eod".to_string(),
-            net_asset_value: Decimal::from(102_000),
-            gross_return: Some(Decimal::new(2, 2)),
-            net_return: Some(Decimal::new(18, 3)),
-            total_slippage_cost: Decimal::from(75),
-            created_at: Utc::now(),
-        };
-        assert_eq!(snapshot.snapshot_type, "eod");
-        assert!(snapshot.gross_return.is_some());
+    fn test_equity_portfolio_snapshot_end_of_day() {
+        let snapshot = EquityPortfolioSnapshot::new(
+            2,
+            Utc::now(),
+            SnapshotType::EndOfDay,
+            Decimal::from(102_000),
+            Some(Decimal::new(2, 2)),
+            Some(Decimal::new(18, 3)),
+            Decimal::from(75),
+            Utc::now(),
+        );
+        assert_eq!(snapshot.snapshot_type(), &SnapshotType::EndOfDay);
+        assert!(snapshot.gross_return().is_some());
     }
 }


### PR DESCRIPTION
# Overview

## Changes

- Fixes #926
- Introduces the boundary-morphism pattern across all internal market and trading types in `libraries/rust`: fields are private, `new()` constructors are the sole construction path, and accessor methods expose read-only views
- `Ticker` newtype with `as_str()`, `PartialEq<str/&str/String>`, `sqlx::transparent` for zero-cost DB mapping
- New typed enums replacing raw string fields: `RebalanceSessionStatus`, `EquityPairStatus`, `AllocationSide`, `AllocationAction`, `SnapshotType`; each carries `sqlx` `type_name`/`rename_all` attributes for DB mapping
- Collection newtypes `EquityBars`, `EquityQuotes`, `EquityDetails` with `Option`-returning constructors (enforces non-empty)
- Updates all `data_manager` callers to use constructors and accessors; removes struct literal construction and direct field access throughout
- Renames `export_trading_history` to `export_equity_trading_history` and extracts `date_partitioned_key` helper
- Removes redundant `filter_map` in `equity_quotes::refresh_active_symbols` since `get_active_tickers` already returns `Vec<Ticker>`
- Updates startup to call `seed_equity_details` (previously `populate_equity_details_if_empty`)
- Updates all integration and unit tests to use `new()` constructors and accessor calls; rewrites upsert test's field mutation as accessor-based reconstruction

## Context

Part of Wave 3 series. Follows the principle that a value in scope should be proof of its own validity, not a candidate for re-checking downstream. All construction now goes through validated `new()` constructors; direct struct literal construction from outside the crate is no longer possible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Redesigned market and trading data models with private fields, accessor methods, and non-empty collection wrappers for improved encapsulation and type safety.
  * Introduced strongly-typed enums for session status, pair status, allocation actions, and snapshot types, replacing string-based representations.
  * Renamed `export_trading_history` to `export_equity_trading_history` for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->