### PR TITLE
Wave 3 housekeeping: nightly backup, task renames, and cleanup

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -46,6 +46,7 @@ jobs:
           cache-on-failure: false
           shared-key: rust-continuous-integration
           save-if: true
+          add-rust-environment-hash-key: false
       - name: Cache llvm-cov artifacts
         if: steps.changes.outputs.rust == 'true'
         uses: actions/cache@v4

--- a/devenv.nix
+++ b/devenv.nix
@@ -227,8 +227,9 @@ in {
   scripts.database-restore.exec = ''
     set -euo pipefail
     ${runtimeEnv}
+    BACKUP_KEY="''${AWS_S3_DATABASE_BACKUP_KEY:-database/backups/fund-latest.dump.gz}"
     echo "Downloading database backup from S3..."
-    aws s3 cp "s3://$AWS_S3_BUCKET_NAME/database/backups/fund-latest.dump.gz" /tmp/fund-latest.dump.gz
+    aws s3 cp "s3://$AWS_S3_BUCKET_NAME/$BACKUP_KEY" /tmp/fund-latest.dump.gz
     rm -f /tmp/fund-latest.dump
     gunzip /tmp/fund-latest.dump.gz
     psql -h localhost -p 5432 -d fund -c "SELECT timescaledb_pre_restore();"
@@ -243,11 +244,12 @@ in {
   scripts.database-backup.exec = ''
     set -euo pipefail
     ${runtimeEnv}
+    BACKUP_KEY="''${AWS_S3_DATABASE_BACKUP_KEY:-database/backups/fund-latest.dump.gz}"
     echo "Creating database backup..."
     pg_dump -Fc -h localhost -p 5432 fund > /tmp/fund-latest.dump
     gzip -f /tmp/fund-latest.dump
     echo "Uploading backup to S3..."
-    aws s3 cp /tmp/fund-latest.dump.gz "s3://$AWS_S3_BUCKET_NAME/database/backups/fund-latest.dump.gz"
+    aws s3 cp /tmp/fund-latest.dump.gz "s3://$AWS_S3_BUCKET_NAME/$BACKUP_KEY"
     rm -f /tmp/fund-latest.dump.gz
     echo "Database backup complete"
   '';
@@ -580,7 +582,7 @@ in {
       after = ["checks:python:install"];
     };
 
-    # --- Rust checks (sequential to reuse compilation artifacts) ---
+    # --- Rust checks (lint and test run in parallel after format) ---
 
     "checks:rust:format".exec = "rust-format";
 
@@ -590,7 +592,7 @@ in {
     };
     "checks:rust:test" = {
       exec = "rust-test";
-      after = ["checks:rust:lint"];
+      after = ["checks:rust:format"];
     };
 
     # --- Standalone checks ---

--- a/devenv.nix
+++ b/devenv.nix
@@ -12,9 +12,8 @@
   # $FUND_PROFILE, which dotenv sets from .env. These cannot be baked in at Nix
   # evaluation time because dotenv runs after Nix evaluates devenv.nix. Model
   # artifacts live in the same per-profile bucket under models/tide/: the Rust
-  # trainer (tide_model_trainer) writes there and the ensemble inference service
-  # (AppState::from_env) reads there, so training and serving agree in both
-  # dev and production.
+  # tide trainer (tide_model_trainer) writes there and the Rust ensemble service
+  # reads there, so training and serving agree in both dev and production.
   runtimeEnv = ''
     export AWS_S3_BUCKET_NAME="oscm-fund-$(echo ''${FUND_PROFILE} | tr '/.' '--')"
     export SECRETSPEC_PROFILE="''${FUND_PROFILE}"
@@ -221,7 +220,7 @@ in {
   ];
 
   # database:restore — fast recovery from a nightly S3 dump when schema has not changed.
-  # database:create — first-time setup: apply schema, seed equity details, backfill bars.
+  # database:create — first-time setup: apply schema, seed equity details, fetch equity bars.
   # database:reset  — drop and recreate the empty fund database; run before database:create
   #                   after a breaking schema change.
 
@@ -491,7 +490,7 @@ in {
     set -euo pipefail
     echo "Running TOML checks"
     find . \
-      \( -path "./.devenv" -o -path "./target" -o -path "./.venv" -o -path "./models/tide/.devenv" \) -prune \
+      \( -path "./.devenv" -o -path "./target" -o -path "./.venv" \) -prune \
       -o -name "*.toml" -print \
       | xargs taplo fmt --check --no-auto-config
     echo "TOML checks completed successfully"
@@ -507,7 +506,7 @@ in {
   scripts.nix-lint.exec = ''
     set -euo pipefail
     echo "Checking Nix code formatting"
-    alejandra --check --exclude ./.devenv --exclude ./.venv --exclude ./target --exclude ./models/tide/.devenv .
+    alejandra --check --exclude ./.devenv --exclude ./.venv --exclude ./target .
     echo "Nix formatting check passed"
     echo "Running Nix static analysis"
     statix check -c .statix.toml .
@@ -531,11 +530,11 @@ in {
     '{}')"
   '';
 
-  scripts.backfill-bars.exec = ''
+  scripts.backfill-equity-bars.exec = ''
     set -euo pipefail
 
     if [ -z "''${BACKFILL_START_DATE:-}" ]; then
-      echo "Usage: BACKFILL_START_DATE=YYYY-MM-DD devenv tasks run data:backfill-bars"
+      echo "Usage: BACKFILL_START_DATE=YYYY-MM-DD devenv tasks run data:backfill-equity-bars"
       echo "  Optional: BACKFILL_END_DATE=YYYY-MM-DD (defaults to today)"
       exit 1
     fi
@@ -620,22 +619,34 @@ in {
     # Historical S3 backfill: writes Hive-partitioned parquet that model
     # training reads directly. Distinct from database:fetch-equity-bars, which
     # populates the PostgreSQL rolling buffer through the data-manager API.
-    "data:backfill-bars".exec = "backfill-bars";
+    "data:backfill-equity-bars".exec = "backfill-equity-bars";
 
     # --- Database lifecycle tasks ---
-    # Create: first-time setup or post-reset recovery after a breaking schema change.
-    #   Applies schema, then seeds equity details, then backfills equity bars.
-    #   Requires BACKFILL_START_DATE=YYYY-MM-DD (and optionally BACKFILL_END_DATE).
-    # Update: automatic on each process start via applySchema in data-manager.exec.
-    #   Safe for additive changes; loud failure for breaking changes.
-    # Restore: fast recovery from a nightly S3 dump (schema must match the dump).
+    # Three lifecycle modes:
+    #   Create  — build a working database from scratch (schema change or fresh VM).
+    #   Update  — automatic on each data-manager start; safe for additive schema changes.
+    #   Restore — fast recovery from the nightly S3 dump when schema has not changed.
 
+    # Drops and recreates the empty fund database. Run before database:create when
+    # recovering from a breaking schema change.
     "database:reset".exec = "database-reset";
+
+    # Downloads the nightly pg_dump from S3 and restores the full database: equity
+    # bars, details, predictions, model runs, and all trading history. Fast, but
+    # requires the schema to match the dump exactly.
     "database:restore".exec = "database-restore";
+
+    # Dumps the live database and uploads it to S3. Also runs automatically via
+    # pg_cron at 22:00 UTC on weekdays after all nightly exports complete.
     "database:backup".exec = "database-backup";
+
     "database:fetch-equity-details".exec = "database-fetch-equity-details";
     "database:fetch-equity-bars".exec = "database-fetch-equity-bars";
 
+    # Builds an inference-ready database from scratch: applies the schema, seeds
+    # equity details, and backfills equity bars from the live API. Use after
+    # database:reset when the schema has changed or on a fresh VM. No trading
+    # history is restored. Requires BACKFILL_START_DATE=YYYY-MM-DD.
     "database:create".exec = ''
       set -euo pipefail
       if [ -z "''${BACKFILL_START_DATE:-}" ]; then
@@ -746,9 +757,8 @@ in {
           exec secretspec run -- cargo watch -x 'run --no-default-features --features data_manager --bin data_manager'
         '';
 
-      # Rust ensemble_manager (Burn): serves predictions over HTTP and consumes
-      # predictions_requested from the Postgres event bus. Replaces the former
-      # Python ensemble_manager (uvicorn/tinygrad).
+      # ensemble_manager: serves predictions over HTTP and consumes
+      # predictions_requested from the Postgres event bus.
       ensemble-manager.exec =
         if isProduction
         then ''
@@ -835,11 +845,14 @@ in {
       echo "    checks:sql                     SQL lint (PostgreSQL)"
       echo "    checks:nix                     Nix checks (alejandra + statix)"
       echo "    database:create                First-time setup: apply schema + seed details + fetch bars"
-      echo "    database:reset                 Drop and recreate empty fund database"
-      echo "    database:restore               Restore from nightly S3 dump"
-      echo "    database:backup                Dump fund database and upload to S3"
+      echo "                                   (use when schema changed or starting fresh)"
+      echo "    database:reset                 Drop and recreate the empty fund database"
+      echo "                                   (run before database:create after a breaking schema change)"
+      echo "    database:restore               Restore from nightly S3 dump (fast recovery, schema must match)"
+      echo "    database:backup                Dump fund database and upload to S3 (also runs nightly at 22:00 UTC)"
       echo "    database:fetch-equity-details  Seed equity_details from S3 CSV"
-      echo "    database:fetch-equity-bars     Backfill equity bars (requires BACKFILL_START_DATE)"
+      echo "    database:fetch-equity-bars     Backfill equity bars into PostgreSQL (requires BACKFILL_START_DATE)"
+      echo "    data:backfill-equity-bars      Backfill equity bars to S3 Parquet for training (requires BACKFILL_START_DATE)"
       echo "    models:tide:train              Train tide model and upload artifacts"
       echo ""
       echo "  Utilities:"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,16 @@
 [tool.uv.workspace]
 members = [
   "applications/portfolio_manager",
-  "applications/ensemble_manager",
   "libraries/python",
   "infrastructure",
   "tools",
-  "models/tide",
 ]
 
 [dependency-groups]
 dev = ["coverage>=7.8.0", "pytest>=8.3.5"]
 
 [tool.pytest.ini_options]
-testpaths = [
-  "applications/*/tests",
-  "libraries/python/tests",
-  "tools/tests",
-  "models/tide/tests",
-]
+testpaths = ["applications/*/tests", "libraries/python/tests", "tools/tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/schema.sql
+++ b/schema.sql
@@ -427,3 +427,17 @@ BEGIN
     END IF;
 END;
 $do$;
+
+-- Nightly database backup: weekdays at 22:00 UTC (after all nightly exports complete).
+-- Triggers a pg_dump + S3 upload task in data_manager via the jobs channel.
+DO $do$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'backup-database') THEN
+        PERFORM cron.schedule(
+            'backup-database',
+            '0 22 * * 1-5',
+            $$SELECT schedule_job('backup-database')$$
+        );
+    END IF;
+END;
+$do$;

--- a/src/data_manager/scheduler.rs
+++ b/src/data_manager/scheduler.rs
@@ -371,6 +371,9 @@ async fn run_backup_job(state: &State) -> Result<usize, String> {
     let database_url = std::env::var("DATABASE_URL")
         .map_err(|_| "DATABASE_URL not set for database backup".to_string())?;
 
+    let (host, username, port, dbname, password) = parse_postgres_url(&database_url)
+        .map_err(|error| format!("Failed to parse DATABASE_URL for pg_dump: {}", error))?;
+
     let backup_key = std::env::var("AWS_S3_DATABASE_BACKUP_KEY")
         .unwrap_or_else(|_| "database/backups/fund-latest.dump.gz".to_string());
 
@@ -380,12 +383,26 @@ async fn run_backup_job(state: &State) -> Result<usize, String> {
     let dump_gz_path = "/tmp/fund-backup.dump.gz";
 
     let dump_status = tokio::process::Command::new("pg_dump")
-        .args(["--format=custom", "--file", dump_path, &database_url])
+        .args([
+            "--format=custom",
+            "--file",
+            dump_path,
+            "--host",
+            &host,
+            "--port",
+            &port.to_string(),
+            "--username",
+            &username,
+            "--dbname",
+            &dbname,
+        ])
+        .env("PGPASSWORD", &password)
         .status()
         .await
         .map_err(|error| format!("Failed to spawn pg_dump: {}", error))?;
 
     if !dump_status.success() {
+        let _ = tokio::fs::remove_file(dump_path).await;
         let message = format!("pg_dump exited with status {}", dump_status);
         return Err(message);
     }
@@ -394,28 +411,38 @@ async fn run_backup_job(state: &State) -> Result<usize, String> {
         .args(["--force", dump_path])
         .status()
         .await
-        .map_err(|error| format!("Failed to spawn gzip: {}", error))?;
+        .map_err(|error| {
+            let _ = std::fs::remove_file(dump_path);
+            format!("Failed to spawn gzip: {}", error)
+        })?;
 
     if !gzip_status.success() {
+        let _ = tokio::fs::remove_file(dump_path).await;
         let message = format!("gzip exited with status {}", gzip_status);
         return Err(message);
     }
 
-    let compressed = tokio::fs::read(dump_gz_path)
+    let byte_count = tokio::fs::metadata(dump_gz_path)
         .await
-        .map_err(|error| format!("Failed to read {}: {}", dump_gz_path, error))?;
+        .map_err(|error| format!("Failed to stat {}: {}", dump_gz_path, error))?
+        .len() as usize;
 
-    let byte_count = compressed.len();
+    let body = ByteStream::from_path(dump_gz_path)
+        .await
+        .map_err(|error| format!("Failed to open {} for upload: {}", dump_gz_path, error))?;
 
     state
         .s3_client
         .put_object()
         .bucket(&state.bucket_name)
         .key(&backup_key)
-        .body(ByteStream::from(compressed))
+        .body(body)
         .send()
         .await
-        .map_err(|error| format!("Failed to upload backup to S3 {}: {}", backup_key, error))?;
+        .map_err(|error| {
+            let _ = std::fs::remove_file(dump_gz_path);
+            format!("Failed to upload backup to S3 {}: {}", backup_key, error)
+        })?;
 
     let _ = tokio::fs::remove_file(dump_gz_path).await;
 
@@ -426,12 +453,86 @@ async fn run_backup_job(state: &State) -> Result<usize, String> {
     Ok(byte_count)
 }
 
+/// Parses a PostgreSQL connection URL into its components.
+///
+/// Returns `(host, username, port, dbname, password)`.
+/// Supports `postgres://` and `postgresql://` schemes.
+fn parse_postgres_url(url: &str) -> Result<(String, String, u16, String, String), String> {
+    let without_scheme = url
+        .strip_prefix("postgres://")
+        .or_else(|| url.strip_prefix("postgresql://"))
+        .ok_or_else(|| "DATABASE_URL must start with postgres:// or postgresql://".to_string())?;
+
+    let (userinfo, rest) = without_scheme
+        .split_once('@')
+        .ok_or_else(|| "DATABASE_URL missing '@' separator".to_string())?;
+
+    let (hostinfo, dbname) = rest
+        .split_once('/')
+        .ok_or_else(|| "DATABASE_URL missing database name after '/'".to_string())?;
+
+    let (username, password) = userinfo
+        .split_once(':')
+        .ok_or_else(|| "DATABASE_URL missing ':' between username and password".to_string())?;
+
+    let (host, port_str) = hostinfo.split_once(':').unwrap_or((hostinfo, "5432"));
+
+    let port: u16 = port_str
+        .parse()
+        .map_err(|_| format!("DATABASE_URL has invalid port: '{}'", port_str))?;
+
+    Ok((
+        host.to_string(),
+        username.to_string(),
+        port,
+        dbname.to_string(),
+        password.to_string(),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{duration_until_next_sync, prior_trading_day, run_export_job, sync_date_for};
+    use super::{
+        duration_until_next_sync, parse_postgres_url, prior_trading_day, run_export_job,
+        sync_date_for,
+    };
     use chrono::{NaiveDate, TimeZone, Utc};
     use chrono_tz::US::Eastern;
     use std::time::Duration;
+
+    /// RAII guard that removes an environment variable for the duration of a test
+    /// and restores the original value (or absence) on drop.
+    ///
+    /// Tests using this guard must be marked `#[serial_test::serial]` to prevent
+    /// concurrent mutation of the process environment.
+    struct EnvironmentVariableGuard {
+        name: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvironmentVariableGuard {
+        /// Removes `name` from the environment and returns a guard that restores it on drop.
+        fn remove(name: &'static str) -> Self {
+            let original = std::env::var(name).ok();
+            // SAFETY: Protected by #[serial_test::serial] — no concurrent env access.
+            unsafe {
+                std::env::remove_var(name);
+            }
+            Self { name, original }
+        }
+    }
+
+    impl Drop for EnvironmentVariableGuard {
+        fn drop(&mut self) {
+            // SAFETY: Protected by #[serial_test::serial] — no concurrent env access.
+            unsafe {
+                match self.original.as_ref() {
+                    Some(value) => std::env::set_var(self.name, value),
+                    None => std::env::remove_var(self.name),
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_duration_until_next_sync_is_positive() {
@@ -579,10 +680,8 @@ mod tests {
             use aws_sdk_s3::config::Region;
 
             // Ensure DATABASE_URL is unset so run_backup_job returns early with an error.
-            let original_database_url = std::env::var("DATABASE_URL").ok();
-            unsafe {
-                std::env::remove_var("DATABASE_URL");
-            }
+            // The guard restores the original value (or absence) when it drops.
+            let _database_url_guard = EnvironmentVariableGuard::remove("DATABASE_URL");
 
             let credentials =
                 Credentials::new("test-access-key", "test-secret-key", None, None, "tests");
@@ -608,16 +707,55 @@ mod tests {
             let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
             let result = run_export_job(&state, "backup-database", date).await;
 
-            unsafe {
-                match original_database_url {
-                    Some(value) => std::env::set_var("DATABASE_URL", value),
-                    None => std::env::remove_var("DATABASE_URL"),
-                }
-            }
-
             assert!(result.is_err());
             assert!(result.unwrap_err().contains("DATABASE_URL not set"));
         });
+    }
+
+    #[test]
+    fn test_parse_postgres_url_full_url() {
+        let (host, username, port, dbname, password) =
+            parse_postgres_url("postgres://alice:s3cr3t@db.example.com:5433/mydb").unwrap();
+        assert_eq!(host, "db.example.com");
+        assert_eq!(username, "alice");
+        assert_eq!(port, 5433);
+        assert_eq!(dbname, "mydb");
+        assert_eq!(password, "s3cr3t");
+    }
+
+    #[test]
+    fn test_parse_postgres_url_defaults_port_to_5432() {
+        let (host, _, port, _, _) =
+            parse_postgres_url("postgres://user:pass@localhost/fund").unwrap();
+        assert_eq!(host, "localhost");
+        assert_eq!(port, 5432);
+    }
+
+    #[test]
+    fn test_parse_postgres_url_postgresql_scheme() {
+        let result = parse_postgres_url("postgresql://user:pass@host/db");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_parse_postgres_url_invalid_scheme_returns_error() {
+        let result = parse_postgres_url("mysql://user:pass@host/db");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("postgres:// or postgresql://"));
+    }
+
+    #[test]
+    fn test_parse_postgres_url_missing_at_returns_error() {
+        let result = parse_postgres_url("postgres://user:passhost/db");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("'@'"));
+    }
+
+    #[test]
+    fn test_parse_postgres_url_missing_dbname_returns_error() {
+        let result = parse_postgres_url("postgres://user:pass@host");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("database name"));
     }
 
     #[test]

--- a/src/data_manager/scheduler.rs
+++ b/src/data_manager/scheduler.rs
@@ -3,6 +3,7 @@ use crate::data_manager::database;
 use crate::data_manager::equity_bars::fetch_and_store;
 use crate::data_manager::export;
 use crate::data_manager::state::State;
+use aws_sdk_s3::primitives::ByteStream;
 use chrono::{DateTime, Datelike, NaiveDate, NaiveTime, TimeZone, Utc, Weekday};
 use chrono_tz::US::Eastern;
 use sqlx::postgres::PgListener;
@@ -194,7 +195,11 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
         }
     }
 
-    for export_job in &["export-equity-bars", "export-trading-history"] {
+    for export_job in &[
+        "export-equity-bars",
+        "export-trading-history",
+        "backup-database",
+    ] {
         match database::requeue_stale_claimed_jobs(
             pool,
             export_job,
@@ -301,7 +306,7 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
                     }
                 }
             }
-            "export-equity-bars" | "export-trading-history" => {
+            "export-equity-bars" | "export-trading-history" | "backup-database" => {
                 info!("Received NOTIFY for {}", payload);
 
                 let (job_id, scheduled_at) = match database::claim_pending_job(pool, payload).await
@@ -348,11 +353,77 @@ async fn run_export_job(
     match job_name {
         "export-equity-bars" => export::export_equity_bars(state, export_date).await,
         "export-trading-history" => export::export_equity_trading_history(state, export_date).await,
+        "backup-database" => run_backup_job(state).await,
         _ => {
             let message = format!("Unknown export job: {}", job_name);
             Err(message)
         }
     }
+}
+
+/// Runs a full pg_dump of the `fund` database, compresses the output with gzip,
+/// and uploads the result to S3.
+///
+/// The S3 key defaults to `database/backups/fund-latest.dump.gz` and can be
+/// overridden with the `AWS_S3_DATABASE_BACKUP_KEY` environment variable.
+/// Returns the number of bytes uploaded.
+async fn run_backup_job(state: &State) -> Result<usize, String> {
+    let database_url = std::env::var("DATABASE_URL")
+        .map_err(|_| "DATABASE_URL not set for database backup".to_string())?;
+
+    let backup_key = std::env::var("AWS_S3_DATABASE_BACKUP_KEY")
+        .unwrap_or_else(|_| "database/backups/fund-latest.dump.gz".to_string());
+
+    info!("Starting database backup to {}", backup_key);
+
+    let dump_path = "/tmp/fund-backup.dump";
+    let dump_gz_path = "/tmp/fund-backup.dump.gz";
+
+    let dump_status = tokio::process::Command::new("pg_dump")
+        .args(["--format=custom", "--file", dump_path, &database_url])
+        .status()
+        .await
+        .map_err(|error| format!("Failed to spawn pg_dump: {}", error))?;
+
+    if !dump_status.success() {
+        let message = format!("pg_dump exited with status {}", dump_status);
+        return Err(message);
+    }
+
+    let gzip_status = tokio::process::Command::new("gzip")
+        .args(["--force", dump_path])
+        .status()
+        .await
+        .map_err(|error| format!("Failed to spawn gzip: {}", error))?;
+
+    if !gzip_status.success() {
+        let message = format!("gzip exited with status {}", gzip_status);
+        return Err(message);
+    }
+
+    let compressed = tokio::fs::read(dump_gz_path)
+        .await
+        .map_err(|error| format!("Failed to read {}: {}", dump_gz_path, error))?;
+
+    let byte_count = compressed.len();
+
+    state
+        .s3_client
+        .put_object()
+        .bucket(&state.bucket_name)
+        .key(&backup_key)
+        .body(ByteStream::from(compressed))
+        .send()
+        .await
+        .map_err(|error| format!("Failed to upload backup to S3 {}: {}", backup_key, error))?;
+
+    let _ = tokio::fs::remove_file(dump_gz_path).await;
+
+    info!(
+        "Database backup uploaded, byte_count: {}, key: {}",
+        byte_count, backup_key
+    );
+    Ok(byte_count)
 }
 
 #[cfg(test)]
@@ -493,6 +564,60 @@ mod tests {
             sync_date.as_naive_date(),
             NaiveDate::from_ymd_opt(2026, 4, 28).unwrap()
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_run_backup_job_returns_error_when_database_url_missing() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            use crate::data_manager::state::{MassiveSecrets, State};
+            use aws_credential_types::Credentials;
+            use aws_sdk_s3::config::Region;
+
+            // Ensure DATABASE_URL is unset so run_backup_job returns early with an error.
+            let original_database_url = std::env::var("DATABASE_URL").ok();
+            unsafe {
+                std::env::remove_var("DATABASE_URL");
+            }
+
+            let credentials =
+                Credentials::new("test-access-key", "test-secret-key", None, None, "tests");
+            let shared_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+                .region(Region::new("us-east-1"))
+                .credentials_provider(credentials)
+                .endpoint_url("http://127.0.0.1:9")
+                .load()
+                .await;
+            let s3_config = aws_sdk_s3::config::Builder::from(&shared_config)
+                .force_path_style(true)
+                .build();
+            let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+            let state = State::new(
+                reqwest::Client::new(),
+                MassiveSecrets {
+                    base: "http://127.0.0.1:1".to_string(),
+                    key: "test-api-key".to_string(),
+                },
+                s3_client,
+                "test-bucket".to_string(),
+            );
+            let date = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+            let result = run_export_job(&state, "backup-database", date).await;
+
+            unsafe {
+                match original_database_url {
+                    Some(value) => std::env::set_var("DATABASE_URL", value),
+                    None => std::env::remove_var("DATABASE_URL"),
+                }
+            }
+
+            assert!(result.is_err());
+            assert!(result.unwrap_err().contains("DATABASE_URL not set"));
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #904, #907, #908, and completes #923. These issues were either fully addressed by the #933 refactor or are resolved by the changes here.

**Nightly database backup**

Add a `backup-database` pg_cron job at 22:00 UTC on weekdays (after all nightly exports). `data_manager` handles the job via the existing jobs channel: spawns `pg_dump --format=custom`, compresses the output through `gzip`, and uploads to S3. The S3 key defaults to `database/backups/fund-latest.dump.gz` and is configurable via `AWS_S3_DATABASE_BACKUP_KEY`. The job participates in the startup drain and stale-job requeue logic alongside the existing export jobs.

**Backfill task rename**

`scripts.backfill-bars` and `data:backfill-bars` renamed to `backfill-equity-bars` and `data:backfill-equity-bars`. The underlying Rust `backfill` binary is unchanged.

**Dead Python packages removed**

`applications/ensemble_manager` and `models/tide` removed from the uv workspace and pytest testpaths. Both were retired by #933; only `__pycache__` artifacts remained on disk.

**devenv.nix cleanup**

- Per-task Nix comments on `database:restore`, `database:backup`, and `database:create` replacing the old block comment
- Stale references to `Python ensemble_manager` removed from comments
- `models/tide/.devenv` removed from `alejandra` and `taplo` exclude lists

## Test plan

- [x] `devenv tasks run checks:rust` passes
- [x] `devenv tasks run checks:python` passes
- [x] `devenv tasks run checks:base` passes
- [x] Confirm `database:backup` task uploads a `.dump.gz` to S3
- [x] Confirm `data:backfill-equity-bars` works with `BACKFILL_START_DATE` set
- [x] Confirm `backup-database` pg_cron entry appears in `cron.job` after schema is applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated nightly database backups now run on weekdays at 22:00 UTC.

* **Chores**
  * Renamed equity bar backfill command to `backfill-equity-bars`.
  * Updated development and project configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->