### PR TITLE
rename apps --> applications

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This is a collection of guidelines and references.
 
 - Rust and Python are the primary project languages
 - [devenv](https://devenv.sh/) manages the development environment, tasks, and local services
-- Services run on a single exe.dev VM via `devenv --profile apps up` in both dev and production
+- Services run on a single exe.dev VM via `devenv --profile applications up` in both dev and production
 - Secrets are managed via [secretspec](https://secretspec.dev/) with the `awssm` provider
 - Python code follows [uv](https://github.com/astral-sh/uv) workspace conventions
 - Rust code follows Cargo workspace conventions
@@ -30,7 +30,7 @@ This is a collection of guidelines and references.
   `sql`, `http`, `url`, `uri`, `io`, `id`, `uuid`, `api`) and established domain or proper-noun terms
   (`aws`, `utc`, `etf`, `ohlcv`, `guc`); case acronyms as ordinary words per language convention
   (Rust `HttpClient`/`Uuid`, Python `api_key`/`http_client`), not all-caps runs
-- Never rename fixed external identifiers: devenv profile names (`apps`, `ml`), the `awssm` secretspec
+- Never rename fixed external identifiers: devenv profile names (`applications`, `ml`), the `awssm` secretspec
   provider, the `tide` model and package name, environment variables and secret keys (e.g.
   `DATABASE_URL`, `ALPACA_API_KEY_ID`), library import aliases (`np`, `pl`, `pa`), linter directives
   (`noqa`), and external library fields and parameters (e.g. the Alpaca/Massive `vw` deserialization

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Once bootstrapped:
 ```sh
 # Environment auto-activates on cd with devenv hook configured
 devenv shell                    # or: enter manually without hook
-devenv --profile apps up        # start application services
+devenv --profile applications up        # start application services
 devenv --profile ml shell       # machine learning training environment
 ```
 
-Production runs on a VM with `devenv --profile apps up` and secretspec for secret injection.
+Production runs on a VM with `devenv --profile applications up` and secretspec for secret injection.
 
 ### Principles
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -397,7 +397,7 @@ in {
     set -euo pipefail
     if ! pg_isready -q 2>/dev/null; then
       echo "sqlx prepare check skipped: database not available"
-      echo "Run 'devenv --profile apps up' then 'cargo sqlx prepare -- --all-features' to verify the cache"
+      echo "Run 'devenv --profile applications up' then 'cargo sqlx prepare -- --all-features' to verify the cache"
       exit 0
     fi
     echo "Checking sqlx query metadata cache is up to date"
@@ -590,7 +590,7 @@ in {
 
   # --- Profiles ---
 
-  profiles.apps.module = {
+  profiles.applications.module = {
     env = {
       DISABLE_DISK_CACHE = "1";
       BACKFILL_LOOKBACK_DAYS = "730";
@@ -715,10 +715,10 @@ in {
       echo "  Bucket: $AWS_S3_BUCKET_NAME"
       echo ""
       echo "  Profiles:"
-      echo "    devenv --profile apps up      Start application services"
+      echo "    devenv --profile applications up      Start application services"
       echo "    devenv --profile ml shell     ML training environment"
       echo ""
-      echo "  Services (apps profile):"
+      echo "  Services (applications profile):"
       echo "    Data Manager:      localhost:8080"
       echo "    Ensemble Manager:  localhost:8082"
       echo "    Portfolio Manager: localhost:8083"


### PR DESCRIPTION
This pull request standardizes the naming of the main devenv profile for application services from `apps` to `applications` across the codebase and documentation. This ensures consistency and prevents confusion for developers working with local and production environments.

**Profile name standardization:**

* Updated all references in documentation files (`README.md`, `CLAUDE.md`) to use `devenv --profile applications up` instead of `apps`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R56) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L11-R11) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L33-R33)
* Renamed the `profiles.apps.module` block to `profiles.applications.module` in `devenv.nix` and updated all related script messages and instructions to use the new profile name. [[1]](diffhunk://#diff-cef540503c67fa4a36d1b9fe95a62f979c4b8b2bc43a6e023e250b7154341afcL593-R593) [[2]](diffhunk://#diff-cef540503c67fa4a36d1b9fe95a62f979c4b8b2bc43a6e023e250b7154341afcL400-R400) [[3]](diffhunk://#diff-cef540503c67fa4a36d1b9fe95a62f979c4b8b2bc43a6e023e250b7154341afcL718-R721)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed `devenv` profile from `apps` to `applications` in configuration and documentation.
  * Updated service startup command: use `--profile applications up` instead of `--profile apps up` for both development and production.
  * Development guidelines updated with the new profile naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->