### PR TITLE
rename secret

### DIFF
--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -26,13 +26,13 @@ impl AlpacaCredentials {
 
     /// Reads Alpaca credentials from environment variables.
     ///
-    /// Reads `ALPACA_KEY_ID` and `ALPACA_SECRET`. Returns `Err` if either
+    /// Reads `ALPACA_API_KEY_ID` and `ALPACA_API_SECRET`. Returns `Err` if either
     /// variable is absent or set to an empty string.
     pub fn from_env() -> Result<Self, String> {
-        let key_id = std::env::var("ALPACA_KEY_ID")
-            .map_err(|_| "ALPACA_KEY_ID environment variable is not set".to_string())?;
-        let secret = std::env::var("ALPACA_SECRET")
-            .map_err(|_| "ALPACA_SECRET environment variable is not set".to_string())?;
+        let key_id = std::env::var("ALPACA_API_KEY_ID")
+            .map_err(|_| "ALPACA_API_KEY_ID environment variable is not set".to_string())?;
+        let secret = std::env::var("ALPACA_API_SECRET")
+            .map_err(|_| "ALPACA_API_SECRET environment variable is not set".to_string())?;
         Self::new(key_id, secret)
     }
 
@@ -85,13 +85,13 @@ mod tests {
     #[serial]
     fn test_from_env_returns_error_when_vars_unset() {
         // Remove both vars to test the missing-variable path.
-        let key_id_backup = std::env::var("ALPACA_KEY_ID").ok();
-        let secret_backup = std::env::var("ALPACA_SECRET").ok();
+        let key_id_backup = std::env::var("ALPACA_API_KEY_ID").ok();
+        let secret_backup = std::env::var("ALPACA_API_SECRET").ok();
 
         // SAFETY: environment mutation is safe in single-threaded test context.
         unsafe {
-            std::env::remove_var("ALPACA_KEY_ID");
-            std::env::remove_var("ALPACA_SECRET");
+            std::env::remove_var("ALPACA_API_KEY_ID");
+            std::env::remove_var("ALPACA_API_SECRET");
         }
 
         let result = AlpacaCredentials::from_env();
@@ -100,10 +100,10 @@ mod tests {
         // Restore originals.
         unsafe {
             if let Some(value) = key_id_backup {
-                std::env::set_var("ALPACA_KEY_ID", value);
+                std::env::set_var("ALPACA_API_KEY_ID", value);
             }
             if let Some(value) = secret_backup {
-                std::env::set_var("ALPACA_SECRET", value);
+                std::env::set_var("ALPACA_API_SECRET", value);
             }
         }
     }

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -57,8 +57,8 @@ mod tests {
             std::env::set_var("AWS_S3_BUCKET_NAME", "test-bucket");
             std::env::set_var("MASSIVE_BASE_URL", "http://test");
             std::env::set_var("MASSIVE_API_KEY", "test-key");
-            std::env::set_var("ALPACA_KEY_ID", "test-key-id");
-            std::env::set_var("ALPACA_SECRET", "test-secret");
+            std::env::set_var("ALPACA_API_KEY_ID", "test-key-id");
+            std::env::set_var("ALPACA_API_SECRET", "test-secret");
             std::env::set_var("RUST_LOG", "data_manager=debug,tower_http=debug");
             std::env::remove_var("DATABASE_URL");
         }
@@ -71,8 +71,8 @@ mod tests {
             std::env::remove_var("AWS_S3_BUCKET_NAME");
             std::env::remove_var("MASSIVE_BASE_URL");
             std::env::remove_var("MASSIVE_API_KEY");
-            std::env::remove_var("ALPACA_KEY_ID");
-            std::env::remove_var("ALPACA_SECRET");
+            std::env::remove_var("ALPACA_API_KEY_ID");
+            std::env::remove_var("ALPACA_API_SECRET");
             std::env::remove_var("RUST_LOG");
         }
     }

--- a/src/data_manager/startup.rs
+++ b/src/data_manager/startup.rs
@@ -198,8 +198,9 @@ mod tests {
         let _massive_base_guard =
             EnvironmentVariableGuard::set("MASSIVE_BASE_URL", "http://127.0.0.1:1");
         let _massive_key_guard = EnvironmentVariableGuard::set("MASSIVE_API_KEY", "test-api-key");
-        let _alpaca_key_guard = EnvironmentVariableGuard::set("ALPACA_KEY_ID", "test-key-id");
-        let _alpaca_secret_guard = EnvironmentVariableGuard::set("ALPACA_SECRET", "test-secret");
+        let _alpaca_key_guard = EnvironmentVariableGuard::set("ALPACA_API_KEY_ID", "test-key-id");
+        let _alpaca_secret_guard =
+            EnvironmentVariableGuard::set("ALPACA_API_SECRET", "test-secret");
         let _database_url_guard = EnvironmentVariableGuard::remove("DATABASE_URL");
 
         let result = run_server("invalid-address").await;

--- a/src/data_manager/state.rs
+++ b/src/data_manager/state.rs
@@ -13,7 +13,7 @@ use tracing::{debug, info, warn};
 /// Alpaca API credentials.
 ///
 /// The private fields enforce that credentials are only constructed when both
-/// `ALPACA_KEY_ID` and `ALPACA_SECRET` are non-empty. An `AlpacaCredentials`
+/// `ALPACA_API_KEY_ID` and `ALPACA_API_SECRET` are non-empty. An `AlpacaCredentials`
 /// in scope is proof that both values were present at initialization.
 #[derive(Clone)]
 pub struct AlpacaCredentials {
@@ -25,11 +25,11 @@ pub struct AlpacaCredentials {
 impl AlpacaCredentials {
     /// Reads credentials from environment variables.
     ///
-    /// Returns `None` if either `ALPACA_KEY_ID` or `ALPACA_SECRET` is absent or empty.
+    /// Returns `None` if either `ALPACA_API_KEY_ID` or `ALPACA_API_SECRET` is absent or empty.
     /// The `ALPACA_FEED` variable defaults to `"iex"` if not set.
     pub fn from_env() -> Option<Self> {
-        let key_id = std::env::var("ALPACA_KEY_ID").unwrap_or_default();
-        let secret = std::env::var("ALPACA_SECRET").unwrap_or_default();
+        let key_id = std::env::var("ALPACA_API_KEY_ID").unwrap_or_default();
+        let secret = std::env::var("ALPACA_API_SECRET").unwrap_or_default();
         if key_id.is_empty() || secret.is_empty() {
             return None;
         }
@@ -268,21 +268,21 @@ mod tests {
     fn test_alpaca_credentials_from_env_returns_none_when_key_id_missing() {
         // SAFETY: protected by serial test runner conventions; env mutation is
         // scoped to the test process.
-        let original_key = std::env::var("ALPACA_KEY_ID").ok();
-        let original_secret = std::env::var("ALPACA_SECRET").ok();
+        let original_key = std::env::var("ALPACA_API_KEY_ID").ok();
+        let original_secret = std::env::var("ALPACA_API_SECRET").ok();
         unsafe {
-            std::env::remove_var("ALPACA_KEY_ID");
-            std::env::set_var("ALPACA_SECRET", "test-secret");
+            std::env::remove_var("ALPACA_API_KEY_ID");
+            std::env::set_var("ALPACA_API_SECRET", "test-secret");
         }
         let result = AlpacaCredentials::from_env();
         unsafe {
             match original_key {
-                Some(v) => std::env::set_var("ALPACA_KEY_ID", v),
-                None => std::env::remove_var("ALPACA_KEY_ID"),
+                Some(v) => std::env::set_var("ALPACA_API_KEY_ID", v),
+                None => std::env::remove_var("ALPACA_API_KEY_ID"),
             }
             match original_secret {
-                Some(v) => std::env::set_var("ALPACA_SECRET", v),
-                None => std::env::remove_var("ALPACA_SECRET"),
+                Some(v) => std::env::set_var("ALPACA_API_SECRET", v),
+                None => std::env::remove_var("ALPACA_API_SECRET"),
             }
         }
         assert!(result.is_none());
@@ -291,21 +291,21 @@ mod tests {
     #[test]
     #[serial]
     fn test_alpaca_credentials_from_env_returns_none_when_secret_missing() {
-        let original_key = std::env::var("ALPACA_KEY_ID").ok();
-        let original_secret = std::env::var("ALPACA_SECRET").ok();
+        let original_key = std::env::var("ALPACA_API_KEY_ID").ok();
+        let original_secret = std::env::var("ALPACA_API_SECRET").ok();
         unsafe {
-            std::env::set_var("ALPACA_KEY_ID", "test-key");
-            std::env::remove_var("ALPACA_SECRET");
+            std::env::set_var("ALPACA_API_KEY_ID", "test-key");
+            std::env::remove_var("ALPACA_API_SECRET");
         }
         let result = AlpacaCredentials::from_env();
         unsafe {
             match original_key {
-                Some(v) => std::env::set_var("ALPACA_KEY_ID", v),
-                None => std::env::remove_var("ALPACA_KEY_ID"),
+                Some(v) => std::env::set_var("ALPACA_API_KEY_ID", v),
+                None => std::env::remove_var("ALPACA_API_KEY_ID"),
             }
             match original_secret {
-                Some(v) => std::env::set_var("ALPACA_SECRET", v),
-                None => std::env::remove_var("ALPACA_SECRET"),
+                Some(v) => std::env::set_var("ALPACA_API_SECRET", v),
+                None => std::env::remove_var("ALPACA_API_SECRET"),
             }
         }
         assert!(result.is_none());
@@ -314,23 +314,23 @@ mod tests {
     #[test]
     #[serial]
     fn test_alpaca_credentials_feed_defaults_to_iex() {
-        let original_key = std::env::var("ALPACA_KEY_ID").ok();
-        let original_secret = std::env::var("ALPACA_SECRET").ok();
+        let original_key = std::env::var("ALPACA_API_KEY_ID").ok();
+        let original_secret = std::env::var("ALPACA_API_SECRET").ok();
         let original_feed = std::env::var("ALPACA_FEED").ok();
         unsafe {
-            std::env::set_var("ALPACA_KEY_ID", "test-key");
-            std::env::set_var("ALPACA_SECRET", "test-secret");
+            std::env::set_var("ALPACA_API_KEY_ID", "test-key");
+            std::env::set_var("ALPACA_API_SECRET", "test-secret");
             std::env::remove_var("ALPACA_FEED");
         }
         let credentials = AlpacaCredentials::from_env().unwrap();
         unsafe {
             match original_key {
-                Some(v) => std::env::set_var("ALPACA_KEY_ID", v),
-                None => std::env::remove_var("ALPACA_KEY_ID"),
+                Some(v) => std::env::set_var("ALPACA_API_KEY_ID", v),
+                None => std::env::remove_var("ALPACA_API_KEY_ID"),
             }
             match original_secret {
-                Some(v) => std::env::set_var("ALPACA_SECRET", v),
-                None => std::env::remove_var("ALPACA_SECRET"),
+                Some(v) => std::env::set_var("ALPACA_API_SECRET", v),
+                None => std::env::remove_var("ALPACA_API_SECRET"),
             }
             match original_feed {
                 Some(v) => std::env::set_var("ALPACA_FEED", v),

--- a/src/portfolio_manager/state.rs
+++ b/src/portfolio_manager/state.rs
@@ -132,9 +132,9 @@ impl AppState {
     ///
     /// Required environment variables:
     /// - `DATABASE_URL`: PostgreSQL connection string
-    /// - `ALPACA_KEY_ID`: Alpaca API key identifier
-    /// - `ALPACA_SECRET`: Alpaca API secret key
-    /// - `IS_PAPER` (optional): `"true"` for paper trading; defaults to `"true"` for safety
+    /// - `ALPACA_API_KEY_ID`: Alpaca API key identifier
+    /// - `ALPACA_API_SECRET`: Alpaca API secret key
+    /// - `ALPACA_IS_PAPER` (optional): `"true"` for paper trading; defaults to `"true"` for safety
     ///
     /// Returns `Err` if any required variable is absent or the database pool
     /// cannot be created.
@@ -151,18 +151,18 @@ impl AppState {
                 message: format!("Failed to connect to PostgreSQL: {error}"),
             })?;
 
-        let key_id = env::var("ALPACA_KEY_ID").map_err(|_| ConfigError {
-            message: "ALPACA_KEY_ID environment variable is not set".to_string(),
+        let key_id = env::var("ALPACA_API_KEY_ID").map_err(|_| ConfigError {
+            message: "ALPACA_API_KEY_ID environment variable is not set".to_string(),
         })?;
-        let secret = env::var("ALPACA_SECRET").map_err(|_| ConfigError {
-            message: "ALPACA_SECRET environment variable is not set".to_string(),
+        let secret = env::var("ALPACA_API_SECRET").map_err(|_| ConfigError {
+            message: "ALPACA_API_SECRET environment variable is not set".to_string(),
         })?;
 
         let credentials = AlpacaCredentials::new(key_id, secret)
             .map_err(|error| ConfigError { message: error })?;
 
         // Default to paper trading for safety; require explicit opt-in for live.
-        let is_paper = env::var("IS_PAPER")
+        let is_paper = env::var("ALPACA_IS_PAPER")
             .map(|value| !value.eq_ignore_ascii_case("false"))
             .unwrap_or(true);
 
@@ -252,7 +252,7 @@ mod tests {
     fn test_from_env_fails_without_alpaca_key_id() {
         unsafe {
             env::set_var("DATABASE_URL", "postgresql://localhost:5432/nonexistent");
-            env::remove_var("ALPACA_KEY_ID");
+            env::remove_var("ALPACA_API_KEY_ID");
         }
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -260,7 +260,7 @@ mod tests {
             .unwrap();
         runtime.block_on(async {
             let result = AppState::from_env().await;
-            // Fails either at DB connect or at ALPACA_KEY_ID — both are errors.
+            // Fails either at DB connect or at ALPACA_API_KEY_ID — both are errors.
             assert!(result.is_err());
         });
         unsafe {


### PR DESCRIPTION
This pull request standardizes the environment variable names used for Alpaca API credentials across the codebase. All references to `ALPACA_KEY_ID` and `ALPACA_SECRET` are updated to `ALPACA_API_KEY_ID` and `ALPACA_API_SECRET`, respectively. Additionally, the optional paper trading environment variable is renamed from `IS_PAPER` to `ALPACA_IS_PAPER`. These changes affect both application logic and tests to ensure consistency and prevent configuration errors.

**Alpaca credentials environment variable updates:**

* All code and documentation references to `ALPACA_KEY_ID` and `ALPACA_SECRET` are renamed to `ALPACA_API_KEY_ID` and `ALPACA_API_SECRET` in `src/common/alpaca.rs`, `src/data_manager/state.rs`, and `src/portfolio_manager/state.rs`, including all related tests. [[1]](diffhunk://#diff-3b4e96b80c4f7b366b459ee4d0474602661be4a369cc15f6c066155911d60292L29-R35) [[2]](diffhunk://#diff-1c878bc5e3856abc8d8a5aeadf6fa5601cfb6befe96527931e579981f635db52L16-R16) [[3]](diffhunk://#diff-1c878bc5e3856abc8d8a5aeadf6fa5601cfb6befe96527931e579981f635db52L28-R32) [[4]](diffhunk://#diff-3bd91e9dcfd78850357e7594bc809bee2f50fce4387314e630d1c2742771c8c2L154-R165) [[5]](diffhunk://#diff-3b4e96b80c4f7b366b459ee4d0474602661be4a369cc15f6c066155911d60292L88-R94) [[6]](diffhunk://#diff-3b4e96b80c4f7b366b459ee4d0474602661be4a369cc15f6c066155911d60292L103-R106) [[7]](diffhunk://#diff-4de75448d0f0b132da159eae9f69b6e0a8a7dac221b18df3a33b28911e80c60fL60-R61) [[8]](diffhunk://#diff-4de75448d0f0b132da159eae9f69b6e0a8a7dac221b18df3a33b28911e80c60fL74-R75) [[9]](diffhunk://#diff-a1903177d18005c7cfc251682787d87e93f6deb9c91365682a728efc75957bc2L201-R203) [[10]](diffhunk://#diff-1c878bc5e3856abc8d8a5aeadf6fa5601cfb6befe96527931e579981f635db52L271-R285) [[11]](diffhunk://#diff-1c878bc5e3856abc8d8a5aeadf6fa5601cfb6befe96527931e579981f635db52L294-R308) [[12]](diffhunk://#diff-1c878bc5e3856abc8d8a5aeadf6fa5601cfb6befe96527931e579981f635db52L317-R333) [[13]](diffhunk://#diff-3bd91e9dcfd78850357e7594bc809bee2f50fce4387314e630d1c2742771c8c2L255-R263)

* Documentation and logic for the optional paper trading variable are updated to use `ALPACA_IS_PAPER` instead of `IS_PAPER` in `src/portfolio_manager/state.rs`. [[1]](diffhunk://#diff-3bd91e9dcfd78850357e7594bc809bee2f50fce4387314e630d1c2742771c8c2L135-R137) [[2]](diffhunk://#diff-3bd91e9dcfd78850357e7594bc809bee2f50fce4387314e630d1c2742771c8c2L154-R165)

These updates ensure that environment variable usage is consistent and less error-prone throughout the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed Alpaca API environment variables: `ALPACA_API_KEY_ID` and `ALPACA_API_SECRET` (previously `ALPACA_KEY_ID` and `ALPACA_SECRET`), and `ALPACA_IS_PAPER` (previously `IS_PAPER`). Update your environment configuration to use the new variable names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->