### PR TITLE
Add `dashboard_service` TUI views

### DIFF
--- a/src/common/observability.rs
+++ b/src/common/observability.rs
@@ -20,6 +20,10 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 /// non-blocking file writer and buffered lines would be lost. Returns `None`
 /// when file logging is disabled. Uses `try_init`, so calling this more than
 /// once (e.g. across tests) is a no-op rather than a panic.
+///
+/// Services that own stdout for terminal rendering (e.g. the dashboard TUI)
+/// should call [`init_tracing_file_only`] instead to avoid corrupting the
+/// alternate screen with JSON log output.
 pub fn init_tracing(log_file: &str, file_filter: Option<&str>) -> Option<WorkerGuard> {
     let fund_profile = env::var("FUND_PROFILE").unwrap_or_else(|_| "unknown".to_string());
 
@@ -64,6 +68,49 @@ pub fn init_tracing(log_file: &str, file_filter: Option<&str>) -> Option<WorkerG
                 .with(stdout_layer)
                 .try_init()
                 .ok();
+            None
+        }
+    };
+
+    tracing::info!(fund_profile = %fund_profile, "Tracing initialized");
+    guard
+}
+
+/// Initialize structured JSON tracing to a file only, with no stdout output.
+///
+/// Identical to [`init_tracing`] except the stdout layer is omitted. Use this
+/// for services that own stdout for terminal rendering (e.g. the dashboard TUI)
+/// where writing JSON to stdout would corrupt the alternate screen buffer.
+///
+/// When the log directory is not writable, tracing is silently disabled rather
+/// than falling back to stdout.
+pub fn init_tracing_file_only(log_file: &str) -> Option<WorkerGuard> {
+    let fund_profile = env::var("FUND_PROFILE").unwrap_or_else(|_| "unknown".to_string());
+
+    let log_dir = env::var("FUND_LOG_DIR").unwrap_or_else(|_| "/var/log/fund".to_string());
+    let guard = match std::fs::create_dir_all(&log_dir) {
+        Ok(()) => {
+            let file_appender = tracing_appender::rolling::daily(log_dir, log_file);
+            let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+            let file_layer = tracing_subscriber::fmt::layer()
+                .json()
+                .with_writer(non_blocking)
+                .with_filter(
+                    tracing_subscriber::EnvFilter::try_from_default_env()
+                        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+                );
+            let initialized = tracing_subscriber::registry()
+                .with(file_layer)
+                .try_init()
+                .is_ok();
+            if initialized {
+                Some(guard)
+            } else {
+                None
+            }
+        }
+        Err(_) => {
+            tracing_subscriber::registry().try_init().ok();
             None
         }
     };

--- a/src/common/observability.rs
+++ b/src/common/observability.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
 /// Initialize structured JSON tracing for a service.
@@ -34,9 +35,14 @@ pub fn init_tracing(log_file: &str, file_filter: Option<&str>) -> Option<WorkerG
     };
 
     let log_dir = env::var("FUND_LOG_DIR").unwrap_or_else(|_| "/var/log/fund".to_string());
-    let guard = match std::fs::create_dir_all(&log_dir) {
-        Ok(()) => {
-            let file_appender = tracing_appender::rolling::daily(log_dir, log_file);
+    let guard = match std::fs::create_dir_all(&log_dir).and_then(|()| {
+        RollingFileAppender::builder()
+            .rotation(Rotation::DAILY)
+            .filename_suffix(log_file)
+            .build(&log_dir)
+            .map_err(std::io::Error::other)
+    }) {
+        Ok(file_appender) => {
             let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
             let file_layer = tracing_subscriber::fmt::layer()
                 .json()
@@ -62,7 +68,7 @@ pub fn init_tracing(log_file: &str, file_filter: Option<&str>) -> Option<WorkerG
             }
         }
         Err(error) => {
-            eprintln!("File logging disabled, cannot create {log_dir:?}: {error}");
+            eprintln!("File logging disabled: {error}");
             tracing_subscriber::registry()
                 .with(global_filter())
                 .with(stdout_layer)
@@ -88,9 +94,14 @@ pub fn init_tracing_file_only(log_file: &str) -> Option<WorkerGuard> {
     let fund_profile = env::var("FUND_PROFILE").unwrap_or_else(|_| "unknown".to_string());
 
     let log_dir = env::var("FUND_LOG_DIR").unwrap_or_else(|_| "/var/log/fund".to_string());
-    let guard = match std::fs::create_dir_all(&log_dir) {
-        Ok(()) => {
-            let file_appender = tracing_appender::rolling::daily(log_dir, log_file);
+    let guard = match std::fs::create_dir_all(&log_dir).and_then(|()| {
+        RollingFileAppender::builder()
+            .rotation(Rotation::DAILY)
+            .filename_suffix(log_file)
+            .build(&log_dir)
+            .map_err(std::io::Error::other)
+    }) {
+        Ok(file_appender) => {
             let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
             let file_layer = tracing_subscriber::fmt::layer()
                 .json()

--- a/src/dashboard_service.rs
+++ b/src/dashboard_service.rs
@@ -16,11 +16,16 @@
 pub mod application;
 pub mod cache;
 pub mod database;
+pub mod events;
+pub mod performance;
+pub mod positions;
+pub mod predictions;
+pub mod trades;
 
 use sqlx::postgres::PgPoolOptions;
 use tracing::info;
 
-use crate::common::observability::init_tracing;
+use crate::common::observability::init_tracing_file_only;
 
 /// Maximum number of Postgres connections the dashboard pool may open.
 ///
@@ -33,7 +38,7 @@ const POOL_MAX_CONNECTIONS: u32 = 4;
 ///
 /// Panics on startup if `DATABASE_URL` is unset or the database is unreachable.
 pub async fn run() {
-    let _tracing_guard = init_tracing("dashboard-service.log", None);
+    let _tracing_guard = init_tracing_file_only("dashboard-service.log");
     info!("Starting dashboard service");
 
     let database_url =

--- a/src/dashboard_service/application.rs
+++ b/src/dashboard_service/application.rs
@@ -20,6 +20,11 @@ use ratatui::Terminal;
 use tracing::{error, info};
 
 use crate::dashboard_service::cache::{DashboardState, SharedState};
+use crate::dashboard_service::events::{render_events, EventsViewState};
+use crate::dashboard_service::performance::render_performance;
+use crate::dashboard_service::positions::render_positions;
+use crate::dashboard_service::predictions::render_predictions;
+use crate::dashboard_service::trades::render_trades;
 
 /// Minimum terminal width required to render the dashboard layout.
 const MINIMUM_TERMINAL_WIDTH: u16 = 80;
@@ -81,9 +86,10 @@ impl Tab {
     }
 }
 
-/// Top-level application state: the currently selected tab.
+/// Top-level application state: the currently selected tab and per-tab view state.
 pub struct Application {
     pub current_tab: Tab,
+    pub events_state: EventsViewState,
 }
 
 impl Application {
@@ -91,7 +97,14 @@ impl Application {
     pub fn new() -> Self {
         Self {
             current_tab: Tab::Positions,
+            events_state: EventsViewState::new(),
         }
+    }
+}
+
+impl Default for Application {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -134,26 +147,31 @@ async fn event_loop_inner(
     let mut app = Application::new();
     loop {
         let dashboard = state.read().await;
-        terminal.draw(|frame| render(frame, &app, &*dashboard))?;
+        terminal.draw(|frame| render(frame, &app, &dashboard))?;
         drop(dashboard);
 
         let polled = tokio::task::spawn_blocking(|| event::poll(INPUT_POLL_INTERVAL))
             .await
-            .map_err(|error| io::Error::new(io::ErrorKind::Other, error))??;
+            .map_err(io::Error::other)??;
 
         if polled {
             let input_event = tokio::task::spawn_blocking(event::read)
                 .await
-                .map_err(|error| io::Error::new(io::ErrorKind::Other, error))??;
+                .map_err(io::Error::other)??;
 
+            #[allow(clippy::single_match)]
             match input_event {
                 Event::Key(key) => {
                     if should_quit(key) {
                         break;
                     }
-                    match key_to_tab(key) {
-                        Some(tab) => app.current_tab = tab,
-                        None => {}
+                    match (app.current_tab, key.code) {
+                        (Tab::Events, KeyCode::Char('f')) => app.events_state.cycle_filter(),
+                        #[allow(clippy::single_match)]
+                        _ => match key_to_tab(key) {
+                            Some(tab) => app.current_tab = tab,
+                            None => {}
+                        },
                     }
                 }
                 _ => {}
@@ -195,7 +213,7 @@ pub fn render(frame: &mut ratatui::Frame, app: &Application, state: &DashboardSt
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(1), // header
-            Constraint::Length(3), // tab bar
+            Constraint::Length(2), // tab bar (labels + bottom border)
             Constraint::Min(0),    // content area
             Constraint::Length(1), // footer
         ])
@@ -204,7 +222,7 @@ pub fn render(frame: &mut ratatui::Frame, app: &Application, state: &DashboardSt
     render_header(frame, chunks[0], state);
     render_tab_bar(frame, chunks[1], app);
     render_content(frame, chunks[2], app, state);
-    render_footer(frame, chunks[3]);
+    render_footer(frame, chunks[3], app);
 }
 
 /// Renders the single-line header: fund name and last-updated timestamp.
@@ -238,58 +256,51 @@ fn render_tab_bar(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, app: 
     frame.render_widget(tab_bar, area);
 }
 
-/// Renders a placeholder content area for the currently selected tab.
+/// Renders the content area for the currently selected tab.
 ///
-/// Full per-tab rendering is implemented in PR 2. Until then, the content
-/// area shows either a database error or a "loading" / placeholder message.
+/// Shows a loading or error overlay until the first successful poll. Once data
+/// is available, dispatches to the appropriate view renderer. Stale data is
+/// shown normally; the header timestamp communicates freshness.
 fn render_content(
     frame: &mut ratatui::Frame,
     area: ratatui::layout::Rect,
     app: &Application,
     state: &DashboardState,
 ) {
-    let text = match &state.database_error {
-        Some(error) => format!(
-            "Data unavailable — database error: {}\n\nLast successful update: {}",
-            error,
-            state
-                .last_updated
-                .map(|time| time.format("%Y-%m-%d %H:%M:%S UTC").to_string())
-                .unwrap_or_else(|| "never".to_string()),
-        ),
-        None => {
-            if state.last_updated.is_none() {
-                "Loading data...".to_string()
-            } else {
-                let tab_name = match app.current_tab {
-                    Tab::Positions => "Positions",
-                    Tab::Performance => "Performance",
-                    Tab::Trades => "Trades",
-                    Tab::Predictions => "Predictions",
-                    Tab::Events => "Events",
-                };
-                format!("{tab_name} — rendering coming in PR 2")
-            }
-        }
-    };
+    if state.last_updated.is_none() {
+        let text = match &state.database_error {
+            Some(error) => format!("Data unavailable — database error: {error}"),
+            None => "Loading data...".to_string(),
+        };
+        let overlay = Paragraph::new(text)
+            .block(Block::default().borders(Borders::ALL))
+            .style(Style::default().fg(Color::Gray));
+        frame.render_widget(overlay, area);
+        return;
+    }
 
-    let content = Paragraph::new(text)
-        .block(Block::default().borders(Borders::ALL))
-        .style(Style::default().fg(Color::Gray));
-    frame.render_widget(content, area);
+    match app.current_tab {
+        Tab::Positions => render_positions(frame, area, state),
+        Tab::Performance => render_performance(frame, area, state),
+        Tab::Trades => render_trades(frame, area, state),
+        Tab::Predictions => render_predictions(frame, area, state),
+        Tab::Events => render_events(frame, area, state, &app.events_state),
+    }
 }
 
 /// Renders the single-line footer with keybind hints.
-fn render_footer(frame: &mut ratatui::Frame, area: ratatui::layout::Rect) {
-    let footer = Paragraph::new(Line::from(vec![
-        Span::raw("1-5 switch tabs  "),
-        Span::raw("q quit  "),
-        Span::styled(
-            "ssh dashboard.oscm.company",
-            Style::default().fg(Color::DarkGray),
-        ),
-    ]))
-    .style(Style::default().fg(Color::DarkGray));
+///
+/// Shows an additional `f filter` hint when the Events tab is active.
+fn render_footer(frame: &mut ratatui::Frame, area: ratatui::layout::Rect, app: &Application) {
+    let mut spans = vec![Span::raw("1-5 switch tabs  "), Span::raw("q quit  ")];
+    if app.current_tab == Tab::Events {
+        spans.push(Span::raw("f filter  "));
+    }
+    spans.push(Span::styled(
+        "ssh dashboard.oscm.company",
+        Style::default().fg(Color::DarkGray),
+    ));
+    let footer = Paragraph::new(Line::from(spans)).style(Style::default().fg(Color::DarkGray));
     frame.render_widget(footer, area);
 }
 
@@ -441,13 +452,32 @@ mod tests {
     }
 
     #[test]
-    fn test_render_shows_database_error() {
+    fn test_render_shows_database_error_before_first_poll() {
         let app = Application::new();
         let mut state = DashboardState::default();
         state.database_error = Some("connection refused".to_string());
+        // last_updated is still None → overlay shown
         let output = render_to_string(120, 40, &app, &state);
         assert!(output.contains("database error"));
         assert!(output.contains("connection refused"));
+    }
+
+    #[test]
+    fn test_render_footer_shows_filter_hint_on_events_tab() {
+        let mut app = Application::new();
+        app.current_tab = Tab::Events;
+        let state = DashboardState::default();
+        let output = render_to_string(120, 40, &app, &state);
+        assert!(output.contains("filter"));
+    }
+
+    #[test]
+    fn test_render_footer_no_filter_hint_on_positions_tab() {
+        let app = Application::new(); // Positions tab
+        let state = DashboardState::default();
+        let output = render_to_string(120, 40, &app, &state);
+        // "filter" should not appear in footer on non-Events tabs
+        assert!(!output.contains("filter"));
     }
 
     #[test]

--- a/src/dashboard_service/cache.rs
+++ b/src/dashboard_service/cache.rs
@@ -92,6 +92,24 @@ pub struct PredictionRow {
     pub timestamp: DateTime<Utc>,
 }
 
+/// Pre-computed period returns for the Performance view (Tab 2).
+///
+/// All values are percentages (e.g. `5.0` means +5%). `None` indicates
+/// insufficient snapshot history for that horizon.
+#[derive(Debug, Clone, Default)]
+pub struct PeriodReturns {
+    pub fund_one_day: Option<f64>,
+    pub fund_one_week: Option<f64>,
+    pub fund_one_month: Option<f64>,
+    pub fund_year_to_date: Option<f64>,
+    pub fund_since_inception: Option<f64>,
+    pub spy_one_day: Option<f64>,
+    pub spy_one_week: Option<f64>,
+    pub spy_one_month: Option<f64>,
+    pub spy_year_to_date: Option<f64>,
+    pub spy_since_inception: Option<f64>,
+}
+
 /// A single event received from the Postgres `events` NOTIFY channel (Tab 5).
 #[derive(Debug, Clone)]
 pub struct EventEntry {
@@ -122,6 +140,8 @@ pub struct DashboardState {
     pub closed_trades_summary: ClosedTradesSummary,
     /// Latest model quantile predictions, sorted by ticker (Tab 4).
     pub predictions: Vec<PredictionRow>,
+    /// Pre-computed period returns for the Performance view (Tab 2).
+    pub period_returns: PeriodReturns,
     /// Bounded event ring buffer, newest first (Tab 5).
     pub events: VecDeque<EventEntry>,
     /// Timestamp of the most recent successful poll. `None` until first poll completes.
@@ -150,6 +170,7 @@ pub fn spawn_polling_task(state: SharedState, pool: PgPool) {
                     guard.gross_exposure = data.gross_exposure;
                     guard.net_exposure = data.net_exposure;
                     guard.performance_history = data.performance_history;
+                    guard.period_returns = data.period_returns;
                     guard.closed_trades = data.closed_trades;
                     guard.closed_trades_summary = data.closed_trades_summary;
                     guard.predictions = data.predictions;

--- a/src/dashboard_service/database.rs
+++ b/src/dashboard_service/database.rs
@@ -4,13 +4,14 @@
 //! dashboard connects to production with a read-only user whose schema
 //! matches the live database, not the local `.sqlx` cache.
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Datelike, Duration, TimeZone, Utc};
 use num_traits::ToPrimitive;
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Row};
 
 use crate::dashboard_service::cache::{
-    ClosedTrade, ClosedTradesSummary, OpenPosition, PerformanceSnapshot, PredictionRow,
+    ClosedTrade, ClosedTradesSummary, OpenPosition, PerformanceSnapshot, PeriodReturns,
+    PredictionRow,
 };
 
 /// How many days of performance snapshot history to fetch for Tab 2.
@@ -25,6 +26,7 @@ pub struct DashboardData {
     pub gross_exposure: Decimal,
     pub net_exposure: Decimal,
     pub performance_history: Vec<PerformanceSnapshot>,
+    pub period_returns: PeriodReturns,
     pub closed_trades: Vec<ClosedTrade>,
     pub closed_trades_summary: ClosedTradesSummary,
     pub predictions: Vec<PredictionRow>,
@@ -39,6 +41,7 @@ pub async fn fetch_dashboard_data(pool: &PgPool) -> Result<DashboardData, sqlx::
     let open_positions = fetch_open_positions(pool).await?;
     let (gross_exposure, net_exposure) = compute_exposures(&open_positions);
     let performance_history = fetch_performance_history(pool).await?;
+    let period_returns = compute_period_returns(&performance_history);
     let closed_trades = fetch_closed_trades(pool).await?;
     let closed_trades_summary = compute_closed_trades_summary(&closed_trades);
     let predictions = fetch_latest_predictions(pool).await?;
@@ -48,6 +51,7 @@ pub async fn fetch_dashboard_data(pool: &PgPool) -> Result<DashboardData, sqlx::
         gross_exposure,
         net_exposure,
         performance_history,
+        period_returns,
         closed_trades,
         closed_trades_summary,
         predictions,
@@ -306,6 +310,93 @@ async fn fetch_latest_predictions(pool: &PgPool) -> Result<Vec<PredictionRow>, s
         .collect()
 }
 
+/// Returns the first snapshot (newest-to-oldest order) whose timestamp is at or
+/// before `cutoff`, giving the most recent baseline for a return period.
+fn find_snapshot_at_or_before(
+    history: &[PerformanceSnapshot],
+    cutoff: DateTime<Utc>,
+) -> Option<&PerformanceSnapshot> {
+    history
+        .iter()
+        .find(|snapshot| snapshot.snapshot_timestamp <= cutoff)
+}
+
+/// Computes the percentage return from `baseline` NAV to `current_nav`.
+///
+/// Returns `None` when baseline NAV converts to zero (division guard).
+fn nav_period_return(current_nav: f64, baseline: &PerformanceSnapshot) -> Option<f64> {
+    let base_nav = baseline.net_asset_value.to_f64()?;
+    if base_nav == 0.0 {
+        return None;
+    }
+    Some((current_nav - base_nav) / base_nav * 100.0)
+}
+
+/// Computes the percentage return from `baseline` SPY close to `current_spy`.
+///
+/// Returns `None` when either close price is absent or baseline is zero.
+fn spy_period_return(current_spy: f64, baseline: &PerformanceSnapshot) -> Option<f64> {
+    let base_spy = baseline.spy_close?;
+    if base_spy == 0.0 {
+        return None;
+    }
+    Some((current_spy - base_spy) / base_spy * 100.0)
+}
+
+/// Computes period returns from the cached snapshot history.
+///
+/// `history` is expected to be sorted newest-first (matching the query
+/// `ORDER BY snapshot_timestamp DESC`). Returns are expressed as percentages.
+/// Any period for which no baseline snapshot exists returns `None`.
+pub fn compute_period_returns(history: &[PerformanceSnapshot]) -> PeriodReturns {
+    if history.is_empty() {
+        return PeriodReturns::default();
+    }
+
+    let current = &history[0];
+    let Some(current_nav) = current.net_asset_value.to_f64() else {
+        return PeriodReturns::default();
+    };
+    if current_nav == 0.0 {
+        return PeriodReturns::default();
+    }
+
+    let now = current.snapshot_timestamp;
+    let one_day_cutoff = now - Duration::days(1);
+    let one_week_cutoff = now - Duration::weeks(1);
+    let one_month_cutoff = now - Duration::days(30);
+    let year_start_cutoff = Utc
+        .with_ymd_and_hms(now.year(), 1, 1, 0, 0, 0)
+        .single()
+        .unwrap_or(now);
+
+    let baseline_1d = find_snapshot_at_or_before(history, one_day_cutoff);
+    let baseline_1w = find_snapshot_at_or_before(history, one_week_cutoff);
+    let baseline_1m = find_snapshot_at_or_before(history, one_month_cutoff);
+    let baseline_ytd = find_snapshot_at_or_before(history, year_start_cutoff);
+    let inception = history.last();
+
+    let current_spy = current.spy_close;
+
+    PeriodReturns {
+        fund_one_day: baseline_1d.and_then(|b| nav_period_return(current_nav, b)),
+        fund_one_week: baseline_1w.and_then(|b| nav_period_return(current_nav, b)),
+        fund_one_month: baseline_1m.and_then(|b| nav_period_return(current_nav, b)),
+        fund_year_to_date: baseline_ytd.and_then(|b| nav_period_return(current_nav, b)),
+        fund_since_inception: inception.and_then(|b| nav_period_return(current_nav, b)),
+        spy_one_day: current_spy
+            .and_then(|spy| baseline_1d.and_then(|b| spy_period_return(spy, b))),
+        spy_one_week: current_spy
+            .and_then(|spy| baseline_1w.and_then(|b| spy_period_return(spy, b))),
+        spy_one_month: current_spy
+            .and_then(|spy| baseline_1m.and_then(|b| spy_period_return(spy, b))),
+        spy_year_to_date: current_spy
+            .and_then(|spy| baseline_ytd.and_then(|b| spy_period_return(spy, b))),
+        spy_since_inception: current_spy
+            .and_then(|spy| inception.and_then(|b| spy_period_return(spy, b))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -475,5 +566,116 @@ mod tests {
         assert_eq!(summary.total_closed, 2);
         assert!(summary.average_holding_seconds.is_none());
         assert_eq!(summary.average_return_percent, Some(0.5));
+    }
+
+    /// Builds a snapshot at an exact offset from a shared `now` so that all
+    /// timestamps in a single test are derived from the same instant. This
+    /// prevents the race where two `Utc::now()` calls return slightly different
+    /// values, causing a baseline snapshot to appear microseconds newer than
+    /// the period cutoff and therefore not be found by
+    /// `find_snapshot_at_or_before`.
+    fn make_snapshot(
+        now: DateTime<Utc>,
+        days_ago: i64,
+        nav: i64,
+        spy: Option<f64>,
+    ) -> PerformanceSnapshot {
+        PerformanceSnapshot {
+            snapshot_timestamp: now - Duration::days(days_ago),
+            net_asset_value: Decimal::new(nav, 0),
+            gross_return: None,
+            net_return: None,
+            total_slippage_cost: Decimal::ZERO,
+            spy_close: spy,
+        }
+    }
+
+    #[test]
+    fn test_compute_period_returns_empty_history() {
+        let returns = compute_period_returns(&[]);
+        assert!(returns.fund_one_day.is_none());
+        assert!(returns.fund_one_week.is_none());
+        assert!(returns.fund_since_inception.is_none());
+        assert!(returns.spy_one_day.is_none());
+    }
+
+    #[test]
+    fn test_compute_period_returns_single_snapshot() {
+        // Only one snapshot — it's both current and inception.
+        // since_inception baseline is history.last() == history[0] == current.
+        // (current - current) / current = 0%
+        let now = Utc::now();
+        let history = vec![make_snapshot(now, 0, 100_000, Some(450.0))];
+        let returns = compute_period_returns(&history);
+        assert_eq!(returns.fund_since_inception, Some(0.0));
+        // No older snapshots → other periods are None.
+        assert!(returns.fund_one_day.is_none());
+        assert!(returns.fund_one_week.is_none());
+    }
+
+    #[test]
+    fn test_compute_period_returns_one_day() {
+        // Current = 110_000, 1-day baseline = 100_000 → 10%
+        let now = Utc::now();
+        let history = vec![
+            make_snapshot(now, 0, 110_000, Some(455.0)),
+            make_snapshot(now, 1, 100_000, Some(450.0)),
+        ];
+        let returns = compute_period_returns(&history);
+        let one_day = returns.fund_one_day.expect("fund_one_day should be Some");
+        assert!((one_day - 10.0).abs() < 1e-9, "expected 10%, got {one_day}");
+    }
+
+    #[test]
+    fn test_compute_period_returns_spy_one_day() {
+        // SPY: current=455, baseline=450 → (455−450)/450×100 ≈ 1.111%
+        let now = Utc::now();
+        let history = vec![
+            make_snapshot(now, 0, 110_000, Some(455.0)),
+            make_snapshot(now, 1, 100_000, Some(450.0)),
+        ];
+        let returns = compute_period_returns(&history);
+        let spy = returns.spy_one_day.expect("spy_one_day should be Some");
+        assert!((spy - (5.0 / 450.0 * 100.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_compute_period_returns_since_inception() {
+        // Oldest snapshot = 80_000; current = 110_000 → 37.5%
+        let now = Utc::now();
+        let history = vec![
+            make_snapshot(now, 0, 110_000, None),
+            make_snapshot(now, 7, 105_000, None),
+            make_snapshot(now, 365, 80_000, None),
+        ];
+        let returns = compute_period_returns(&history);
+        let inception = returns
+            .fund_since_inception
+            .expect("fund_since_inception should be Some");
+        assert!((inception - 37.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_compute_period_returns_missing_spy_gives_none() {
+        let now = Utc::now();
+        let history = vec![
+            make_snapshot(now, 0, 110_000, None),
+            make_snapshot(now, 1, 100_000, None),
+        ];
+        let returns = compute_period_returns(&history);
+        assert!(returns.spy_one_day.is_none());
+        // Fund return is still computed even when SPY data is absent.
+        assert!(returns.fund_one_day.is_some());
+    }
+
+    #[test]
+    fn test_compute_period_returns_zero_baseline_nav_gives_none() {
+        let now = Utc::now();
+        let history = vec![
+            make_snapshot(now, 0, 110_000, None),
+            make_snapshot(now, 1, 0, None), // zero baseline NAV → division guard
+        ];
+        let returns = compute_period_returns(&history);
+        assert!(returns.fund_one_day.is_none());
     }
 }

--- a/src/dashboard_service/database.rs
+++ b/src/dashboard_service/database.rs
@@ -321,15 +321,15 @@ fn find_snapshot_at_or_before(
         .find(|snapshot| snapshot.snapshot_timestamp <= cutoff)
 }
 
-/// Computes the percentage return from `baseline` NAV to `current_nav`.
+/// Computes the percentage return from `baseline` NAV to `current_net_asset_value`.
 ///
 /// Returns `None` when baseline NAV converts to zero (division guard).
-fn nav_period_return(current_nav: f64, baseline: &PerformanceSnapshot) -> Option<f64> {
-    let base_nav = baseline.net_asset_value.to_f64()?;
-    if base_nav == 0.0 {
+fn nav_period_return(current_net_asset_value: f64, baseline: &PerformanceSnapshot) -> Option<f64> {
+    let baseline_net_asset_value = baseline.net_asset_value.to_f64()?;
+    if baseline_net_asset_value == 0.0 {
         return None;
     }
-    Some((current_nav - base_nav) / base_nav * 100.0)
+    Some((current_net_asset_value - baseline_net_asset_value) / baseline_net_asset_value * 100.0)
 }
 
 /// Computes the percentage return from `baseline` SPY close to `current_spy`.
@@ -354,10 +354,10 @@ pub fn compute_period_returns(history: &[PerformanceSnapshot]) -> PeriodReturns 
     }
 
     let current = &history[0];
-    let Some(current_nav) = current.net_asset_value.to_f64() else {
+    let Some(current_net_asset_value) = current.net_asset_value.to_f64() else {
         return PeriodReturns::default();
     };
-    if current_nav == 0.0 {
+    if current_net_asset_value == 0.0 {
         return PeriodReturns::default();
     }
 
@@ -370,28 +370,31 @@ pub fn compute_period_returns(history: &[PerformanceSnapshot]) -> PeriodReturns 
         .single()
         .unwrap_or(now);
 
-    let baseline_1d = find_snapshot_at_or_before(history, one_day_cutoff);
-    let baseline_1w = find_snapshot_at_or_before(history, one_week_cutoff);
-    let baseline_1m = find_snapshot_at_or_before(history, one_month_cutoff);
-    let baseline_ytd = find_snapshot_at_or_before(history, year_start_cutoff);
+    let baseline_one_day = find_snapshot_at_or_before(history, one_day_cutoff);
+    let baseline_one_week = find_snapshot_at_or_before(history, one_week_cutoff);
+    let baseline_one_month = find_snapshot_at_or_before(history, one_month_cutoff);
+    let baseline_year_to_date = find_snapshot_at_or_before(history, year_start_cutoff);
     let inception = history.last();
 
     let current_spy = current.spy_close;
 
     PeriodReturns {
-        fund_one_day: baseline_1d.and_then(|b| nav_period_return(current_nav, b)),
-        fund_one_week: baseline_1w.and_then(|b| nav_period_return(current_nav, b)),
-        fund_one_month: baseline_1m.and_then(|b| nav_period_return(current_nav, b)),
-        fund_year_to_date: baseline_ytd.and_then(|b| nav_period_return(current_nav, b)),
-        fund_since_inception: inception.and_then(|b| nav_period_return(current_nav, b)),
+        fund_one_day: baseline_one_day.and_then(|b| nav_period_return(current_net_asset_value, b)),
+        fund_one_week: baseline_one_week
+            .and_then(|b| nav_period_return(current_net_asset_value, b)),
+        fund_one_month: baseline_one_month
+            .and_then(|b| nav_period_return(current_net_asset_value, b)),
+        fund_year_to_date: baseline_year_to_date
+            .and_then(|b| nav_period_return(current_net_asset_value, b)),
+        fund_since_inception: inception.and_then(|b| nav_period_return(current_net_asset_value, b)),
         spy_one_day: current_spy
-            .and_then(|spy| baseline_1d.and_then(|b| spy_period_return(spy, b))),
+            .and_then(|spy| baseline_one_day.and_then(|b| spy_period_return(spy, b))),
         spy_one_week: current_spy
-            .and_then(|spy| baseline_1w.and_then(|b| spy_period_return(spy, b))),
+            .and_then(|spy| baseline_one_week.and_then(|b| spy_period_return(spy, b))),
         spy_one_month: current_spy
-            .and_then(|spy| baseline_1m.and_then(|b| spy_period_return(spy, b))),
+            .and_then(|spy| baseline_one_month.and_then(|b| spy_period_return(spy, b))),
         spy_year_to_date: current_spy
-            .and_then(|spy| baseline_ytd.and_then(|b| spy_period_return(spy, b))),
+            .and_then(|spy| baseline_year_to_date.and_then(|b| spy_period_return(spy, b))),
         spy_since_inception: current_spy
             .and_then(|spy| inception.and_then(|b| spy_period_return(spy, b))),
     }

--- a/src/dashboard_service/events.rs
+++ b/src/dashboard_service/events.rs
@@ -1,0 +1,375 @@
+//! Tab 5: real-time event feed with category filter.
+//!
+//! [`EventsViewState`] holds the active filter and is owned by [`super::application::Application`].
+//! [`render_events`] is the top-level render entry point called from the application event loop.
+
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+
+use crate::dashboard_service::cache::DashboardState;
+
+/// Category filter for the event feed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventsFilter {
+    All,
+    Trading,
+    Data,
+    Predictions,
+}
+
+impl EventsFilter {
+    /// Returns all filter variants in display order.
+    pub fn all() -> &'static [EventsFilter] {
+        &[
+            EventsFilter::All,
+            EventsFilter::Trading,
+            EventsFilter::Data,
+            EventsFilter::Predictions,
+        ]
+    }
+
+    /// Returns the display label for the filter.
+    pub fn label(self) -> &'static str {
+        match self {
+            EventsFilter::All => "All",
+            EventsFilter::Trading => "Trading",
+            EventsFilter::Data => "Data",
+            EventsFilter::Predictions => "Predictions",
+        }
+    }
+
+    /// Returns `true` if `event_type` matches this filter category.
+    pub fn matches(self, event_type: &str) -> bool {
+        match self {
+            EventsFilter::All => true,
+            EventsFilter::Trading => {
+                event_type.contains("portfolio")
+                    || event_type.contains("rebalance")
+                    || event_type.contains("liquidation")
+                    || event_type.contains("market_session")
+            }
+            EventsFilter::Data => {
+                event_type.contains("equity_bars")
+                    || event_type.contains("export")
+                    || event_type.contains("backup")
+                    || event_type.contains("database")
+            }
+            EventsFilter::Predictions => event_type.contains("prediction"),
+        }
+    }
+
+    /// Advances to the next filter in cycle order.
+    pub fn next(self) -> EventsFilter {
+        match self {
+            EventsFilter::All => EventsFilter::Trading,
+            EventsFilter::Trading => EventsFilter::Data,
+            EventsFilter::Data => EventsFilter::Predictions,
+            EventsFilter::Predictions => EventsFilter::All,
+        }
+    }
+}
+
+/// Per-tab state for the Events view: the active category filter.
+pub struct EventsViewState {
+    pub filter: EventsFilter,
+}
+
+impl Default for EventsViewState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EventsViewState {
+    /// Creates a new state with the `All` filter selected.
+    pub fn new() -> Self {
+        Self {
+            filter: EventsFilter::All,
+        }
+    }
+
+    /// Advances the filter to the next category.
+    pub fn cycle_filter(&mut self) {
+        self.filter = self.filter.next();
+    }
+}
+
+/// Renders Tab 5: a filter bar above the live event list.
+pub fn render_events(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+    events_state: &EventsViewState,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(2), Constraint::Min(0)])
+        .split(area);
+
+    render_filter_bar(frame, chunks[0], events_state);
+    render_event_list(frame, chunks[1], state, events_state);
+}
+
+/// Renders the horizontal filter bar showing each category option.
+fn render_filter_bar(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    events_state: &EventsViewState,
+) {
+    let spans: Vec<Span> = EventsFilter::all()
+        .iter()
+        .flat_map(|&filter| {
+            let style = if filter == events_state.filter {
+                Style::default()
+                    .add_modifier(Modifier::BOLD)
+                    .fg(Color::White)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+            [
+                Span::styled(format!("[{}]", filter.label()), style),
+                Span::raw("  "),
+            ]
+        })
+        .collect();
+
+    let bar = Paragraph::new(Line::from(spans)).style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(bar, area);
+}
+
+/// Renders the filtered event list from the ring buffer.
+fn render_event_list(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+    events_state: &EventsViewState,
+) {
+    let block = Block::default().title("Events").borders(Borders::ALL);
+
+    let items: Vec<ListItem> = state
+        .events
+        .iter()
+        .filter(|entry| events_state.filter.matches(&entry.event_type))
+        .map(|entry| {
+            let time = entry.received_at.format("%H:%M:%S").to_string();
+            let payload_summary = truncate_payload(&entry.payload);
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("{time}  "), Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!("{:<42}", entry.event_type),
+                    event_type_style(&entry.event_type),
+                ),
+                Span::styled(payload_summary, Style::default().fg(Color::DarkGray)),
+            ]))
+        })
+        .collect();
+
+    if items.is_empty() {
+        let message = match events_state.filter {
+            EventsFilter::All => "No events received yet",
+            _ => "No events match this filter",
+        };
+        let placeholder = Paragraph::new(message)
+            .block(block)
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(placeholder, area);
+        return;
+    }
+
+    let list = List::new(items).block(block);
+    frame.render_widget(list, area);
+}
+
+/// Returns a style based on the event outcome encoded in `event_type`.
+fn event_type_style(event_type: &str) -> Style {
+    if event_type.ends_with("errored") {
+        Style::default().fg(Color::Red)
+    } else if event_type.ends_with("completed") {
+        Style::default().fg(Color::Green)
+    } else if event_type.ends_with("started") || event_type.ends_with("requested") {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default()
+    }
+}
+
+/// Truncates a JSON payload to a short summary string.
+fn truncate_payload(payload: &serde_json::Value) -> String {
+    let serialized = payload.to_string();
+    if serialized.len() > 58 {
+        format!("{}…", &serialized[..57])
+    } else {
+        serialized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    use crate::dashboard_service::cache::{DashboardState, EventEntry};
+
+    fn render_to_string(
+        width: u16,
+        height: u16,
+        state: &DashboardState,
+        events_state: &EventsViewState,
+    ) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_events(frame, frame.area(), state, events_state))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .clone()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol().to_string())
+            .collect()
+    }
+
+    fn make_event(event_type: &str) -> EventEntry {
+        EventEntry {
+            event_id: 1,
+            event_type: event_type.to_string(),
+            payload: serde_json::json!({"session_id": "abc"}),
+            received_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_events_filter_all_variants_covered() {
+        assert_eq!(EventsFilter::all().len(), 4);
+    }
+
+    #[test]
+    fn test_events_filter_cycle_wraps() {
+        let mut state = EventsViewState::new();
+        assert_eq!(state.filter, EventsFilter::All);
+        state.cycle_filter();
+        assert_eq!(state.filter, EventsFilter::Trading);
+        state.cycle_filter();
+        assert_eq!(state.filter, EventsFilter::Data);
+        state.cycle_filter();
+        assert_eq!(state.filter, EventsFilter::Predictions);
+        state.cycle_filter();
+        assert_eq!(state.filter, EventsFilter::All);
+    }
+
+    #[test]
+    fn test_events_filter_all_matches_everything() {
+        assert!(EventsFilter::All.matches("portfolio_rebalance_completed"));
+        assert!(EventsFilter::All.matches("equity_bars_sync_completed"));
+        assert!(EventsFilter::All.matches("equity_predictions_completed"));
+    }
+
+    #[test]
+    fn test_events_filter_trading_matches_portfolio_events() {
+        assert!(EventsFilter::Trading.matches("portfolio_rebalance_completed"));
+        assert!(EventsFilter::Trading.matches("portfolio_liquidation_errored"));
+        assert!(EventsFilter::Trading.matches("market_session_check"));
+        assert!(!EventsFilter::Trading.matches("equity_bars_sync_completed"));
+        assert!(!EventsFilter::Trading.matches("equity_predictions_completed"));
+    }
+
+    #[test]
+    fn test_events_filter_data_matches_data_events() {
+        assert!(EventsFilter::Data.matches("equity_bars_sync_completed"));
+        assert!(EventsFilter::Data.matches("trading_history_export_completed"));
+        assert!(EventsFilter::Data.matches("database_backup_completed"));
+        assert!(!EventsFilter::Data.matches("portfolio_rebalance_completed"));
+        assert!(!EventsFilter::Data.matches("equity_predictions_completed"));
+    }
+
+    #[test]
+    fn test_events_filter_predictions_matches_prediction_events() {
+        assert!(EventsFilter::Predictions.matches("equity_predictions_completed"));
+        assert!(EventsFilter::Predictions.matches("equity_predictions_errored"));
+        assert!(!EventsFilter::Predictions.matches("portfolio_rebalance_completed"));
+        assert!(!EventsFilter::Predictions.matches("equity_bars_sync_completed"));
+    }
+
+    #[test]
+    fn test_render_events_empty_state_shows_placeholder() {
+        let state = DashboardState::default();
+        let events_state = EventsViewState::new();
+        let output = render_to_string(120, 40, &state, &events_state);
+        assert!(output.contains("No events"));
+    }
+
+    #[test]
+    fn test_render_events_shows_filter_labels() {
+        let state = DashboardState::default();
+        let events_state = EventsViewState::new();
+        let output = render_to_string(120, 40, &state, &events_state);
+        assert!(output.contains("All"));
+        assert!(output.contains("Trading"));
+        assert!(output.contains("Data"));
+        assert!(output.contains("Predictions"));
+    }
+
+    #[test]
+    fn test_render_events_shows_event_type() {
+        let mut state = DashboardState::default();
+        state
+            .events
+            .push_back(make_event("portfolio_rebalance_completed"));
+        let events_state = EventsViewState::new();
+        let output = render_to_string(120, 40, &state, &events_state);
+        assert!(output.contains("portfolio_rebalance_completed"));
+    }
+
+    #[test]
+    fn test_render_events_filter_hides_non_matching() {
+        let mut state = DashboardState::default();
+        state
+            .events
+            .push_back(make_event("portfolio_rebalance_completed"));
+        let mut events_state = EventsViewState::new();
+        events_state.filter = EventsFilter::Data;
+        let output = render_to_string(120, 40, &state, &events_state);
+        // Data filter active — trading event should not render in the list.
+        assert!(output.contains("No events match this filter"));
+    }
+
+    #[test]
+    fn test_truncate_payload_short_value() {
+        let payload = serde_json::json!({"id": 1});
+        let result = truncate_payload(&payload);
+        assert!(!result.contains('…'));
+    }
+
+    #[test]
+    fn test_truncate_payload_long_value() {
+        let payload = serde_json::json!({"key": "a very long value that exceeds the display limit for dashboard rendering"});
+        let result = truncate_payload(&payload);
+        assert!(result.contains('…'));
+        // Displayed portion is 57 visible chars + ellipsis.
+        assert!(result.len() <= 61); // 57 chars + "…" (multi-byte)
+    }
+
+    #[test]
+    fn test_event_type_style_errored_is_red() {
+        let style = event_type_style("equity_bars_sync_errored");
+        assert_eq!(style.fg, Some(Color::Red));
+    }
+
+    #[test]
+    fn test_event_type_style_completed_is_green() {
+        let style = event_type_style("portfolio_rebalance_completed");
+        assert_eq!(style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn test_event_type_style_started_is_yellow() {
+        let style = event_type_style("equity_bars_sync_started");
+        assert_eq!(style.fg, Some(Color::Yellow));
+    }
+}

--- a/src/dashboard_service/events.rs
+++ b/src/dashboard_service/events.rs
@@ -196,10 +196,14 @@ fn event_type_style(event_type: &str) -> Style {
 }
 
 /// Truncates a JSON payload to a short summary string.
+///
+/// Truncation is performed on Unicode codepoint boundaries (not byte boundaries)
+/// to avoid panicking on multibyte characters such as CJK, emoji, or accented text.
 fn truncate_payload(payload: &serde_json::Value) -> String {
     let serialized = payload.to_string();
-    if serialized.len() > 58 {
-        format!("{}…", &serialized[..57])
+    if serialized.chars().count() > 58 {
+        let truncated: String = serialized.chars().take(57).collect();
+        format!("{truncated}…")
     } else {
         serialized
     }
@@ -353,6 +357,19 @@ mod tests {
         assert!(result.contains('…'));
         // Displayed portion is 57 visible chars + ellipsis.
         assert!(result.len() <= 61); // 57 chars + "…" (multi-byte)
+    }
+
+    #[test]
+    fn test_truncate_payload_multibyte_does_not_panic() {
+        // JSON value with CJK characters (3 bytes each in UTF-8).
+        // 60 repetitions produces a serialized string well over 58 chars,
+        // so truncation is triggered. A byte-index slice would panic here
+        // if the cut landed mid-codepoint.
+        let long_cjk = "日".repeat(60);
+        let payload = serde_json::json!({"key": long_cjk});
+        let result = truncate_payload(&payload);
+        assert!(result.contains('…'));
+        assert!(result.is_char_boundary(result.len()));
     }
 
     #[test]

--- a/src/dashboard_service/performance.rs
+++ b/src/dashboard_service/performance.rs
@@ -1,0 +1,287 @@
+//! Tab 2: portfolio NAV sparkline and period-return comparison vs SPY.
+
+use num_traits::ToPrimitive;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Sparkline, Table};
+
+use crate::dashboard_service::cache::DashboardState;
+
+/// Renders Tab 2: a NAV sparkline above a period-return comparison table.
+pub fn render_performance(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(5), Constraint::Min(0)])
+        .split(area);
+
+    render_sparkline(frame, chunks[0], state);
+    render_period_returns_table(frame, chunks[1], state);
+}
+
+fn render_sparkline(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+) {
+    let block = Block::default().title("NAV History").borders(Borders::ALL);
+
+    if state.performance_history.is_empty() {
+        let placeholder = Paragraph::new("No performance history")
+            .block(block)
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(placeholder, area);
+        return;
+    }
+
+    let sparkline_data = nav_sparkline_data(&state.performance_history);
+    let sparkline = Sparkline::default()
+        .block(block)
+        .data(&sparkline_data)
+        .style(Style::default().fg(Color::Cyan));
+    frame.render_widget(sparkline, area);
+}
+
+fn render_period_returns_table(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+) {
+    let returns = &state.period_returns;
+
+    let header = Row::new([Cell::from("PERIOD"), Cell::from("FUND"), Cell::from("SPY")])
+        .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let rows = [
+        ("1D", returns.fund_one_day, returns.spy_one_day),
+        ("1W", returns.fund_one_week, returns.spy_one_week),
+        ("1M", returns.fund_one_month, returns.spy_one_month),
+        ("YTD", returns.fund_year_to_date, returns.spy_year_to_date),
+        (
+            "Inception",
+            returns.fund_since_inception,
+            returns.spy_since_inception,
+        ),
+    ]
+    .map(|(label, fund, spy)| {
+        let fund_cell = Cell::from(format_return(fund)).style(return_style(fund));
+        let spy_cell = Cell::from(format_return(spy)).style(return_style(spy));
+        Row::new([Cell::from(label), fund_cell, spy_cell])
+    });
+
+    let widths = [
+        Constraint::Length(10),
+        Constraint::Length(12),
+        Constraint::Length(12),
+    ];
+
+    let table = Table::new(rows, widths).header(header).block(
+        Block::default()
+            .title("Period Returns")
+            .borders(Borders::ALL),
+    );
+    frame.render_widget(table, area);
+}
+
+/// Normalises NAV history (newest-first) to a `u64` range for the sparkline.
+///
+/// The sparkline renders oldest-to-newest (left-to-right), so the history
+/// slice is reversed before normalisation. Returns an empty vec when history
+/// is empty; returns uniform 50s when all NAV values are identical.
+pub fn nav_sparkline_data(
+    history: &[crate::dashboard_service::cache::PerformanceSnapshot],
+) -> Vec<u64> {
+    let nav_values: Vec<f64> = history
+        .iter()
+        .rev()
+        .filter_map(|snapshot| snapshot.net_asset_value.to_f64())
+        .collect();
+
+    if nav_values.is_empty() {
+        return vec![];
+    }
+
+    let min_nav = nav_values.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max_nav = nav_values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    let range = max_nav - min_nav;
+
+    if range == 0.0 {
+        return vec![50u64; nav_values.len()];
+    }
+
+    nav_values
+        .iter()
+        .map(|&nav| ((nav - min_nav) / range * 100.0) as u64)
+        .collect()
+}
+
+/// Formats an optional return percentage with sign and two decimal places.
+fn format_return(value: Option<f64>) -> String {
+    match value {
+        Some(return_value) => format!("{:+.2}%", return_value),
+        None => "—".to_string(),
+    }
+}
+
+/// Returns a coloured style for a return value: green positive, red negative, gray absent.
+fn return_style(value: Option<f64>) -> Style {
+    match value {
+        Some(return_value) if return_value > 0.0 => Style::default().fg(Color::Green),
+        Some(return_value) if return_value < 0.0 => Style::default().fg(Color::Red),
+        Some(_) => Style::default(),
+        None => Style::default().fg(Color::DarkGray),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use rust_decimal::Decimal;
+
+    use crate::dashboard_service::cache::{DashboardState, PerformanceSnapshot, PeriodReturns};
+
+    fn render_to_string(width: u16, height: u16, state: &DashboardState) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_performance(frame, frame.area(), state))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .clone()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol().to_string())
+            .collect()
+    }
+
+    fn make_snapshot(nav: i64, spy: Option<f64>) -> PerformanceSnapshot {
+        PerformanceSnapshot {
+            snapshot_timestamp: Utc::now(),
+            net_asset_value: Decimal::new(nav, 0),
+            gross_return: None,
+            net_return: None,
+            total_slippage_cost: Decimal::ZERO,
+            spy_close: spy,
+        }
+    }
+
+    #[test]
+    fn test_render_performance_empty_shows_placeholder() {
+        let state = DashboardState::default();
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("No performance history"));
+    }
+
+    #[test]
+    fn test_render_performance_shows_period_labels() {
+        let state = DashboardState::default();
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("1D"));
+        assert!(output.contains("1W"));
+        assert!(output.contains("1M"));
+        assert!(output.contains("YTD"));
+        assert!(output.contains("Inception"));
+    }
+
+    #[test]
+    fn test_render_performance_shows_fund_and_spy_columns() {
+        let state = DashboardState::default();
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("FUND"));
+        assert!(output.contains("SPY"));
+    }
+
+    #[test]
+    fn test_render_performance_shows_return_values() {
+        let mut state = DashboardState::default();
+        state.performance_history = vec![make_snapshot(110_000, Some(455.0))];
+        state.period_returns = PeriodReturns {
+            fund_one_day: Some(10.0),
+            spy_one_day: Some(1.1),
+            ..Default::default()
+        };
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("+10.00%"));
+        assert!(output.contains("+1.10%"));
+    }
+
+    #[test]
+    fn test_render_performance_shows_dash_for_none_returns() {
+        let mut state = DashboardState::default();
+        state.performance_history = vec![make_snapshot(100_000, None)];
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("—"));
+    }
+
+    #[test]
+    fn test_nav_sparkline_data_empty() {
+        let data = nav_sparkline_data(&[]);
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn test_nav_sparkline_data_uniform_nav() {
+        let history = vec![
+            make_snapshot(100_000, None),
+            make_snapshot(100_000, None),
+            make_snapshot(100_000, None),
+        ];
+        let data = nav_sparkline_data(&history);
+        assert_eq!(data, vec![50, 50, 50]);
+    }
+
+    #[test]
+    fn test_nav_sparkline_data_range() {
+        // Three snapshots newest-first; reversed for sparkline: 80k, 100k, 120k.
+        // Min=80k, max=120k, range=40k.
+        // 80k → 0, 100k → 50, 120k → 100.
+        let history = vec![
+            make_snapshot(120_000, None),
+            make_snapshot(100_000, None),
+            make_snapshot(80_000, None),
+        ];
+        let data = nav_sparkline_data(&history);
+        assert_eq!(data, vec![0, 50, 100]);
+    }
+
+    #[test]
+    fn test_format_return_positive() {
+        assert_eq!(format_return(Some(5.25)), "+5.25%");
+    }
+
+    #[test]
+    fn test_format_return_negative() {
+        assert_eq!(format_return(Some(-3.10)), "-3.10%");
+    }
+
+    #[test]
+    fn test_format_return_none() {
+        assert_eq!(format_return(None), "—");
+    }
+
+    #[test]
+    fn test_return_style_positive_is_green() {
+        let style = return_style(Some(1.0));
+        assert_eq!(style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn test_return_style_negative_is_red() {
+        let style = return_style(Some(-1.0));
+        assert_eq!(style.fg, Some(Color::Red));
+    }
+
+    #[test]
+    fn test_return_style_none_is_dark_gray() {
+        let style = return_style(None);
+        assert_eq!(style.fg, Some(Color::DarkGray));
+    }
+}

--- a/src/dashboard_service/performance.rs
+++ b/src/dashboard_service/performance.rs
@@ -114,7 +114,7 @@ pub fn nav_sparkline_data(
 
     nav_values
         .iter()
-        .map(|&nav| ((nav - min_nav) / range * 100.0) as u64)
+        .map(|&nav| ((nav - min_nav) / range * 100.0).clamp(0.0, 100.0) as u64)
         .collect()
 }
 

--- a/src/dashboard_service/positions.rs
+++ b/src/dashboard_service/positions.rs
@@ -1,0 +1,227 @@
+//! Tab 1: open long/short pair positions and exposure summary.
+
+use num_traits::ToPrimitive;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
+
+use crate::dashboard_service::cache::DashboardState;
+
+/// Renders Tab 1: an open-pairs table above an exposure summary footer row.
+pub fn render_positions(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(area);
+
+    render_positions_table(frame, chunks[0], state);
+    render_positions_footer(frame, chunks[1], state);
+}
+
+fn render_positions_table(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+) {
+    let block = Block::default()
+        .title("Open Positions")
+        .borders(Borders::ALL);
+
+    if state.open_positions.is_empty() {
+        let placeholder = Paragraph::new("No open positions")
+            .block(block)
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(placeholder, area);
+        return;
+    }
+
+    let header = Row::new([
+        Cell::from("PAIR"),
+        Cell::from("LONG"),
+        Cell::from("SHORT"),
+        Cell::from("Z-SCORE"),
+        Cell::from("SIGNAL"),
+        Cell::from("LONG $"),
+        Cell::from("SHORT $"),
+        Cell::from("OPENED"),
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let rows: Vec<Row> = state
+        .open_positions
+        .iter()
+        .map(|position| {
+            Row::new([
+                Cell::from(position.pair_id.as_str().to_string()),
+                Cell::from(position.long_ticker.as_str().to_string()),
+                Cell::from(position.short_ticker.as_str().to_string()),
+                Cell::from(format!("{:.2}", position.z_score.to_f64().unwrap_or(0.0))),
+                Cell::from(format!(
+                    "{:.2}",
+                    position.signal_strength.to_f64().unwrap_or(0.0)
+                )),
+                Cell::from(format_dollars(position.long_dollar_amount)),
+                Cell::from(format_dollars(position.short_dollar_amount)),
+                Cell::from(position.opened_at.format("%Y-%m-%d %H:%M").to_string()),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(12),
+        Constraint::Length(6),
+        Constraint::Length(6),
+        Constraint::Length(9),
+        Constraint::Length(8),
+        Constraint::Length(12),
+        Constraint::Length(12),
+        Constraint::Min(0),
+    ];
+
+    let table = Table::new(rows, widths).header(header).block(block);
+    frame.render_widget(table, area);
+}
+
+fn render_positions_footer(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+) {
+    let pair_count = state.open_positions.len();
+    let text = format!(
+        "  {} {}  |  Gross: {}  |  Net: {}",
+        pair_count,
+        if pair_count == 1 {
+            "pair open"
+        } else {
+            "pairs open"
+        },
+        format_dollars(state.gross_exposure),
+        format_dollars(state.net_exposure),
+    );
+    let footer = Paragraph::new(text).style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(footer, area);
+}
+
+fn format_dollars(decimal: rust_decimal::Decimal) -> String {
+    format!("${:.2}", decimal.to_f64().unwrap_or(0.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use rust_decimal::Decimal;
+
+    use crate::dashboard_service::cache::{DashboardState, OpenPosition};
+    use crate::domain::market::{PairID, Ticker};
+
+    fn render_to_string(width: u16, height: u16, state: &DashboardState) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_positions(frame, frame.area(), state))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .clone()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol().to_string())
+            .collect()
+    }
+
+    fn make_position(long: &str, short: &str, long_amount: i64, short_amount: i64) -> OpenPosition {
+        OpenPosition {
+            pair_id: PairID::parse(&format!("{long}-{short}")).unwrap(),
+            long_ticker: Ticker::new(long).unwrap(),
+            short_ticker: Ticker::new(short).unwrap(),
+            z_score: Decimal::new(15, 1),
+            hedge_ratio: Decimal::ONE,
+            signal_strength: Decimal::new(8, 1),
+            long_dollar_amount: Decimal::new(long_amount, 0),
+            short_dollar_amount: Decimal::new(short_amount, 0),
+            opened_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_render_positions_empty_shows_placeholder() {
+        let state = DashboardState::default();
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("No open positions"));
+    }
+
+    #[test]
+    fn test_render_positions_shows_table_header() {
+        let state = DashboardState::default();
+        let output = render_to_string(120, 40, &state);
+        // Block title always shows
+        assert!(output.contains("Open Positions"));
+    }
+
+    #[test]
+    fn test_render_positions_shows_tickers() {
+        let mut state = DashboardState::default();
+        state.open_positions = vec![make_position("AAPL", "MSFT", 10000, 9500)];
+        state.gross_exposure = Decimal::new(19500, 0);
+        state.net_exposure = Decimal::new(500, 0);
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("AAPL"));
+        assert!(output.contains("MSFT"));
+    }
+
+    #[test]
+    fn test_render_positions_footer_shows_exposure_labels() {
+        let mut state = DashboardState::default();
+        state.open_positions = vec![make_position("AAPL", "MSFT", 10000, 9500)];
+        state.gross_exposure = Decimal::new(19500, 0);
+        state.net_exposure = Decimal::new(500, 0);
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("Gross"));
+        assert!(output.contains("Net"));
+    }
+
+    #[test]
+    fn test_render_positions_footer_singular_pair() {
+        let mut state = DashboardState::default();
+        state.open_positions = vec![make_position("AAPL", "MSFT", 10000, 9500)];
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("1 pair open"));
+    }
+
+    #[test]
+    fn test_render_positions_footer_plural_pairs() {
+        let mut state = DashboardState::default();
+        state.open_positions = vec![
+            make_position("AAPL", "MSFT", 10000, 9500),
+            make_position("TSLA", "NVDA", 8000, 7500),
+        ];
+        state.gross_exposure = Decimal::new(35000, 0);
+        state.net_exposure = Decimal::new(1000, 0);
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("2 pairs open"));
+    }
+
+    #[test]
+    fn test_format_dollars_positive() {
+        assert_eq!(format_dollars(Decimal::new(1000, 0)), "$1000.00");
+    }
+
+    #[test]
+    fn test_format_dollars_zero() {
+        assert_eq!(format_dollars(Decimal::ZERO), "$0.00");
+    }
+
+    #[test]
+    fn test_format_dollars_fractional() {
+        assert_eq!(format_dollars(Decimal::new(10050, 2)), "$100.50");
+    }
+}

--- a/src/dashboard_service/positions.rs
+++ b/src/dashboard_service/positions.rs
@@ -22,6 +22,7 @@ pub fn render_positions(
     render_positions_footer(frame, chunks[1], state);
 }
 
+/// Renders the open-pairs table showing tickers, z-score, signal, and dollar amounts.
 fn render_positions_table(
     frame: &mut ratatui::Frame,
     area: ratatui::layout::Rect,
@@ -86,6 +87,7 @@ fn render_positions_table(
     frame.render_widget(table, area);
 }
 
+/// Renders the one-line exposure summary footer below the positions table.
 fn render_positions_footer(
     frame: &mut ratatui::Frame,
     area: ratatui::layout::Rect,
@@ -107,8 +109,12 @@ fn render_positions_footer(
     frame.render_widget(footer, area);
 }
 
+/// Formats a `Decimal` value as a dollar string with two decimal places (e.g. `"$1000.50"`).
+///
+/// Formats directly in decimal space to preserve cent-level precision without
+/// converting through floating point.
 fn format_dollars(decimal: rust_decimal::Decimal) -> String {
-    format!("${:.2}", decimal.to_f64().unwrap_or(0.0))
+    format!("${:.2}", decimal)
 }
 
 #[cfg(test)]

--- a/src/dashboard_service/predictions.rs
+++ b/src/dashboard_service/predictions.rs
@@ -1,0 +1,197 @@
+//! Tab 4: latest model quantile forecasts per ticker.
+
+use chrono::Utc;
+use ratatui::layout::Constraint;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
+
+use crate::dashboard_service::cache::DashboardState;
+
+/// Renders Tab 4: a table of the latest quantile predictions with model run age.
+pub fn render_predictions(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+) {
+    let block = Block::default()
+        .title("Model Predictions")
+        .borders(Borders::ALL);
+
+    if state.predictions.is_empty() {
+        let placeholder = Paragraph::new("No predictions available")
+            .block(block)
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(placeholder, area);
+        return;
+    }
+
+    let header = Row::new([
+        Cell::from("TICKER"),
+        Cell::from("Q10"),
+        Cell::from("Q50"),
+        Cell::from("Q90"),
+        Cell::from("MODEL RUN"),
+        Cell::from("AGE"),
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let rows: Vec<Row> = state
+        .predictions
+        .iter()
+        .map(|prediction| {
+            let q50_style = if prediction.quantile_50 > 0.0 {
+                Style::default().fg(Color::Green)
+            } else if prediction.quantile_50 < 0.0 {
+                Style::default().fg(Color::Red)
+            } else {
+                Style::default()
+            };
+
+            Row::new([
+                Cell::from(prediction.ticker.as_str().to_string()),
+                Cell::from(format!("{:+.4}", prediction.quantile_10)),
+                Cell::from(format!("{:+.4}", prediction.quantile_50)).style(q50_style),
+                Cell::from(format!("{:+.4}", prediction.quantile_90)),
+                Cell::from(prediction.model_run_id.clone()),
+                Cell::from(format_age(prediction.timestamp)),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(8),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(10),
+        Constraint::Length(20),
+        Constraint::Min(0),
+    ];
+
+    let table = Table::new(rows, widths).header(header).block(block);
+    frame.render_widget(table, area);
+}
+
+/// Formats the age of a prediction timestamp as a human-readable string.
+pub fn format_age(timestamp: chrono::DateTime<Utc>) -> String {
+    let age = Utc::now() - timestamp;
+    if age.num_days() > 0 {
+        format!("{}d {}h", age.num_days(), age.num_hours() % 24)
+    } else if age.num_hours() > 0 {
+        format!("{}h {}m", age.num_hours(), age.num_minutes() % 60)
+    } else {
+        format!("{}m", age.num_minutes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    use crate::dashboard_service::cache::{DashboardState, PredictionRow};
+    use crate::domain::market::Ticker;
+
+    fn render_to_string(width: u16, height: u16, state: &DashboardState) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_predictions(frame, frame.area(), state))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .clone()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol().to_string())
+            .collect()
+    }
+
+    fn make_prediction(ticker: &str, q10: f64, q50: f64, q90: f64) -> PredictionRow {
+        PredictionRow {
+            ticker: Ticker::new(ticker).unwrap(),
+            quantile_10: q10,
+            quantile_50: q50,
+            quantile_90: q90,
+            model_run_id: "run-abc123".to_string(),
+            timestamp: Utc::now() - Duration::hours(2),
+        }
+    }
+
+    #[test]
+    fn test_render_predictions_empty_shows_placeholder() {
+        let state = DashboardState::default();
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("No predictions available"));
+    }
+
+    #[test]
+    fn test_render_predictions_shows_block_title() {
+        let state = DashboardState::default();
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("Model Predictions"));
+    }
+
+    #[test]
+    fn test_render_predictions_shows_ticker() {
+        let mut state = DashboardState::default();
+        state.predictions = vec![make_prediction("AAPL", -0.001, 0.002, 0.005)];
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("AAPL"));
+    }
+
+    #[test]
+    fn test_render_predictions_shows_model_run_id() {
+        let mut state = DashboardState::default();
+        state.predictions = vec![make_prediction("AAPL", -0.001, 0.002, 0.005)];
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("run-abc123"));
+    }
+
+    #[test]
+    fn test_render_predictions_shows_column_headers() {
+        let mut state = DashboardState::default();
+        state.predictions = vec![make_prediction("AAPL", -0.001, 0.002, 0.005)];
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("Q10"));
+        assert!(output.contains("Q50"));
+        assert!(output.contains("Q90"));
+    }
+
+    #[test]
+    fn test_render_predictions_shows_age() {
+        let mut state = DashboardState::default();
+        state.predictions = vec![make_prediction("AAPL", -0.001, 0.002, 0.005)];
+        let output = render_to_string(120, 40, &state);
+        // Prediction was made 2 hours ago
+        assert!(output.contains("2h"));
+    }
+
+    #[test]
+    fn test_format_age_minutes() {
+        let timestamp = Utc::now() - Duration::minutes(45);
+        assert_eq!(format_age(timestamp), "45m");
+    }
+
+    #[test]
+    fn test_format_age_hours_and_minutes() {
+        let timestamp = Utc::now() - Duration::hours(3) - Duration::minutes(20);
+        let result = format_age(timestamp);
+        assert!(
+            result.starts_with("3h"),
+            "expected '3h ...', got '{result}'"
+        );
+    }
+
+    #[test]
+    fn test_format_age_days_and_hours() {
+        let timestamp = Utc::now() - Duration::days(2) - Duration::hours(5);
+        let result = format_age(timestamp);
+        assert!(
+            result.starts_with("2d"),
+            "expected '2d ...', got '{result}'"
+        );
+    }
+}

--- a/src/dashboard_service/predictions.rs
+++ b/src/dashboard_service/predictions.rs
@@ -72,8 +72,14 @@ pub fn render_predictions(
 }
 
 /// Formats the age of a prediction timestamp as a human-readable string.
+///
+/// Returns `"0m"` when the timestamp is in the future (e.g. due to clock skew
+/// between the database host and the TUI host) to avoid rendering negative ages.
 pub fn format_age(timestamp: chrono::DateTime<Utc>) -> String {
     let age = Utc::now() - timestamp;
+    if age < chrono::Duration::zero() {
+        return "0m".to_string();
+    }
     if age.num_days() > 0 {
         format!("{}d {}h", age.num_days(), age.num_hours() % 24)
     } else if age.num_hours() > 0 {
@@ -193,5 +199,12 @@ mod tests {
             result.starts_with("2d"),
             "expected '2d ...', got '{result}'"
         );
+    }
+
+    #[test]
+    fn test_format_age_future_timestamp_returns_zero() {
+        // Timestamp in the future (e.g. DB clock ahead of TUI host).
+        let timestamp = Utc::now() + Duration::minutes(5);
+        assert_eq!(format_age(timestamp), "0m");
     }
 }

--- a/src/dashboard_service/trades.rs
+++ b/src/dashboard_service/trades.rs
@@ -1,0 +1,288 @@
+//! Tab 3: closed pair trades table with aggregate statistics footer.
+
+use num_traits::ToPrimitive;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
+
+use crate::dashboard_service::cache::{ClosedTradesSummary, DashboardState};
+
+/// Renders Tab 3: a closed-trades table above an aggregate statistics footer.
+pub fn render_trades(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(2)])
+        .split(area);
+
+    render_trades_table(frame, chunks[0], state);
+    render_trades_footer(frame, chunks[1], &state.closed_trades_summary);
+}
+
+fn render_trades_table(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+) {
+    let block = Block::default()
+        .title("Closed Trades")
+        .borders(Borders::ALL);
+
+    if state.closed_trades.is_empty() {
+        let placeholder = Paragraph::new("No closed trades")
+            .block(block)
+            .style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(placeholder, area);
+        return;
+    }
+
+    let header = Row::new([
+        Cell::from("PAIR"),
+        Cell::from("LONG"),
+        Cell::from("SHORT"),
+        Cell::from("P&L"),
+        Cell::from("RETURN"),
+        Cell::from("HOLDING"),
+        Cell::from("REASON"),
+        Cell::from("CLOSED"),
+    ])
+    .style(Style::default().add_modifier(Modifier::BOLD));
+
+    let rows: Vec<Row> = state
+        .closed_trades
+        .iter()
+        .map(|trade| {
+            let profit_and_loss_str = trade
+                .realized_profit_and_loss
+                .map(|value| format!("${:.2}", value.to_f64().unwrap_or(0.0)))
+                .unwrap_or_else(|| "—".to_string());
+            let profit_and_loss_style = match trade.realized_profit_and_loss {
+                Some(value) if value.to_f64().unwrap_or(0.0) > 0.0 => {
+                    Style::default().fg(Color::Green)
+                }
+                Some(value) if value.to_f64().unwrap_or(0.0) < 0.0 => {
+                    Style::default().fg(Color::Red)
+                }
+                _ => Style::default(),
+            };
+
+            let return_str = trade
+                .return_percent
+                .map(|value| format!("{:+.2}%", value.to_f64().unwrap_or(0.0)))
+                .unwrap_or_else(|| "—".to_string());
+            let return_style = match trade.return_percent {
+                Some(value) if value.to_f64().unwrap_or(0.0) > 0.0 => {
+                    Style::default().fg(Color::Green)
+                }
+                Some(value) if value.to_f64().unwrap_or(0.0) < 0.0 => {
+                    Style::default().fg(Color::Red)
+                }
+                _ => Style::default(),
+            };
+
+            Row::new([
+                Cell::from(trade.pair_id.as_str().to_string()),
+                Cell::from(trade.long_ticker.as_str().to_string()),
+                Cell::from(trade.short_ticker.as_str().to_string()),
+                Cell::from(profit_and_loss_str).style(profit_and_loss_style),
+                Cell::from(return_str).style(return_style),
+                Cell::from(
+                    trade
+                        .holding_seconds
+                        .map(format_holding_duration)
+                        .unwrap_or_else(|| "—".to_string()),
+                ),
+                Cell::from(trade.close_reason.as_deref().unwrap_or("—").to_string()),
+                Cell::from(
+                    trade
+                        .closed_at
+                        .map(|timestamp| timestamp.format("%Y-%m-%d").to_string())
+                        .unwrap_or_else(|| "—".to_string()),
+                ),
+            ])
+        })
+        .collect();
+
+    let widths = [
+        Constraint::Length(12),
+        Constraint::Length(6),
+        Constraint::Length(6),
+        Constraint::Length(11),
+        Constraint::Length(9),
+        Constraint::Length(9),
+        Constraint::Length(14),
+        Constraint::Min(0),
+    ];
+
+    let table = Table::new(rows, widths).header(header).block(block);
+    frame.render_widget(table, area);
+}
+
+fn render_trades_footer(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    summary: &ClosedTradesSummary,
+) {
+    let win_rate = summary
+        .win_rate
+        .map(|rate| format!("{:.1}%", rate * 100.0))
+        .unwrap_or_else(|| "—".to_string());
+    let profit_factor = summary
+        .profit_factor
+        .map(|factor| format!("{:.2}", factor))
+        .unwrap_or_else(|| "—".to_string());
+    let average_return = summary
+        .average_return_percent
+        .map(|return_percent| format!("{:+.2}%", return_percent))
+        .unwrap_or_else(|| "—".to_string());
+    let average_holding = summary
+        .average_holding_seconds
+        .map(|seconds| format_holding_duration(seconds as i64))
+        .unwrap_or_else(|| "—".to_string());
+    let total_profit_and_loss = summary
+        .total_realized_profit_and_loss
+        .map(|value| format!("${:.2}", value.to_f64().unwrap_or(0.0)))
+        .unwrap_or_else(|| "—".to_string());
+
+    let text = format!(
+        "  {} closed  |  Win: {}  |  PF: {}  |  Avg return: {}  |  Avg hold: {}  |  Total P&L: {}",
+        summary.total_closed,
+        win_rate,
+        profit_factor,
+        average_return,
+        average_holding,
+        total_profit_and_loss,
+    );
+    let footer = Paragraph::new(text).style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(footer, area);
+}
+
+/// Formats a holding duration in seconds to a human-readable string.
+pub fn format_holding_duration(seconds: i64) -> String {
+    if seconds < 3600 {
+        format!("{}m", seconds / 60)
+    } else if seconds < 86400 {
+        format!("{}h {}m", seconds / 3600, (seconds % 3600) / 60)
+    } else {
+        format!("{}d {}h", seconds / 86400, (seconds % 86400) / 3600)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+    use rust_decimal::Decimal;
+
+    use crate::dashboard_service::cache::{ClosedTrade, DashboardState};
+    use crate::domain::market::{PairID, Ticker};
+
+    fn render_to_string(width: u16, height: u16, state: &DashboardState) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_trades(frame, frame.area(), state))
+            .unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .clone()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol().to_string())
+            .collect()
+    }
+
+    fn make_trade(
+        long: &str,
+        short: &str,
+        profit_and_loss: Option<i64>,
+        return_percent: Option<&str>,
+        holding_seconds: Option<i64>,
+    ) -> ClosedTrade {
+        ClosedTrade {
+            pair_id: PairID::parse(&format!("{long}-{short}")).unwrap(),
+            long_ticker: Ticker::new(long).unwrap(),
+            short_ticker: Ticker::new(short).unwrap(),
+            realized_profit_and_loss: profit_and_loss.map(|v| Decimal::new(v, 0)),
+            return_percent: return_percent.map(|s| s.parse::<Decimal>().expect("valid decimal")),
+            holding_seconds,
+            close_reason: Some("profit_taken".to_string()),
+            closed_at: Some(Utc::now()),
+        }
+    }
+
+    #[test]
+    fn test_render_trades_empty_shows_placeholder() {
+        let state = DashboardState::default();
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("No closed trades"));
+    }
+
+    #[test]
+    fn test_render_trades_shows_table_header() {
+        let state = DashboardState::default();
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("Closed Trades"));
+    }
+
+    #[test]
+    fn test_render_trades_shows_pair_tickers() {
+        let mut state = DashboardState::default();
+        state.closed_trades = vec![make_trade("AAPL", "MSFT", Some(500), Some("2"), Some(3600))];
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("AAPL"));
+        assert!(output.contains("MSFT"));
+    }
+
+    #[test]
+    fn test_render_trades_footer_shows_summary_labels() {
+        let state = DashboardState::default();
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("closed"));
+        assert!(output.contains("Win"));
+    }
+
+    #[test]
+    fn test_render_trades_shows_dash_for_none_fields() {
+        let mut state = DashboardState::default();
+        state.closed_trades = vec![make_trade("AAPL", "MSFT", None, None, None)];
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("—"));
+    }
+
+    #[test]
+    fn test_format_holding_duration_minutes() {
+        assert_eq!(format_holding_duration(300), "5m");
+    }
+
+    #[test]
+    fn test_format_holding_duration_hours_and_minutes() {
+        assert_eq!(format_holding_duration(3900), "1h 5m");
+    }
+
+    #[test]
+    fn test_format_holding_duration_days_and_hours() {
+        assert_eq!(format_holding_duration(90000), "1d 1h");
+    }
+
+    #[test]
+    fn test_format_holding_duration_zero() {
+        assert_eq!(format_holding_duration(0), "0m");
+    }
+
+    #[test]
+    fn test_format_holding_duration_exactly_one_hour() {
+        assert_eq!(format_holding_duration(3600), "1h 0m");
+    }
+
+    #[test]
+    fn test_format_holding_duration_exactly_one_day() {
+        assert_eq!(format_holding_duration(86400), "1d 0h");
+    }
+}

--- a/src/dashboard_service/trades.rs
+++ b/src/dashboard_service/trades.rs
@@ -1,6 +1,5 @@
 //! Tab 3: closed pair trades table with aggregate statistics footer.
 
-use num_traits::ToPrimitive;
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
@@ -22,6 +21,7 @@ pub fn render_trades(
     render_trades_footer(frame, chunks[1], &state.closed_trades_summary);
 }
 
+/// Renders the closed-trades table showing pair P&L, return, holding time, and close reason.
 fn render_trades_table(
     frame: &mut ratatui::Frame,
     area: ratatui::layout::Rect,
@@ -57,29 +57,25 @@ fn render_trades_table(
         .map(|trade| {
             let profit_and_loss_str = trade
                 .realized_profit_and_loss
-                .map(|value| format!("${:.2}", value.to_f64().unwrap_or(0.0)))
+                .map(|value| format!("${:.2}", value))
                 .unwrap_or_else(|| "—".to_string());
             let profit_and_loss_style = match trade.realized_profit_and_loss {
-                Some(value) if value.to_f64().unwrap_or(0.0) > 0.0 => {
+                Some(value) if value.is_sign_positive() && !value.is_zero() => {
                     Style::default().fg(Color::Green)
                 }
-                Some(value) if value.to_f64().unwrap_or(0.0) < 0.0 => {
-                    Style::default().fg(Color::Red)
-                }
+                Some(value) if value.is_sign_negative() => Style::default().fg(Color::Red),
                 _ => Style::default(),
             };
 
             let return_str = trade
                 .return_percent
-                .map(|value| format!("{:+.2}%", value.to_f64().unwrap_or(0.0)))
+                .map(|value| format!("{:+.2}%", value))
                 .unwrap_or_else(|| "—".to_string());
             let return_style = match trade.return_percent {
-                Some(value) if value.to_f64().unwrap_or(0.0) > 0.0 => {
+                Some(value) if value.is_sign_positive() && !value.is_zero() => {
                     Style::default().fg(Color::Green)
                 }
-                Some(value) if value.to_f64().unwrap_or(0.0) < 0.0 => {
-                    Style::default().fg(Color::Red)
-                }
+                Some(value) if value.is_sign_negative() => Style::default().fg(Color::Red),
                 _ => Style::default(),
             };
 
@@ -121,6 +117,7 @@ fn render_trades_table(
     frame.render_widget(table, area);
 }
 
+/// Renders the one-line aggregate statistics footer below the trades table.
 fn render_trades_footer(
     frame: &mut ratatui::Frame,
     area: ratatui::layout::Rect,
@@ -144,7 +141,7 @@ fn render_trades_footer(
         .unwrap_or_else(|| "—".to_string());
     let total_profit_and_loss = summary
         .total_realized_profit_and_loss
-        .map(|value| format!("${:.2}", value.to_f64().unwrap_or(0.0)))
+        .map(|value| format!("${:.2}", value))
         .unwrap_or_else(|| "—".to_string());
 
     let text = format!(


### PR DESCRIPTION
# Overview

## Changes

- Implements the five tab views for the SSH-accessible read-only TUI dashboard, building on the `tui-foundation` scaffolding (PR 1)
- contributes to #869

**New modules:**
- `positions.rs` — Tab 1: open long/short pair table with PAIR/LONG/SHORT/Z-SCORE/SIGNAL/LONG$/SHORT$/OPENED columns and a gross/net exposure footer
- `performance.rs` — Tab 2: NAV history sparkline above a period returns table comparing Fund vs SPY across 1D/1W/1M/YTD/Inception horizons
- `trades.rs` — Tab 3: closed trades table with coloured P&L/return cells and an aggregate statistics footer (win rate, profit factor, avg return, avg hold, total P&L)
- `predictions.rs` — Tab 4: model quantile forecast table (Q10/Q50/Q90) with coloured Q50 and human-readable age column
- `events.rs` — Tab 5: real-time Postgres NOTIFY event feed with `EventsFilter` (All/Trading/Data/Predictions) cycling via `f`

**Modified modules:**
- `application.rs` — wires `EventsViewState` into the event loop; dispatches rendering to view modules; fixes tab bar constraint (`Length(3)` → `Length(2)`) to eliminate ghost header artifact from ratatui diff rendering
- `cache.rs` — adds `PeriodReturns` struct with `fund_`/`spy_` prefixed fields; adds `period_returns` field to `DashboardState`; `spawn_polling_task` sets `period_returns` on each successful poll
- `database.rs` — adds `compute_period_returns` + helpers (`find_snapshot_at_or_before`, `nav_period_return`, `spy_period_return`); populates `period_returns` in `DashboardData`
- `observability.rs` — adds `init_tracing_file_only` for services that own stdout (suppresses JSON log output that would corrupt the ratatui alternate screen buffer)
- `dashboard_service.rs` — declares the five new sub-modules; switches to `init_tracing_file_only`

## Context

This PR is the second of two for issue #869. PR 1 (`tui-foundation`) established the module structure, `DashboardState` cache, background polling/event-listener tasks, and the application shell with tab bar layout. This PR fills in all five tab renderers and the supporting data structures.

Key design decisions:
- `PeriodReturns` is pre-computed by the polling task rather than at render time, avoiding repeated O(n) passes per frame across all connected SSH sessions
- `EventsViewState` is colocated in `events.rs` (owned by `Application`) since it is only used in that one view
- NAV sparkline uses min-max normalisation to a 0–100 `u64` range; uniform 50 when all values are identical

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated dashboard tabs for positions, performance, trades, predictions, and real-time events.
  * Added event filtering, period-return summaries, performance sparklines, and richer table views across the dashboard.
  * Startup logging now writes to a file without cluttering the terminal display.

* **Bug Fixes**
  * Improved dashboard loading behavior with clearer overlays before data is available.
  * Added better handling for missing or incomplete values in tables and summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->