### PR TITLE
Add `dashboard_service` freshness indicators: model run, bars, and rebalance

### DIFF
--- a/src/dashboard_service/cache.rs
+++ b/src/dashboard_service/cache.rs
@@ -113,11 +113,56 @@ pub struct PeriodReturns {
 /// Metadata from the most recently completed model run (Tab 4 header).
 #[derive(Debug, Clone)]
 pub struct ModelRunInformation {
-    pub completed_at: DateTime<Utc>,
-    pub start_date: chrono::NaiveDate,
-    pub end_date: chrono::NaiveDate,
-    pub continuous_ranked_probability_score: Option<f64>,
-    pub directional_accuracy: Option<f64>,
+    completed_at: DateTime<Utc>,
+    start_date: Option<chrono::NaiveDate>,
+    end_date: Option<chrono::NaiveDate>,
+    continuous_ranked_probability_score: Option<f64>,
+    directional_accuracy: Option<f64>,
+}
+
+impl ModelRunInformation {
+    /// Constructs a `ModelRunInformation`, validating that `start_date < end_date` when both are
+    /// provided. Returns an error if the date range is invalid.
+    pub fn new(
+        completed_at: DateTime<Utc>,
+        start_date: Option<chrono::NaiveDate>,
+        end_date: Option<chrono::NaiveDate>,
+        continuous_ranked_probability_score: Option<f64>,
+        directional_accuracy: Option<f64>,
+    ) -> Result<Self, &'static str> {
+        if let (Some(start), Some(end)) = (start_date, end_date) {
+            if start >= end {
+                return Err("start_date must be before end_date");
+            }
+        }
+        Ok(Self {
+            completed_at,
+            start_date,
+            end_date,
+            continuous_ranked_probability_score,
+            directional_accuracy,
+        })
+    }
+
+    pub fn completed_at(&self) -> DateTime<Utc> {
+        self.completed_at
+    }
+
+    pub fn start_date(&self) -> Option<chrono::NaiveDate> {
+        self.start_date
+    }
+
+    pub fn end_date(&self) -> Option<chrono::NaiveDate> {
+        self.end_date
+    }
+
+    pub fn continuous_ranked_probability_score(&self) -> Option<f64> {
+        self.continuous_ranked_probability_score
+    }
+
+    pub fn directional_accuracy(&self) -> Option<f64> {
+        self.directional_accuracy
+    }
 }
 
 /// A single event received from the Postgres `events` NOTIFY channel (Tab 5).
@@ -308,16 +353,36 @@ mod tests {
     #[test]
     fn test_model_run_information_fields() {
         use chrono::NaiveDate;
-        let info = ModelRunInformation {
-            completed_at: Utc::now(),
-            start_date: NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
-            end_date: NaiveDate::from_ymd_opt(2025, 12, 31).unwrap(),
-            continuous_ranked_probability_score: Some(0.123),
-            directional_accuracy: Some(0.725),
-        };
-        assert!(info.continuous_ranked_probability_score.is_some());
-        assert!(info.directional_accuracy.is_some());
-        assert!(info.start_date < info.end_date);
+        let info = ModelRunInformation::new(
+            Utc::now(),
+            Some(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
+            Some(NaiveDate::from_ymd_opt(2025, 12, 31).unwrap()),
+            Some(0.123),
+            Some(0.725),
+        )
+        .unwrap();
+        assert!(info.continuous_ranked_probability_score().is_some());
+        assert!(info.directional_accuracy().is_some());
+        assert!(info.start_date().unwrap() < info.end_date().unwrap());
+    }
+
+    #[test]
+    fn test_model_run_information_rejects_invalid_date_range() {
+        use chrono::NaiveDate;
+        let result = ModelRunInformation::new(
+            Utc::now(),
+            Some(NaiveDate::from_ymd_opt(2025, 12, 31).unwrap()),
+            Some(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
+            None,
+            None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_model_run_information_allows_null_dates() {
+        let result = ModelRunInformation::new(Utc::now(), None, None, None, None);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/dashboard_service/cache.rs
+++ b/src/dashboard_service/cache.rs
@@ -110,6 +110,16 @@ pub struct PeriodReturns {
     pub spy_since_inception: Option<f64>,
 }
 
+/// Metadata from the most recently completed model run (Tab 4 header).
+#[derive(Debug, Clone)]
+pub struct ModelRunInformation {
+    pub completed_at: DateTime<Utc>,
+    pub start_date: chrono::NaiveDate,
+    pub end_date: chrono::NaiveDate,
+    pub continuous_ranked_probability_score: Option<f64>,
+    pub directional_accuracy: Option<f64>,
+}
+
 /// A single event received from the Postgres `events` NOTIFY channel (Tab 5).
 #[derive(Debug, Clone)]
 pub struct EventEntry {
@@ -144,6 +154,14 @@ pub struct DashboardState {
     pub period_returns: PeriodReturns,
     /// Bounded event ring buffer, newest first (Tab 5).
     pub events: VecDeque<EventEntry>,
+    /// Metadata from the most recently completed model run (Tab 4 header). `None` until first poll.
+    pub model_run_information: Option<ModelRunInformation>,
+    /// Timestamp of the most recently inserted equity bar row (Tab 4 header freshness).
+    /// `None` until first poll or when the table is empty.
+    pub latest_bars_inserted_at: Option<DateTime<Utc>>,
+    /// Completion time of the most recent rebalance session (Tab 1 header freshness).
+    /// `None` until first poll or when no sessions have completed.
+    pub last_rebalance_completed_at: Option<DateTime<Utc>>,
     /// Timestamp of the most recent successful poll. `None` until first poll completes.
     pub last_updated: Option<DateTime<Utc>>,
     /// Last database error message, if any. Cleared on successful poll.
@@ -174,6 +192,9 @@ pub fn spawn_polling_task(state: SharedState, pool: PgPool) {
                     guard.closed_trades = data.closed_trades;
                     guard.closed_trades_summary = data.closed_trades_summary;
                     guard.predictions = data.predictions;
+                    guard.model_run_information = data.model_run_information;
+                    guard.latest_bars_inserted_at = data.latest_bars_inserted_at;
+                    guard.last_rebalance_completed_at = data.last_rebalance_completed_at;
                     guard.last_updated = Some(Utc::now());
                     guard.database_error = None;
                     info!("Dashboard state refreshed");
@@ -279,6 +300,24 @@ mod tests {
         assert_eq!(state.net_exposure, Decimal::ZERO);
         assert!(state.last_updated.is_none());
         assert!(state.database_error.is_none());
+        assert!(state.model_run_information.is_none());
+        assert!(state.latest_bars_inserted_at.is_none());
+        assert!(state.last_rebalance_completed_at.is_none());
+    }
+
+    #[test]
+    fn test_model_run_information_fields() {
+        use chrono::NaiveDate;
+        let info = ModelRunInformation {
+            completed_at: Utc::now(),
+            start_date: NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            end_date: NaiveDate::from_ymd_opt(2025, 12, 31).unwrap(),
+            continuous_ranked_probability_score: Some(0.123),
+            directional_accuracy: Some(0.725),
+        };
+        assert!(info.continuous_ranked_probability_score.is_some());
+        assert!(info.directional_accuracy.is_some());
+        assert!(info.start_date < info.end_date);
     }
 
     #[test]

--- a/src/dashboard_service/database.rs
+++ b/src/dashboard_service/database.rs
@@ -10,8 +10,8 @@ use rust_decimal::Decimal;
 use sqlx::{PgPool, Row};
 
 use crate::dashboard_service::cache::{
-    ClosedTrade, ClosedTradesSummary, OpenPosition, PerformanceSnapshot, PeriodReturns,
-    PredictionRow,
+    ClosedTrade, ClosedTradesSummary, ModelRunInformation, OpenPosition, PerformanceSnapshot,
+    PeriodReturns, PredictionRow,
 };
 
 /// How many days of performance snapshot history to fetch for Tab 2.
@@ -30,6 +30,9 @@ pub struct DashboardData {
     pub closed_trades: Vec<ClosedTrade>,
     pub closed_trades_summary: ClosedTradesSummary,
     pub predictions: Vec<PredictionRow>,
+    pub model_run_information: Option<ModelRunInformation>,
+    pub latest_bars_inserted_at: Option<DateTime<Utc>>,
+    pub last_rebalance_completed_at: Option<DateTime<Utc>>,
 }
 
 /// Fetches all data needed for a full dashboard state refresh.
@@ -45,6 +48,9 @@ pub async fn fetch_dashboard_data(pool: &PgPool) -> Result<DashboardData, sqlx::
     let closed_trades = fetch_closed_trades(pool).await?;
     let closed_trades_summary = compute_closed_trades_summary(&closed_trades);
     let predictions = fetch_latest_predictions(pool).await?;
+    let model_run_information = fetch_latest_model_run_information(pool).await?;
+    let latest_bars_inserted_at = fetch_latest_bars_inserted_at(pool).await?;
+    let last_rebalance_completed_at = fetch_last_rebalance_completed_at(pool).await?;
 
     Ok(DashboardData {
         open_positions,
@@ -55,6 +61,9 @@ pub async fn fetch_dashboard_data(pool: &PgPool) -> Result<DashboardData, sqlx::
         closed_trades,
         closed_trades_summary,
         predictions,
+        model_run_information,
+        latest_bars_inserted_at,
+        last_rebalance_completed_at,
     })
 }
 
@@ -308,6 +317,64 @@ async fn fetch_latest_predictions(pool: &PgPool) -> Result<Vec<PredictionRow>, s
             })
         })
         .collect()
+}
+
+/// Fetches metadata for the most recently completed model run.
+///
+/// Returns `None` when no run has completed yet. Used by Tab 4 to display
+/// training recency alongside the prediction table.
+async fn fetch_latest_model_run_information(
+    pool: &PgPool,
+) -> Result<Option<ModelRunInformation>, sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT completed_at, start_date, end_date,
+                continuous_ranked_probability_score, directional_accuracy
+         FROM model_runs
+         WHERE status = 'completed' AND completed_at IS NOT NULL
+         ORDER BY completed_at DESC
+         LIMIT 1",
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    match row {
+        None => Ok(None),
+        Some(row) => Ok(Some(ModelRunInformation {
+            completed_at: row.try_get("completed_at")?,
+            start_date: row.try_get("start_date")?,
+            end_date: row.try_get("end_date")?,
+            continuous_ranked_probability_score: row
+                .try_get("continuous_ranked_probability_score")?,
+            directional_accuracy: row.try_get("directional_accuracy")?,
+        })),
+    }
+}
+
+/// Returns the maximum `inserted_at` timestamp across all equity bars rows.
+///
+/// Used by Tab 4 to indicate how recently market data was ingested. Returns
+/// `None` when the table is empty (e.g. before the first nightly ingest).
+async fn fetch_latest_bars_inserted_at(
+    pool: &PgPool,
+) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
+    let row = sqlx::query("SELECT MAX(inserted_at) AS max_inserted_at FROM equity_bars")
+        .fetch_one(pool)
+        .await?;
+    Ok(row.try_get("max_inserted_at")?)
+}
+
+/// Returns the most recent `completed_at` across all rebalance sessions.
+///
+/// Used by Tab 1 to indicate how recently the portfolio was rebalanced. Returns
+/// `None` when no session has completed yet.
+async fn fetch_last_rebalance_completed_at(
+    pool: &PgPool,
+) -> Result<Option<DateTime<Utc>>, sqlx::Error> {
+    let row =
+        sqlx::query("SELECT MAX(completed_at) AS max_completed_at FROM equity_rebalance_sessions")
+            .fetch_one(pool)
+            .await?;
+    Ok(row.try_get("max_completed_at")?)
 }
 
 /// Returns the first snapshot (newest-to-oldest order) whose timestamp is at or

--- a/src/dashboard_service/database.rs
+++ b/src/dashboard_service/database.rs
@@ -339,14 +339,17 @@ async fn fetch_latest_model_run_information(
 
     match row {
         None => Ok(None),
-        Some(row) => Ok(Some(ModelRunInformation {
-            completed_at: row.try_get("completed_at")?,
-            start_date: row.try_get("start_date")?,
-            end_date: row.try_get("end_date")?,
-            continuous_ranked_probability_score: row
-                .try_get("continuous_ranked_probability_score")?,
-            directional_accuracy: row.try_get("directional_accuracy")?,
-        })),
+        Some(row) => {
+            let model_run_information = ModelRunInformation::new(
+                row.try_get("completed_at")?,
+                row.try_get("start_date")?,
+                row.try_get("end_date")?,
+                row.try_get("continuous_ranked_probability_score")?,
+                row.try_get("directional_accuracy")?,
+            )
+            .map_err(|message| sqlx::Error::Protocol(message.to_string()))?;
+            Ok(Some(model_run_information))
+        }
     }
 }
 

--- a/src/dashboard_service/positions.rs
+++ b/src/dashboard_service/positions.rs
@@ -1,11 +1,20 @@
 //! Tab 1: open long/short pair positions and exposure summary.
 
+use chrono::Utc;
 use num_traits::ToPrimitive;
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
 
 use crate::dashboard_service::cache::DashboardState;
+use crate::dashboard_service::predictions::format_age;
+
+/// Age threshold in minutes above which no rebalance is flagged as stale (red).
+const REBALANCE_STALE_MINUTES: i64 = 30;
+
+/// Age threshold in minutes above which no rebalance triggers a warning (yellow).
+const REBALANCE_WARNING_MINUTES: i64 = 10;
 
 /// Renders Tab 1: an open-pairs table above an exposure summary footer row.
 pub fn render_positions(
@@ -28,9 +37,8 @@ fn render_positions_table(
     area: ratatui::layout::Rect,
     state: &DashboardState,
 ) {
-    let block = Block::default()
-        .title("Open Positions")
-        .borders(Borders::ALL);
+    let title = build_positions_title(state);
+    let block = Block::default().title(title).borders(Borders::ALL);
 
     if state.open_positions.is_empty() {
         let placeholder = Paragraph::new("No open positions")
@@ -107,6 +115,39 @@ fn render_positions_footer(
     );
     let footer = Paragraph::new(text).style(Style::default().fg(Color::DarkGray));
     frame.render_widget(footer, area);
+}
+
+/// Builds the positions table block title, appending last rebalance age when available.
+///
+/// The rebalance age is colored green when fresh, yellow when approaching the
+/// [`REBALANCE_WARNING_MINUTES`] threshold, and red when past the
+/// [`REBALANCE_STALE_MINUTES`] threshold.
+fn build_positions_title(state: &DashboardState) -> Line<'static> {
+    match state.last_rebalance_completed_at {
+        None => Line::from("Open Positions"),
+        Some(completed_at) => {
+            let style = rebalance_age_style(completed_at);
+            Line::from(vec![
+                Span::raw("Open Positions"),
+                Span::styled(format!(" | Rebalance: {}", format_age(completed_at)), style),
+            ])
+        }
+    }
+}
+
+/// Returns the style for a rebalance age based on staleness thresholds.
+///
+/// Red when older than [`REBALANCE_STALE_MINUTES`], yellow when older than
+/// [`REBALANCE_WARNING_MINUTES`], green otherwise.
+fn rebalance_age_style(completed_at: chrono::DateTime<Utc>) -> Style {
+    let minutes = (Utc::now() - completed_at).num_minutes();
+    if minutes > REBALANCE_STALE_MINUTES {
+        Style::default().fg(Color::Red)
+    } else if minutes > REBALANCE_WARNING_MINUTES {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::Green)
+    }
 }
 
 /// Formats a `Decimal` value as a dollar string with two decimal places (e.g. `"$1000.50"`).
@@ -229,5 +270,45 @@ mod tests {
     #[test]
     fn test_format_dollars_fractional() {
         assert_eq!(format_dollars(Decimal::new(10050, 2)), "$100.50");
+    }
+
+    #[test]
+    fn test_render_positions_shows_rebalance_age_when_present() {
+        use chrono::Duration;
+        let mut state = DashboardState::default();
+        state.last_rebalance_completed_at = Some(Utc::now() - Duration::minutes(5));
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("Rebalance:"));
+    }
+
+    #[test]
+    fn test_render_positions_no_rebalance_info_when_none() {
+        let state = DashboardState::default(); // last_rebalance_completed_at is None
+        let output = render_to_string(120, 40, &state);
+        assert!(!output.contains("Rebalance:"));
+    }
+
+    #[test]
+    fn test_rebalance_age_style_green_when_fresh() {
+        use chrono::Duration;
+        let completed_at = Utc::now() - Duration::minutes(3);
+        let style = rebalance_age_style(completed_at);
+        assert_eq!(style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn test_rebalance_age_style_yellow_when_warning() {
+        use chrono::Duration;
+        let completed_at = Utc::now() - Duration::minutes(20);
+        let style = rebalance_age_style(completed_at);
+        assert_eq!(style.fg, Some(Color::Yellow));
+    }
+
+    #[test]
+    fn test_rebalance_age_style_red_when_stale() {
+        use chrono::Duration;
+        let completed_at = Utc::now() - Duration::minutes(45);
+        let style = rebalance_age_style(completed_at);
+        assert_eq!(style.fg, Some(Color::Red));
     }
 }

--- a/src/dashboard_service/positions.rs
+++ b/src/dashboard_service/positions.rs
@@ -140,10 +140,10 @@ fn build_positions_title(state: &DashboardState) -> Line<'static> {
 /// Red when older than [`REBALANCE_STALE_MINUTES`], yellow when older than
 /// [`REBALANCE_WARNING_MINUTES`], green otherwise.
 fn rebalance_age_style(completed_at: chrono::DateTime<Utc>) -> Style {
-    let minutes = (Utc::now() - completed_at).num_minutes();
-    if minutes > REBALANCE_STALE_MINUTES {
+    let age = Utc::now() - completed_at;
+    if age > chrono::Duration::minutes(REBALANCE_STALE_MINUTES) {
         Style::default().fg(Color::Red)
-    } else if minutes > REBALANCE_WARNING_MINUTES {
+    } else if age > chrono::Duration::minutes(REBALANCE_WARNING_MINUTES) {
         Style::default().fg(Color::Yellow)
     } else {
         Style::default().fg(Color::Green)

--- a/src/dashboard_service/predictions.rs
+++ b/src/dashboard_service/predictions.rs
@@ -1,30 +1,108 @@
 //! Tab 4: latest model quantile forecasts per ticker.
 
 use chrono::Utc;
-use ratatui::layout::Constraint;
+use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
 
-use crate::dashboard_service::cache::DashboardState;
+use crate::dashboard_service::cache::{DashboardState, ModelRunInformation};
+
+/// Age threshold in hours above which model run data is considered stale.
+const MODEL_RUN_STALE_HOURS: i64 = 36;
+
+/// Age threshold in hours above which model run data is approaching stale (warning).
+const MODEL_RUN_WARNING_HOURS: i64 = 25;
+
+/// Age threshold in hours above which equity bar data is considered stale on a weekday.
+const BARS_STALE_WEEKDAY_HOURS: i64 = 25;
 
 /// Renders Tab 4: a table of the latest quantile predictions with model run age.
+///
+/// When model run metadata is available, renders a one-line freshness summary
+/// (run age, CRPS, directional accuracy, and bar insertion age) above the
+/// prediction table inside the outer block.
 pub fn render_predictions(
     frame: &mut ratatui::Frame,
     area: ratatui::layout::Rect,
     state: &DashboardState,
 ) {
-    let block = Block::default()
+    let outer_block = Block::default()
         .title("Model Predictions")
         .borders(Borders::ALL);
 
     if state.predictions.is_empty() {
         let placeholder = Paragraph::new("No predictions available")
-            .block(block)
+            .block(outer_block)
             .style(Style::default().fg(Color::DarkGray));
         frame.render_widget(placeholder, area);
         return;
     }
 
+    let inner_area = outer_block.inner(area);
+    frame.render_widget(outer_block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(0)])
+        .split(inner_area);
+
+    render_freshness_line(frame, chunks[0], state);
+    render_predictions_table(frame, chunks[1], state);
+}
+
+/// Renders the one-line freshness summary: model run age, CRPS, DA, and bar age.
+fn render_freshness_line(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+) {
+    let mut spans: Vec<Span> = Vec::new();
+
+    match &state.model_run_information {
+        None => {
+            spans.push(Span::styled(
+                "Model run: no completed runs",
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        Some(info) => {
+            let age_style = model_run_age_style(info);
+            spans.push(Span::raw("Run: "));
+            spans.push(Span::styled(format_age(info.completed_at), age_style));
+
+            if let Some(crps) = info.continuous_ranked_probability_score {
+                spans.push(Span::styled(
+                    "  CRPS: ",
+                    Style::default().fg(Color::DarkGray),
+                ));
+                spans.push(Span::raw(format!("{crps:.3}")));
+            }
+            if let Some(directional_accuracy) = info.directional_accuracy {
+                spans.push(Span::styled("  DA: ", Style::default().fg(Color::DarkGray)));
+                spans.push(Span::raw(format!("{:.1}%", directional_accuracy * 100.0)));
+            }
+        }
+    }
+
+    if let Some(inserted_at) = state.latest_bars_inserted_at {
+        let style = bars_age_style(inserted_at);
+        spans.push(Span::styled(
+            "  Bars: ",
+            Style::default().fg(Color::DarkGray),
+        ));
+        spans.push(Span::styled(format_age(inserted_at), style));
+    }
+
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+/// Renders the predictions table without an outer block (already rendered by caller).
+fn render_predictions_table(
+    frame: &mut ratatui::Frame,
+    area: ratatui::layout::Rect,
+    state: &DashboardState,
+) {
     let header = Row::new([
         Cell::from("TICKER"),
         Cell::from("Q10"),
@@ -67,8 +145,44 @@ pub fn render_predictions(
         Constraint::Min(0),
     ];
 
-    let table = Table::new(rows, widths).header(header).block(block);
+    let table = Table::new(rows, widths).header(header);
     frame.render_widget(table, area);
+}
+
+/// Returns the style for a model run age based on staleness thresholds.
+///
+/// Red when older than [`MODEL_RUN_STALE_HOURS`], yellow when older than
+/// [`MODEL_RUN_WARNING_HOURS`], green otherwise.
+fn model_run_age_style(info: &ModelRunInformation) -> Style {
+    let hours = (Utc::now() - info.completed_at).num_hours();
+    if hours > MODEL_RUN_STALE_HOURS {
+        Style::default().fg(Color::Red)
+    } else if hours > MODEL_RUN_WARNING_HOURS {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default().fg(Color::Green)
+    }
+}
+
+/// Returns the style for equity bar insertion age.
+///
+/// Red when the most recent bar is older than [`BARS_STALE_WEEKDAY_HOURS`]
+/// on a weekday (nightly ingest is expected). On weekends staleness is normal
+/// and the indicator stays green.
+fn bars_age_style(inserted_at: chrono::DateTime<Utc>) -> Style {
+    use chrono::Datelike;
+    use chrono::Weekday;
+    let now = Utc::now();
+    let hours = (now - inserted_at).num_hours();
+    let is_weekday = matches!(
+        now.weekday(),
+        Weekday::Mon | Weekday::Tue | Weekday::Wed | Weekday::Thu | Weekday::Fri
+    );
+    if is_weekday && hours > BARS_STALE_WEEKDAY_HOURS {
+        Style::default().fg(Color::Red)
+    } else {
+        Style::default().fg(Color::Green)
+    }
 }
 
 /// Formats the age of a prediction timestamp as a human-readable string.
@@ -92,11 +206,11 @@ pub fn format_age(timestamp: chrono::DateTime<Utc>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{Duration, Utc};
+    use chrono::{Duration, NaiveDate, Utc};
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
 
-    use crate::dashboard_service::cache::{DashboardState, PredictionRow};
+    use crate::dashboard_service::cache::{DashboardState, ModelRunInformation, PredictionRow};
     use crate::domain::market::Ticker;
 
     fn render_to_string(width: u16, height: u16, state: &DashboardState) -> String {
@@ -206,5 +320,65 @@ mod tests {
         // Timestamp in the future (e.g. DB clock ahead of TUI host).
         let timestamp = Utc::now() + Duration::minutes(5);
         assert_eq!(format_age(timestamp), "0m");
+    }
+
+    fn make_model_run_information(hours_ago: i64) -> ModelRunInformation {
+        ModelRunInformation {
+            completed_at: Utc::now() - Duration::hours(hours_ago),
+            start_date: NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
+            end_date: NaiveDate::from_ymd_opt(2025, 12, 31).unwrap(),
+            continuous_ranked_probability_score: Some(0.123),
+            directional_accuracy: Some(0.725),
+        }
+    }
+
+    #[test]
+    fn test_render_predictions_shows_freshness_line_with_model_info() {
+        let mut state = DashboardState::default();
+        state.predictions = vec![make_prediction("AAPL", -0.001, 0.002, 0.005)];
+        state.model_run_information = Some(make_model_run_information(2));
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("Run:"));
+        assert!(output.contains("CRPS:"));
+        assert!(output.contains("DA:"));
+    }
+
+    #[test]
+    fn test_render_predictions_shows_no_completed_runs_when_none() {
+        let mut state = DashboardState::default();
+        state.predictions = vec![make_prediction("AAPL", -0.001, 0.002, 0.005)];
+        // model_run_information is None by default
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("no completed runs"));
+    }
+
+    #[test]
+    fn test_render_predictions_shows_bars_freshness_when_present() {
+        let mut state = DashboardState::default();
+        state.predictions = vec![make_prediction("AAPL", -0.001, 0.002, 0.005)];
+        state.latest_bars_inserted_at = Some(Utc::now() - Duration::hours(3));
+        let output = render_to_string(120, 40, &state);
+        assert!(output.contains("Bars:"));
+    }
+
+    #[test]
+    fn test_model_run_age_style_green_when_fresh() {
+        let info = make_model_run_information(1);
+        let style = model_run_age_style(&info);
+        assert_eq!(style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn test_model_run_age_style_yellow_when_warning() {
+        let info = make_model_run_information(30);
+        let style = model_run_age_style(&info);
+        assert_eq!(style.fg, Some(Color::Yellow));
+    }
+
+    #[test]
+    fn test_model_run_age_style_red_when_stale() {
+        let info = make_model_run_information(40);
+        let style = model_run_age_style(&info);
+        assert_eq!(style.fg, Some(Color::Red));
     }
 }

--- a/src/dashboard_service/predictions.rs
+++ b/src/dashboard_service/predictions.rs
@@ -14,14 +14,13 @@ const MODEL_RUN_STALE_HOURS: i64 = 36;
 /// Age threshold in hours above which model run data is approaching stale (warning).
 const MODEL_RUN_WARNING_HOURS: i64 = 25;
 
-/// Age threshold in hours above which equity bar data is considered stale on a weekday.
-const BARS_STALE_WEEKDAY_HOURS: i64 = 25;
-
 /// Renders Tab 4: a table of the latest quantile predictions with model run age.
 ///
 /// When model run metadata is available, renders a one-line freshness summary
 /// (run age, CRPS, directional accuracy, and bar insertion age) above the
-/// prediction table inside the outer block.
+/// prediction table inside the outer block. The freshness line is always
+/// rendered, even when the prediction table is empty, so operators can diagnose
+/// stale or failed runs without a populated prediction set.
 pub fn render_predictions(
     frame: &mut ratatui::Frame,
     area: ratatui::layout::Rect,
@@ -30,14 +29,6 @@ pub fn render_predictions(
     let outer_block = Block::default()
         .title("Model Predictions")
         .borders(Borders::ALL);
-
-    if state.predictions.is_empty() {
-        let placeholder = Paragraph::new("No predictions available")
-            .block(outer_block)
-            .style(Style::default().fg(Color::DarkGray));
-        frame.render_widget(placeholder, area);
-        return;
-    }
 
     let inner_area = outer_block.inner(area);
     frame.render_widget(outer_block, area);
@@ -48,7 +39,13 @@ pub fn render_predictions(
         .split(inner_area);
 
     render_freshness_line(frame, chunks[0], state);
-    render_predictions_table(frame, chunks[1], state);
+    if state.predictions.is_empty() {
+        let placeholder =
+            Paragraph::new("No predictions available").style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(placeholder, chunks[1]);
+    } else {
+        render_predictions_table(frame, chunks[1], state);
+    }
 }
 
 /// Renders the one-line freshness summary: model run age, CRPS, DA, and bar age.
@@ -69,16 +66,16 @@ fn render_freshness_line(
         Some(info) => {
             let age_style = model_run_age_style(info);
             spans.push(Span::raw("Run: "));
-            spans.push(Span::styled(format_age(info.completed_at), age_style));
+            spans.push(Span::styled(format_age(info.completed_at()), age_style));
 
-            if let Some(crps) = info.continuous_ranked_probability_score {
+            if let Some(crps) = info.continuous_ranked_probability_score() {
                 spans.push(Span::styled(
                     "  CRPS: ",
                     Style::default().fg(Color::DarkGray),
                 ));
                 spans.push(Span::raw(format!("{crps:.3}")));
             }
-            if let Some(directional_accuracy) = info.directional_accuracy {
+            if let Some(directional_accuracy) = info.directional_accuracy() {
                 spans.push(Span::styled("  DA: ", Style::default().fg(Color::DarkGray)));
                 spans.push(Span::raw(format!("{:.1}%", directional_accuracy * 100.0)));
             }
@@ -154,10 +151,10 @@ fn render_predictions_table(
 /// Red when older than [`MODEL_RUN_STALE_HOURS`], yellow when older than
 /// [`MODEL_RUN_WARNING_HOURS`], green otherwise.
 fn model_run_age_style(info: &ModelRunInformation) -> Style {
-    let hours = (Utc::now() - info.completed_at).num_hours();
-    if hours > MODEL_RUN_STALE_HOURS {
+    let age = Utc::now() - info.completed_at();
+    if age > chrono::Duration::hours(MODEL_RUN_STALE_HOURS) {
         Style::default().fg(Color::Red)
-    } else if hours > MODEL_RUN_WARNING_HOURS {
+    } else if age > chrono::Duration::hours(MODEL_RUN_WARNING_HOURS) {
         Style::default().fg(Color::Yellow)
     } else {
         Style::default().fg(Color::Green)
@@ -166,19 +163,39 @@ fn model_run_age_style(info: &ModelRunInformation) -> Style {
 
 /// Returns the style for equity bar insertion age.
 ///
-/// Red when the most recent bar is older than [`BARS_STALE_WEEKDAY_HOURS`]
-/// on a weekday (nightly ingest is expected). On weekends staleness is normal
-/// and the indicator stays green.
+/// On weekdays, flags as red when the last expected nightly ingest date has
+/// been missed — e.g. on Monday the last expected ingest date is Friday, so
+/// bars older than Friday are stale. On weekends, staleness is expected and
+/// the indicator stays green. Delegates to [`compute_bars_age_style`] so the
+/// logic can be tested with a fixed clock.
 fn bars_age_style(inserted_at: chrono::DateTime<Utc>) -> Style {
-    use chrono::Datelike;
-    use chrono::Weekday;
-    let now = Utc::now();
-    let hours = (now - inserted_at).num_hours();
-    let is_weekday = matches!(
-        now.weekday(),
-        Weekday::Mon | Weekday::Tue | Weekday::Wed | Weekday::Thu | Weekday::Fri
-    );
-    if is_weekday && hours > BARS_STALE_WEEKDAY_HOURS {
+    compute_bars_age_style(inserted_at, Utc::now())
+}
+
+/// Computes the bar staleness style given an explicit `now` for testability.
+///
+/// Red on weekdays when `inserted_at` predates the most recent expected
+/// ingest date (last weekday before today, accounting for the weekend gap
+/// on Monday). Green on weekends and when the bar is current.
+fn compute_bars_age_style(inserted_at: chrono::DateTime<Utc>, now: chrono::DateTime<Utc>) -> Style {
+    use chrono::{Datelike, Duration, Weekday};
+    if inserted_at >= now {
+        return Style::default().fg(Color::Green);
+    }
+    // On weekends ingest doesn't run — suppress false positives
+    if matches!(now.weekday(), Weekday::Sat | Weekday::Sun) {
+        return Style::default().fg(Color::Green);
+    }
+    // Find the last weekday before today (the most recent expected ingest date),
+    // accounting for Monday where "yesterday" was Sunday
+    let yesterday = now.date_naive() - Duration::days(1);
+    let skip = match yesterday.weekday() {
+        Weekday::Sat => 1,
+        Weekday::Sun => 2,
+        _ => 0,
+    };
+    let last_expected_ingest_date = yesterday - Duration::days(skip);
+    if inserted_at.date_naive() < last_expected_ingest_date {
         Style::default().fg(Color::Red)
     } else {
         Style::default().fg(Color::Green)
@@ -323,13 +340,14 @@ mod tests {
     }
 
     fn make_model_run_information(hours_ago: i64) -> ModelRunInformation {
-        ModelRunInformation {
-            completed_at: Utc::now() - Duration::hours(hours_ago),
-            start_date: NaiveDate::from_ymd_opt(2025, 1, 1).unwrap(),
-            end_date: NaiveDate::from_ymd_opt(2025, 12, 31).unwrap(),
-            continuous_ranked_probability_score: Some(0.123),
-            directional_accuracy: Some(0.725),
-        }
+        ModelRunInformation::new(
+            Utc::now() - Duration::hours(hours_ago),
+            Some(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
+            Some(NaiveDate::from_ymd_opt(2025, 12, 31).unwrap()),
+            Some(0.123),
+            Some(0.725),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -380,5 +398,50 @@ mod tests {
         let info = make_model_run_information(40);
         let style = model_run_age_style(&info);
         assert_eq!(style.fg, Some(Color::Red));
+    }
+
+    // --- compute_bars_age_style tests (clock-independent, use fixed dates) ---
+
+    fn make_utc(year: i32, month: u32, day: u32, hour: u32) -> chrono::DateTime<Utc> {
+        NaiveDate::from_ymd_opt(year, month, day)
+            .unwrap()
+            .and_hms_opt(hour, 0, 0)
+            .unwrap()
+            .and_utc()
+    }
+
+    #[test]
+    fn test_compute_bars_age_style_green_on_monday_after_weekend_gap() {
+        // Monday 2025-01-06 09:00, bars from Friday 2025-01-03 22:00 (~35h gap, no missed ingest)
+        let now = make_utc(2025, 1, 6, 9);
+        let inserted_at = make_utc(2025, 1, 3, 22);
+        let style = compute_bars_age_style(inserted_at, now);
+        assert_eq!(style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn test_compute_bars_age_style_red_when_weekday_ingest_missed() {
+        // Tuesday 2025-01-07 09:00, bars from Friday 2025-01-03 22:00 (Monday ingest missed)
+        let now = make_utc(2025, 1, 7, 9);
+        let inserted_at = make_utc(2025, 1, 3, 22);
+        let style = compute_bars_age_style(inserted_at, now);
+        assert_eq!(style.fg, Some(Color::Red));
+    }
+
+    #[test]
+    fn test_compute_bars_age_style_green_on_weekend() {
+        // Saturday 2025-01-04 09:00, bars from Thursday 2025-01-02 22:00 (>48h, but weekend)
+        let now = make_utc(2025, 1, 4, 9);
+        let inserted_at = make_utc(2025, 1, 2, 22);
+        let style = compute_bars_age_style(inserted_at, now);
+        assert_eq!(style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn test_compute_bars_age_style_green_future_timestamp() {
+        let now = make_utc(2025, 1, 7, 9);
+        let inserted_at = make_utc(2025, 1, 7, 10); // future
+        let style = compute_bars_age_style(inserted_at, now);
+        assert_eq!(style.fg, Some(Color::Green));
     }
 }


### PR DESCRIPTION
# Overview

## Changes

- Adds `ModelRunInformation` struct to `cache.rs` capturing completed model run metadata (completion time, training window, CRPS, directional accuracy)
- Adds three new fields to `DashboardState`: `model_run_information`, `latest_bars_inserted_at`, `last_rebalance_completed_at`
- Adds three new read-only queries to `database.rs`: latest completed model run, `MAX(inserted_at)` from `equity_bars`, `MAX(completed_at)` from `equity_rebalance_sessions`
- Tab 4 (Predictions): renders a one-line freshness header inside the block showing model run age (green <25h, yellow 25–36h, red >36h), CRPS, directional accuracy, and bar insertion age (red on weekdays >25h)
- Tab 1 (Positions): block title includes last rebalance age (green <10m, yellow 10–30m, red >30m) when a completed session exists
- fixes #869

## Context

Builds on the dashboard_service foundation and five-tab TUI views in the `tui-views` branch. Freshness thresholds reflect the nightly cadence for equity bars and model runs, and the five-minute rebalance evaluation cadence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard freshness details for model runs, recent data inserts, and rebalance completion times.
  * Enhanced the Predictions view with a summary showing model age, accuracy metrics, and data recency.
  * Updated the Positions view to show rebalance timing alongside the table title.

* **Bug Fixes**
  * Improved visibility into stale or missing dashboard data with clearer status styling and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->