### PR TITLE
Harden `dashboard_service` string fields to domain types

### DIFF
--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -119,6 +119,41 @@ impl EventType {
             Self::PortfolioLiquidationErrored => "portfolio_liquidation_errored",
         }
     }
+
+    /// Parses a stored event type string. Returns `None` for unknown values.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "equity_bars_sync_requested" => Some(Self::EquityBarsSyncRequested),
+            "equity_bars_sync_started" => Some(Self::EquityBarsSyncStarted),
+            "equity_bars_sync_completed" => Some(Self::EquityBarsSyncCompleted),
+            "equity_bars_sync_errored" => Some(Self::EquityBarsSyncErrored),
+            "equity_bars_export_requested" => Some(Self::EquityBarsExportRequested),
+            "equity_bars_export_started" => Some(Self::EquityBarsExportStarted),
+            "equity_bars_export_completed" => Some(Self::EquityBarsExportCompleted),
+            "equity_bars_export_errored" => Some(Self::EquityBarsExportErrored),
+            "trading_history_export_requested" => Some(Self::TradingHistoryExportRequested),
+            "trading_history_export_started" => Some(Self::TradingHistoryExportStarted),
+            "trading_history_export_completed" => Some(Self::TradingHistoryExportCompleted),
+            "trading_history_export_errored" => Some(Self::TradingHistoryExportErrored),
+            "database_backup_requested" => Some(Self::DatabaseBackupRequested),
+            "database_backup_started" => Some(Self::DatabaseBackupStarted),
+            "database_backup_completed" => Some(Self::DatabaseBackupCompleted),
+            "database_backup_errored" => Some(Self::DatabaseBackupErrored),
+            "market_session_check" => Some(Self::MarketSessionCheck),
+            "equity_predictions_requested" => Some(Self::EquityPredictionsRequested),
+            "equity_predictions_started" => Some(Self::EquityPredictionsStarted),
+            "equity_predictions_completed" => Some(Self::EquityPredictionsCompleted),
+            "equity_predictions_errored" => Some(Self::EquityPredictionsErrored),
+            "portfolio_rebalance_started" => Some(Self::PortfolioRebalanceStarted),
+            "portfolio_rebalance_completed" => Some(Self::PortfolioRebalanceCompleted),
+            "portfolio_rebalance_errored" => Some(Self::PortfolioRebalanceErrored),
+            "portfolio_liquidation_requested" => Some(Self::PortfolioLiquidationRequested),
+            "portfolio_liquidation_started" => Some(Self::PortfolioLiquidationStarted),
+            "portfolio_liquidation_completed" => Some(Self::PortfolioLiquidationCompleted),
+            "portfolio_liquidation_errored" => Some(Self::PortfolioLiquidationErrored),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for EventType {
@@ -288,6 +323,56 @@ mod tests {
             .enable_all()
             .build()
             .unwrap()
+    }
+
+    #[test]
+    fn test_event_type_parse_round_trips_all_variants() {
+        // Every as_str() output must parse back to the same variant.
+        let all: &[EventType] = &[
+            EventType::EquityBarsSyncRequested,
+            EventType::EquityBarsSyncStarted,
+            EventType::EquityBarsSyncCompleted,
+            EventType::EquityBarsSyncErrored,
+            EventType::EquityBarsExportRequested,
+            EventType::EquityBarsExportStarted,
+            EventType::EquityBarsExportCompleted,
+            EventType::EquityBarsExportErrored,
+            EventType::TradingHistoryExportRequested,
+            EventType::TradingHistoryExportStarted,
+            EventType::TradingHistoryExportCompleted,
+            EventType::TradingHistoryExportErrored,
+            EventType::DatabaseBackupRequested,
+            EventType::DatabaseBackupStarted,
+            EventType::DatabaseBackupCompleted,
+            EventType::DatabaseBackupErrored,
+            EventType::MarketSessionCheck,
+            EventType::EquityPredictionsRequested,
+            EventType::EquityPredictionsStarted,
+            EventType::EquityPredictionsCompleted,
+            EventType::EquityPredictionsErrored,
+            EventType::PortfolioRebalanceStarted,
+            EventType::PortfolioRebalanceCompleted,
+            EventType::PortfolioRebalanceErrored,
+            EventType::PortfolioLiquidationRequested,
+            EventType::PortfolioLiquidationStarted,
+            EventType::PortfolioLiquidationCompleted,
+            EventType::PortfolioLiquidationErrored,
+        ];
+        for &event_type in all {
+            assert_eq!(
+                EventType::parse(event_type.as_str()),
+                Some(event_type),
+                "parse round-trip failed for {:?}",
+                event_type
+            );
+        }
+    }
+
+    #[test]
+    fn test_event_type_parse_rejects_unknown() {
+        assert_eq!(EventType::parse("unknown_event"), None);
+        assert_eq!(EventType::parse(""), None);
+        assert_eq!(EventType::parse("EQUITY_BARS_SYNC_COMPLETED"), None);
     }
 
     #[test]

--- a/src/dashboard_service/cache.rs
+++ b/src/dashboard_service/cache.rs
@@ -19,7 +19,9 @@ use sqlx::PgPool;
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
+use crate::common::events::EventType;
 use crate::domain::market::{PairID, Ticker};
+use crate::domain::trading::CloseReason;
 
 /// How often the background task refreshes all static view data from Postgres.
 const POLL_INTERVAL_SECONDS: u64 = 30;
@@ -65,7 +67,7 @@ pub struct ClosedTrade {
     pub return_percent: Option<Decimal>,
     /// Seconds the position was held; computed from `opened_at`/`closed_at` timestamps.
     pub holding_seconds: Option<i64>,
-    pub close_reason: Option<String>,
+    pub close_reason: Option<CloseReason>,
     pub closed_at: Option<DateTime<Utc>>,
 }
 
@@ -169,7 +171,7 @@ impl ModelRunInformation {
 #[derive(Debug, Clone)]
 pub struct EventEntry {
     pub event_id: i64,
-    pub event_type: String,
+    pub event_type: EventType,
     pub payload: serde_json::Value,
     pub received_at: DateTime<Utc>,
 }
@@ -297,15 +299,22 @@ pub fn spawn_event_listener_task(state: SharedState, pool: PgPool) {
                             warn!("Event notification missing event_id field");
                             continue;
                         };
-                        let Some(event_type) =
+                        let Some(event_type_str) =
                             parsed.get("event_type").and_then(serde_json::Value::as_str)
                         else {
                             warn!("Event notification missing event_type field");
                             continue;
                         };
+                        let Some(event_type) = EventType::parse(event_type_str) else {
+                            warn!(
+                                event_type = event_type_str,
+                                "Unknown event type in notification, skipping"
+                            );
+                            continue;
+                        };
                         let entry = EventEntry {
                             event_id,
-                            event_type: event_type.to_string(),
+                            event_type,
                             payload: parsed
                                 .get("payload")
                                 .cloned()
@@ -389,12 +398,12 @@ mod tests {
     fn test_event_entry_fields() {
         let entry = EventEntry {
             event_id: 42,
-            event_type: "portfolio_rebalance_completed".to_string(),
+            event_type: EventType::PortfolioRebalanceCompleted,
             payload: serde_json::json!({"session_id": "abc"}),
             received_at: Utc::now(),
         };
         assert_eq!(entry.event_id, 42);
-        assert_eq!(entry.event_type, "portfolio_rebalance_completed");
+        assert_eq!(entry.event_type, EventType::PortfolioRebalanceCompleted);
         assert_eq!(entry.payload["session_id"], "abc");
     }
 
@@ -418,7 +427,7 @@ mod tests {
             realized_profit_and_loss: Some(rust_decimal::Decimal::new(500, 0)),
             return_percent: Some(rust_decimal::Decimal::new(5, 2)),
             holding_seconds: Some(3600),
-            close_reason: Some("profit_taken".to_string()),
+            close_reason: Some(CloseReason::ProfitTaken),
             closed_at: Some(Utc::now()),
         };
         assert_eq!(trade.pair_id.as_str(), "TSLA-NVDA");

--- a/src/dashboard_service/events.rs
+++ b/src/dashboard_service/events.rs
@@ -151,7 +151,7 @@ fn render_event_list(
     let items: Vec<ListItem> = state
         .events
         .iter()
-        .filter(|entry| events_state.filter.matches(&entry.event_type))
+        .filter(|entry| events_state.filter.matches(entry.event_type.as_str()))
         .map(|entry| {
             let time = entry.received_at.format("%H:%M:%S").to_string();
             let payload_summary = truncate_payload(&entry.payload);
@@ -159,7 +159,7 @@ fn render_event_list(
                 Span::styled(format!("{time}  "), Style::default().fg(Color::DarkGray)),
                 Span::styled(
                     format!("{:<42}", entry.event_type),
-                    event_type_style(&entry.event_type),
+                    event_type_style(entry.event_type.as_str()),
                 ),
                 Span::styled(payload_summary, Style::default().fg(Color::DarkGray)),
             ]))
@@ -216,6 +216,7 @@ mod tests {
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
 
+    use crate::common::events::EventType;
     use crate::dashboard_service::cache::{DashboardState, EventEntry};
 
     fn render_to_string(
@@ -242,7 +243,8 @@ mod tests {
     fn make_event(event_type: &str) -> EventEntry {
         EventEntry {
             event_id: 1,
-            event_type: event_type.to_string(),
+            event_type: EventType::parse(event_type)
+                .unwrap_or_else(|| panic!("unknown test event type: {event_type}")),
             payload: serde_json::json!({"session_id": "abc"}),
             received_at: Utc::now(),
         }

--- a/src/dashboard_service/trades.rs
+++ b/src/dashboard_service/trades.rs
@@ -91,7 +91,14 @@ fn render_trades_table(
                         .map(format_holding_duration)
                         .unwrap_or_else(|| "—".to_string()),
                 ),
-                Cell::from(trade.close_reason.as_deref().unwrap_or("—").to_string()),
+                Cell::from(
+                    trade
+                        .close_reason
+                        .as_ref()
+                        .map(|reason| reason.as_str())
+                        .unwrap_or("—")
+                        .to_string(),
+                ),
                 Cell::from(
                     trade
                         .closed_at
@@ -178,6 +185,7 @@ mod tests {
 
     use crate::dashboard_service::cache::{ClosedTrade, DashboardState};
     use crate::domain::market::{PairID, Ticker};
+    use crate::domain::trading::CloseReason;
 
     fn render_to_string(width: u16, height: u16, state: &DashboardState) -> String {
         let backend = TestBackend::new(width, height);
@@ -209,7 +217,7 @@ mod tests {
             realized_profit_and_loss: profit_and_loss.map(|v| Decimal::new(v, 0)),
             return_percent: return_percent.map(|s| s.parse::<Decimal>().expect("valid decimal")),
             holding_seconds,
-            close_reason: Some("profit_taken".to_string()),
+            close_reason: Some(CloseReason::ProfitTaken),
             closed_at: Some(Utc::now()),
         }
     }

--- a/src/domain/signals.rs
+++ b/src/domain/signals.rs
@@ -1,5 +1,6 @@
 //! Regime classification and signal gating types.
 
+use crate::domain::market::Ticker;
 use crate::domain::primitives::Percent;
 use serde::{Deserialize, Serialize};
 
@@ -40,7 +41,7 @@ pub struct ConfidenceFloor(pub Percent);
 /// A single equity signal from the ensemble model.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Signal {
-    pub ticker: String,
+    pub ticker: Ticker,
     /// Ensemble confidence in this signal, in `[0.0, 1.0]`.
     pub confidence: Percent,
     /// Predicted price return for the next period.
@@ -183,10 +184,13 @@ mod tests {
         returns
             .iter()
             .enumerate()
-            .map(|(index, &predicted_return)| Signal {
-                ticker: format!("TICK{}", index),
-                confidence: Percent::new(0.8).unwrap(),
-                predicted_return,
+            .map(|(index, &predicted_return)| {
+                let letter = (b'A' + (index as u8 % 26)) as char;
+                Signal {
+                    ticker: Ticker::new(&format!("TST{letter}")).unwrap(),
+                    confidence: Percent::new(0.8).unwrap(),
+                    predicted_return,
+                }
             })
             .collect()
     }

--- a/src/domain/signals.rs
+++ b/src/domain/signals.rs
@@ -185,7 +185,7 @@ mod tests {
             .iter()
             .enumerate()
             .map(|(index, &predicted_return)| {
-                let letter = (b'A' + (index as u8 % 26)) as char;
+                let letter = (b'A' + (index % 26) as u8) as char;
                 Signal {
                     ticker: Ticker::new(&format!("TST{letter}")).unwrap(),
                     confidence: Percent::new(0.8).unwrap(),

--- a/src/domain/trading.rs
+++ b/src/domain/trading.rs
@@ -148,6 +148,48 @@ impl SnapshotType {
     }
 }
 
+/// Reason a long-short pair position was closed.
+///
+/// Mirrors the `CHECK` constraint on `equity_pairs.close_reason`:
+/// `('profit_taken', 'stop_loss', 'rebalance', 'end_of_day')`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
+#[sqlx(type_name = "text", rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
+pub enum CloseReason {
+    ProfitTaken,
+    StopLoss,
+    Rebalance,
+    EndOfDay,
+}
+
+impl CloseReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ProfitTaken => "profit_taken",
+            Self::StopLoss => "stop_loss",
+            Self::Rebalance => "rebalance",
+            Self::EndOfDay => "end_of_day",
+        }
+    }
+
+    /// Parses a stored database value. Returns `None` for unknown values.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "profit_taken" => Some(Self::ProfitTaken),
+            "stop_loss" => Some(Self::StopLoss),
+            "rebalance" => Some(Self::Rebalance),
+            "end_of_day" => Some(Self::EndOfDay),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for CloseReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
 /// Groups one full rebalance cycle from allocation through order submission.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EquityRebalanceSession {
@@ -713,6 +755,45 @@ mod tests {
 
     fn make_pair_id() -> PairID {
         PairID::new(Ticker::new("AAPL").unwrap(), Ticker::new("MSFT").unwrap())
+    }
+
+    #[test]
+    fn test_close_reason_round_trip() {
+        for reason in [
+            CloseReason::ProfitTaken,
+            CloseReason::StopLoss,
+            CloseReason::Rebalance,
+            CloseReason::EndOfDay,
+        ] {
+            assert_eq!(CloseReason::parse(reason.as_str()), Some(reason.clone()));
+            let serialized = serde_json::to_string(&reason).unwrap();
+            assert_eq!(serialized, format!("\"{}\"", reason.as_str()));
+            let deserialized: CloseReason = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(deserialized, reason);
+        }
+    }
+
+    #[test]
+    fn test_close_reason_parse_rejects_unknown() {
+        assert_eq!(CloseReason::parse("expired"), None);
+        assert_eq!(CloseReason::parse("PROFIT_TAKEN"), None);
+    }
+
+    #[test]
+    fn test_close_reason_display() {
+        assert_eq!(CloseReason::ProfitTaken.to_string(), "profit_taken");
+        assert_eq!(CloseReason::StopLoss.to_string(), "stop_loss");
+        assert_eq!(CloseReason::Rebalance.to_string(), "rebalance");
+        assert_eq!(CloseReason::EndOfDay.to_string(), "end_of_day");
+    }
+
+    #[test]
+    fn test_close_reason_matches_schema_check_constraint() {
+        // Values must exactly match the CHECK constraint in schema.sql.
+        assert_eq!(CloseReason::ProfitTaken.as_str(), "profit_taken");
+        assert_eq!(CloseReason::StopLoss.as_str(), "stop_loss");
+        assert_eq!(CloseReason::Rebalance.as_str(), "rebalance");
+        assert_eq!(CloseReason::EndOfDay.as_str(), "end_of_day");
     }
 
     #[test]

--- a/src/domain/trading.rs
+++ b/src/domain/trading.rs
@@ -163,6 +163,7 @@ pub enum CloseReason {
 }
 
 impl CloseReason {
+    /// Returns the database string identifier for this close reason.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::ProfitTaken => "profit_taken",


### PR DESCRIPTION
# Overview

## Changes

- Adds `CloseReason` enum to `src/domain/trading.rs` with variants `ProfitTaken`, `StopLoss`, `Rebalance`, `EndOfDay`, mirroring the `equity_pairs.close_reason` CHECK constraint; implements `sqlx::Type`, `Serialize`/`Deserialize`, `as_str`, `parse`, and `Display`
- Adds `EventType::parse(value: &str) -> Option<Self>` to `src/common/events.rs` covering all 28 variants with an exhaustive round-trip test
- Updates `ClosedTrade.close_reason: Option<String>` → `Option<CloseReason>` and `EventEntry.event_type: String` → `EventType` across `cache.rs`, `database.rs`, `events.rs`, and `trades.rs`
- Updates `spawn_event_listener_task` to parse NOTIFY event type strings and skip unknown types with a structured warning rather than storing a raw string
- Hardens `Signal.ticker: String` → `Ticker` in `src/domain/signals.rs`, enforcing validated ticker format at the ensemble signal boundary
- fixes #960

## Context

The `CloseReason` enum mirrors the four-value CHECK constraint on `equity_pairs.close_reason`, following the same pattern as `EquityPairStatus`, `SnapshotType`, and other enums in `trading.rs`.

`EventType::parse` was added to the existing `common::events::EventType` rather than creating a second type. The dashboard event listener skips unknown event type strings (log warning, no entry added to the ring buffer), which is the correct behavior for a display-only service that may encounter event types added by other services before a code update.

`Signal.ticker` was always semantically a validated ticker symbol; this change makes that constraint explicit at the type level. The field was only ever constructed in tests, so the impact is contained to the `make_signals` test helper in `signals.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved event and trade handling with consistent, human-readable reason and type labels across the dashboard.

* **Bug Fixes**
  * Unknown event types are now safely ignored instead of being stored incorrectly.
  * Event filters and styling now work more reliably with normalized event type values.
  * Trade close reasons now display correctly, including a dash when no reason is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->