### PR TITLE
Update devenv lock and CI workflow configuration

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -38,7 +38,6 @@ jobs:
         if: steps.changes.outputs.rust == 'true'
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: .
           cache-on-failure: false
           shared-key: rust-continuous-integration
           save-if: true
@@ -59,6 +58,7 @@ jobs:
         if: steps.changes.outputs.rust == 'true'
         env:
           SQLX_OFFLINE: "true"
+          CARGO_INCREMENTAL: "0"
         run: >-
           devenv --secretspec-provider env --secretspec-profile development
           tasks run checks:rust

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1781195293,
-        "narHash": "sha256-C9OFghpvf3RzK2rGsZjjNNrTrHgFOecEkpDhFnU4QGs=",
+        "lastModified": 1783109842,
+        "narHash": "sha256-Fi7lW+sg1ChduOOQRBCK5JeA1cw4x5wSjIJcppRGGqQ=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "5f5109c83854577191634f7b86fc6e0c8fd44964",
+        "rev": "e30eb49258bee68353bd9c619823f635f4afa86c",
         "type": "github"
       },
       "original": {
@@ -36,43 +36,21 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -81,11 +59,11 @@
         "nixpkgs-src": "nixpkgs-src"
       },
       "locked": {
-        "lastModified": 1778507786,
-        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
+        "lastModified": 1782924808,
+        "narHash": "sha256-tn2ahNv3ZNXyVHdPx/uw+N0xa7YSMtXUr6OEvu+s8ng=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
+        "rev": "e2c881cb8d5f1cac6cef9d71f0d450a55691b999",
         "type": "github"
       },
       "original": {
@@ -98,11 +76,11 @@
     "nixpkgs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778274207,
-        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
+        "lastModified": 1782636521,
+        "narHash": "sha256-OG8laCOGtkxlB1JH3XqOnXxnkGJme4mQdXo5hkhCQIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
+        "rev": "e1c1b84752fb0897897380a3cae9dc7fcab91ca3",
         "type": "github"
       },
       "original": {

--- a/devenv.nix
+++ b/devenv.nix
@@ -192,7 +192,13 @@ in {
     markdownlint-cli
     postgresql_16
     rustup
-    sqlfluff
+    (sqlfluff.overridePythonAttrs (_: {
+      # The aarch64-darwin binary is not cached on cache.nixos.org for this
+      # nixpkgs revision; building from source runs the full pytest suite which
+      # exceeds available memory (OOM kill). Tests are validated by Hydra when
+      # producing the Linux binary cache entry.
+      doCheck = false;
+    }))
     sqlx-cli
     statix
     taplo


### PR DESCRIPTION
## Summary

- Update `devenv.lock` to latest nixpkgs rolling pin, resolving a missing Nix store path
  (`fix-kill-doctest.patch` for coreutils) that blocked VM provisioning
- Override sqlfluff build to skip check phase on aarch64-darwin where the binary cache has no
  pre-built artifact and the test suite exceeds available memory (OOM kill)
- Remove redundant `workspaces: .` default from rust-cache action
- Disable incremental compilation in CI (`CARGO_INCREMENTAL=0`) where it adds overhead without benefit

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and local development tooling settings to make builds more reliable and resource-efficient.
  * Adjusted Rust check environment settings to reduce incremental build overhead during validation.
  * Modified the SQL linting tool setup to skip an unavailable test suite in this environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->