### PR TITLE
Fix broken isProduction conditional and wire up git-sync for production

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -1,13 +1,6 @@
 {pkgs, ...}: let
   awsRegion = "us-east-1";
 
-  rawFundProfile = builtins.getEnv "FUND_PROFILE";
-  fundProfile =
-    if rawFundProfile == ""
-    then "development"
-    else rawFundProfile;
-  isProduction = fundProfile == "production";
-
   # Compute bucket name and secretspec profile at shell/process start time from
   # $FUND_PROFILE, which dotenv sets from .env. These cannot be baked in at Nix
   # evaluation time because dotenv runs after Nix evaluates devenv.nix. Model
@@ -19,6 +12,10 @@
     export SECRETSPEC_PROFILE="''${FUND_PROFILE}"
     export AWS_S3_MODEL_ARTIFACTS_BUCKET_NAME="$AWS_S3_BUCKET_NAME"
     export AWS_S3_MODEL_ARTIFACT_PATH="models/tide/"
+    if [[ ! -w "''${FUND_LOG_DIR:-/var/log/fund}" ]]; then
+      export FUND_LOG_DIR="$HOME/.local/state/fund/log"
+    fi
+    mkdir -p "$FUND_LOG_DIR" 2>/dev/null || true
   '';
 
   applySchema = ''
@@ -40,15 +37,10 @@
     then "365"
     else rawLookbackDays;
 
-  # Log directory. Production keeps the root-owned /var/log/fund path
-  # (provisioned on the VM, where logrotate and monitoring expect it). Local
-  # development points FUND_LOG_DIR at an XDG state path so file logging works
-  # without sudo.
-  homeDirectory = builtins.getEnv "HOME";
-  fundLogDir =
-    if isProduction
-    then "/var/log/fund"
-    else "${homeDirectory}/.local/state/fund/log";
+  # Log directory. VMs use /var/log/fund (provisioned by bootstrap-machine).
+  # The runtimeEnv block above detects when that path is not writable (e.g.
+  # local laptop without bootstrap) and falls back to an XDG state path.
+  fundLogDir = "/var/log/fund";
 in {
   dotenv.enable = true;
 
@@ -646,60 +638,32 @@ in {
         done
       '';
     in {
-      data-manager.exec =
-        if isProduction
-        then ''
-          set -euo pipefail
-          ${runtimeEnv}
-          ${waitForPostgres}
-          ${applySchema}
-          ${killPort "8080"}
-          exec secretspec run -- cargo run --no-default-features --features data_manager --bin data_manager --release
-        ''
-        else ''
-          set -euo pipefail
-          ${runtimeEnv}
-          ${waitForPostgres}
-          ${applySchema}
-          ${killPort "8080"}
-          exec secretspec run -- cargo watch -x 'run --no-default-features --features data_manager --bin data_manager'
-        '';
+      data-manager.exec = ''
+        set -euo pipefail
+        ${runtimeEnv}
+        ${waitForPostgres}
+        ${applySchema}
+        ${killPort "8080"}
+        exec secretspec run -- cargo run --release --bin data_manager
+      '';
 
       # ensemble_manager: serves predictions over HTTP and consumes
       # predictions_requested from the Postgres event bus.
-      ensemble-manager.exec =
-        if isProduction
-        then ''
-          set -euo pipefail
-          ${runtimeEnv}
-          ${waitForPostgres}
-          ${killPort "8082"}
-          exec secretspec run -- cargo run --no-default-features --features ensemble_manager --bin ensemble_manager --release
-        ''
-        else ''
-          set -euo pipefail
-          ${runtimeEnv}
-          ${waitForPostgres}
-          ${killPort "8082"}
-          exec secretspec run -- cargo watch -x 'run --no-default-features --features ensemble_manager --bin ensemble_manager'
-        '';
+      ensemble-manager.exec = ''
+        set -euo pipefail
+        ${runtimeEnv}
+        ${waitForPostgres}
+        ${killPort "8082"}
+        exec secretspec run -- cargo run --release --bin ensemble_manager
+      '';
 
-      portfolio-manager.exec =
-        if isProduction
-        then ''
-          set -euo pipefail
-          ${runtimeEnv}
-          ${waitForPostgres}
-          ${killPort "8083"}
-          exec secretspec run -- cargo run --no-default-features --features portfolio_manager --bin portfolio_manager --release
-        ''
-        else ''
-          set -euo pipefail
-          ${runtimeEnv}
-          ${waitForPostgres}
-          ${killPort "8083"}
-          exec secretspec run -- cargo watch -x 'run --no-default-features --features portfolio_manager --bin portfolio_manager'
-        '';
+      portfolio-manager.exec = ''
+        set -euo pipefail
+        ${runtimeEnv}
+        ${waitForPostgres}
+        ${killPort "8083"}
+        exec secretspec run -- cargo run --release --bin portfolio_manager
+      '';
     };
   };
 
@@ -713,7 +677,6 @@ in {
 
   enterShell = ''
     ${runtimeEnv}
-    mkdir -p "$FUND_LOG_DIR" 2>/dev/null || true
     {
       echo "Fund development environment (profile: $FUND_PROFILE)"
       echo ""

--- a/devenv.nix
+++ b/devenv.nix
@@ -14,6 +14,8 @@
     export AWS_S3_MODEL_ARTIFACT_PATH="models/tide/"
     if [[ ! -w "''${FUND_LOG_DIR:-/var/log/fund}" ]]; then
       export FUND_LOG_DIR="$HOME/.local/state/fund/log"
+    else
+      export FUND_LOG_DIR="''${FUND_LOG_DIR:-/var/log/fund}"
     fi
     mkdir -p "$FUND_LOG_DIR" 2>/dev/null || true
   '';

--- a/tools/git-sync
+++ b/tools/git-sync
@@ -147,6 +147,7 @@ while true; do
     stop_devenv
     log "Resetting to origin/master"
     git reset --hard origin/master
+    devenv allow 2>/dev/null || true
     log "Now at $(git rev-parse --short HEAD)"
     build_and_install_dashboard_service
     start_devenv

--- a/tools/git-sync
+++ b/tools/git-sync
@@ -147,7 +147,7 @@ while true; do
     stop_devenv
     log "Resetting to origin/master"
     git reset --hard origin/master
-    devenv allow 2>/dev/null || true
+    devenv allow 2>/dev/null || log "WARNING: devenv allow failed; manual 'devenv allow' may be needed"
     log "Now at $(git rev-parse --short HEAD)"
     build_and_install_dashboard_service
     start_devenv

--- a/tools/provision-application-vm
+++ b/tools/provision-application-vm
@@ -50,7 +50,7 @@ phase_reboot
 
 if [[ "$PRODUCTION" == true ]]; then
   step "Starting git-sync in tmux session"
-  remote "$NIX_SOURCE && cd ~/fund && tmux new-session -d -s fund 'bash tools/git-sync'"
+  remote "$NIX_SOURCE && cd ~/fund && tmux kill-session -t fund 2>/dev/null || true && tmux new-session -d -s fund 'bash tools/git-sync'"
   echo "Services started via git-sync in tmux session 'fund'"
 
   step "Applying dashboard reader database setup"

--- a/tools/provision-application-vm
+++ b/tools/provision-application-vm
@@ -49,9 +49,9 @@ phase_reboot
 # --------------------------------------------------------------------------- #
 
 if [[ "$PRODUCTION" == true ]]; then
-  step "Starting services in tmux session"
-  remote "$NIX_SOURCE && cd ~/fund && tmux new-session -d -s fund 'devenv --profile application up'"
-  echo "Services started in tmux session 'fund'"
+  step "Starting git-sync in tmux session"
+  remote "$NIX_SOURCE && cd ~/fund && tmux new-session -d -s fund 'bash tools/git-sync'"
+  echo "Services started via git-sync in tmux session 'fund'"
 
   step "Applying dashboard reader database setup"
   local_pg_elapsed=0
@@ -116,7 +116,7 @@ else
 fi
 echo "  Profile:  $SECRETSPEC_PROFILE"
 if [[ "$PRODUCTION" == true ]]; then
-  echo "  Services: running in tmux session 'fund'"
+  echo "  Services: running via git-sync in tmux session 'fund'"
 fi
 echo ""
 echo "Next steps:"


### PR DESCRIPTION
# Overview

## Changes

- Remove broken `isProduction` conditional from `devenv.nix` — `builtins.getEnv "FUND_PROFILE"` always returned `""` at Nix evaluation time (dotenv loads after Nix evaluates), so all VMs ran `cargo watch` in debug mode instead of `cargo run --release`
- Simplify all three service process definitions to always use `cargo run --release` with default features, eliminating 3x build artifact duplication (~101GB to ~10-15GB in `target/`)
- Move log directory fallback into `runtimeEnv` so it works for both interactive shells and Process Compose processes
- Wire up `git-sync` for production VM provisioning — production now starts `git-sync` in tmux (which manages devenv lifecycle, polls `origin/master`, and handles crash recovery) instead of bare `devenv up`
- Add `devenv allow` to `git-sync` after pulling new commits so devenv config changes do not block restarts

## Context

The `isProduction` flag (`devenv.nix` line 9) used `builtins.getEnv "FUND_PROFILE"` to determine whether to run `cargo watch` (development) or `cargo run --release` (production). However, `FUND_PROFILE` comes from `.env` via `dotenv.enable = true`, which loads after Nix evaluation. The flag was always `false`, meaning even production VMs compiled in debug mode with `cargo watch`.

Additionally, `git-sync` — which polls `origin/master` for updates, manages devenv lifecycle, and rebuilds `dashboard_service` — existed but was never started by the provisioning scripts. Production VMs ran bare `devenv --profile application up` with no auto-update capability.

The fix removes the broken conditional entirely (no environment needs `cargo watch` since code is not edited on VMs), uses default Cargo features for a single shared artifact set, and wires `git-sync` into the production provisioning flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application services now start through a unified release-mode command, improving consistency across environments.
  * VM provisioning now launches services via the existing sync workflow in the `fund` session for production setups.

* **Bug Fixes**
  * Log directory handling now falls back to a writable location when the default path is unavailable, and creates it automatically.
  * Repository sync now includes an additional permission step after resetting to the latest revision, helping restarts complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->