### PR TITLE
Fix POSIX incompatible date comparison in equity bars backfill

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -299,8 +299,9 @@ in {
 
     echo "Fetching equity bars from $BACKFILL_START_DATE to $END_DATE"
     current_date="$BACKFILL_START_DATE"
+    end_date_numeric="$(printf '%s' "$END_DATE" | tr -d '-')"
     request_count=0
-    while [ "$(echo "$current_date" | tr -d '-')" -le "$(echo "$END_DATE" | tr -d '-')" ]; do
+    while [ "$(printf '%s' "$current_date" | tr -d '-')" -le "$end_date_numeric" ]; do
       request_count=$((request_count + 1))
       date_string="''${current_date}T12:00:00Z"
       echo "Syncing equity bars for $current_date (request $request_count)"

--- a/devenv.nix
+++ b/devenv.nix
@@ -300,7 +300,7 @@ in {
     echo "Fetching equity bars from $BACKFILL_START_DATE to $END_DATE"
     current_date="$BACKFILL_START_DATE"
     request_count=0
-    while [[ "$current_date" <= "$END_DATE" ]]; do
+    while [ "$(echo "$current_date" | tr -d '-')" -le "$(echo "$END_DATE" | tr -d '-')" ]; do
       request_count=$((request_count + 1))
       date_string="''${current_date}T12:00:00Z"
       echo "Syncing equity bars for $current_date (request $request_count)"


### PR DESCRIPTION
# Overview

## Changes

- Replace bash-specific `[[ ... ]]` date string comparison with POSIX-compatible numeric comparison in `fetch-database-equity-bars` script
- Strip hyphens from date strings (`YYYY-MM-DD` to `YYYYMMDD`) for integer comparison using `[ ... -le ... ]`

## Context

The `fetch-database-equity-bars` script used `[[ "$current_date" <= "$END_DATE" ]]` for the date loop comparison. Nix script wrappers run under POSIX `sh`, not `bash`, so the `[[` syntax causes a syntax error at runtime:

```
syntax error in conditional expression: unexpected token `"$END_DATE"'
```

This was encountered during production VM setup when running `devenv tasks run database:create`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date-range iteration so date comparisons are evaluated numerically, helping the process stop at the correct end date.
  * Reduced the risk of incorrect loop behavior when handling formatted dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->