### PR TITLE
Wrap multi-step database writes in single transactions

### DIFF
--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -193,8 +193,11 @@ pub const CONSUMER_DATA_MANAGER_DATABASE_BACKUP: &str = "data-manager-database-b
 
 /// Inserts an event row by calling the `emit_event` PostgreSQL stored procedure.
 /// The `events_notify` trigger fires `pg_notify` on the `events` channel automatically.
-pub async fn emit_event(
-    pool: &PgPool,
+///
+/// Accepts any sqlx executor (`&PgPool`, `&mut Transaction`, etc.) so callers
+/// can include event emission inside a transaction when atomicity is needed.
+pub async fn emit_event<'e>(
+    executor: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
     event_type: EventType,
     payload: &serde_json::Value,
 ) -> Result<(), sqlx::Error> {
@@ -203,7 +206,7 @@ pub async fn emit_event(
         event_type.as_str(),
         payload
     )
-    .execute(pool)
+    .execute(executor)
     .await?;
     info!(event_type = event_type.as_str(), "Emitted event");
     Ok(())

--- a/src/data_manager/database.rs
+++ b/src/data_manager/database.rs
@@ -15,10 +15,8 @@ use tracing::{debug, info, warn};
 /// Massive's grouped-daily endpoint occasionally returns a ticker more than once
 /// for a date. A single `INSERT ... ON CONFLICT (ticker, timestamp) DO UPDATE`
 /// rejects a repeated conflict target with "ON CONFLICT DO UPDATE command cannot
-/// affect row a second time", which fails the whole 1000-row chunk and—because
-/// the chunks are not wrapped in a transaction—leaves the day's bars partially
-/// written. Keeping the last occurrence mirrors the upsert's latest-write
-/// semantics.
+/// affect row a second time", which fails the whole 1000-row chunk. Keeping the
+/// last occurrence mirrors the upsert's latest-write semantics.
 fn deduplicate_equity_bars(bars: &[EquityBar]) -> Vec<EquityBar> {
     let mut seen: HashSet<(Ticker, DateTime<Utc>)> = HashSet::with_capacity(bars.len());
     let mut deduplicated: Vec<EquityBar> = Vec::with_capacity(bars.len());
@@ -39,6 +37,7 @@ pub async fn insert_equity_bars(pool: &PgPool, bars: &[EquityBar]) -> Result<u64
     let bars = deduplicate_equity_bars(bars);
 
     let mut rows_affected: u64 = 0;
+    let mut transaction = pool.begin().await?;
 
     for chunk in bars.chunks(1000) {
         let mut query_builder = sqlx::QueryBuilder::new(
@@ -71,10 +70,11 @@ pub async fn insert_equity_bars(pool: &PgPool, bars: &[EquityBar]) -> Result<u64
              inserted_at = EXCLUDED.inserted_at",
         );
 
-        let result = query_builder.build().execute(pool).await?;
+        let result = query_builder.build().execute(&mut *transaction).await?;
         rows_affected += result.rows_affected();
     }
 
+    transaction.commit().await?;
     info!("Inserted {} equity bars into PostgreSQL", rows_affected);
     Ok(rows_affected)
 }
@@ -88,6 +88,7 @@ pub async fn insert_equity_quotes(
     }
 
     let mut rows_affected: u64 = 0;
+    let mut transaction = pool.begin().await?;
 
     for chunk in quotes.chunks(1000) {
         let mut query_builder = sqlx::QueryBuilder::new(
@@ -104,10 +105,11 @@ pub async fn insert_equity_quotes(
                 .push_bind(quote.ask_size());
         });
 
-        let result = query_builder.build().execute(pool).await?;
+        let result = query_builder.build().execute(&mut *transaction).await?;
         rows_affected += result.rows_affected();
     }
 
+    transaction.commit().await?;
     debug!("Inserted {} equity quotes into PostgreSQL", rows_affected);
     Ok(rows_affected)
 }

--- a/src/ensemble_manager/database.rs
+++ b/src/ensemble_manager/database.rs
@@ -175,6 +175,7 @@ pub async fn insert_predictions(
         .collect::<Result<_, _>>()?;
 
     let mut rows_affected: u64 = 0;
+    let mut transaction = pool.begin().await?;
 
     for chunk in validated.chunks(1000) {
         let mut query_builder = sqlx::QueryBuilder::new(
@@ -201,10 +202,11 @@ pub async fn insert_predictions(
              quantile_90 = EXCLUDED.quantile_90",
         );
 
-        let result = query_builder.build().execute(pool).await?;
+        let result = query_builder.build().execute(&mut *transaction).await?;
         rows_affected += result.rows_affected();
     }
 
+    transaction.commit().await?;
     info!(rows = rows_affected, "Predictions inserted into PostgreSQL");
     Ok(rows_affected)
 }

--- a/src/portfolio_manager/database.rs
+++ b/src/portfolio_manager/database.rs
@@ -380,8 +380,8 @@ pub async fn fetch_latest_portfolio_net_asset_value(
 }
 
 /// Inserts a new equity rebalance session record.
-pub async fn insert_rebalance_session(
-    pool: &PgPool,
+pub async fn insert_rebalance_session<'e>(
+    executor: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
     session: &EquityRebalanceSession,
 ) -> Result<(), sqlx::Error> {
     sqlx::query!(
@@ -395,7 +395,7 @@ pub async fn insert_rebalance_session(
         session.completed_at(),
         session.status().as_str()
     )
-    .execute(pool)
+    .execute(executor)
     .await?;
 
     info!(session_id = %session.id(), "Rebalance session inserted into PostgreSQL");
@@ -403,8 +403,8 @@ pub async fn insert_rebalance_session(
 }
 
 /// Updates the `status` and `completed_at` of a rebalance session.
-pub async fn update_rebalance_session_status(
-    pool: &PgPool,
+pub async fn update_rebalance_session_status<'e>(
+    executor: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
     session_id: Uuid,
     status: &RebalanceSessionStatus,
     completed_at: DateTime<Utc>,
@@ -417,7 +417,7 @@ pub async fn update_rebalance_session_status(
         completed_at,
         session_id
     )
-    .execute(pool)
+    .execute(executor)
     .await?;
 
     if result.rows_affected() != 1 {
@@ -429,7 +429,10 @@ pub async fn update_rebalance_session_status(
 }
 
 /// Inserts an equity pair record with status `open`.
-pub async fn insert_equity_pair(pool: &PgPool, pair: &EquityPair) -> Result<(), sqlx::Error> {
+pub async fn insert_equity_pair<'e>(
+    executor: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
+    pair: &EquityPair,
+) -> Result<(), sqlx::Error> {
     sqlx::query!(
         "INSERT INTO equity_pairs \
          (id, rebalance_id, pair_id, long_ticker, short_ticker, z_score, hedge_ratio, \
@@ -446,7 +449,7 @@ pub async fn insert_equity_pair(pool: &PgPool, pair: &EquityPair) -> Result<(), 
         pair.status().as_str(),
         pair.opened_at()
     )
-    .execute(pool)
+    .execute(executor)
     .await?;
 
     info!(
@@ -460,8 +463,8 @@ pub async fn insert_equity_pair(pool: &PgPool, pair: &EquityPair) -> Result<(), 
 ///
 /// Used by per-pair evaluation (`ProfitTaken`, `StopLoss`), and end-of-day
 /// liquidation (`EndOfDay`).
-pub async fn close_equity_pair_with_reason(
-    pool: &PgPool,
+pub async fn close_equity_pair_with_reason<'e>(
+    executor: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
     pair_id: Uuid,
     closed_at: DateTime<Utc>,
     reason: &CloseReason,
@@ -474,7 +477,7 @@ pub async fn close_equity_pair_with_reason(
         reason.as_str(),
         pair_id
     )
-    .execute(pool)
+    .execute(executor)
     .await?;
 
     if result.rows_affected() != 1 {
@@ -490,8 +493,8 @@ pub async fn close_equity_pair_with_reason(
 }
 
 /// Inserts an equity allocation record for one leg of a pair.
-pub async fn insert_equity_allocation(
-    pool: &PgPool,
+pub async fn insert_equity_allocation<'e>(
+    executor: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
     allocation: &EquityAllocation,
 ) -> Result<(), sqlx::Error> {
     sqlx::query!(
@@ -512,14 +515,17 @@ pub async fn insert_equity_allocation(
         allocation.quantity().copied(),
         allocation.notional().copied()
     )
-    .execute(pool)
+    .execute(executor)
     .await?;
 
     Ok(())
 }
 
 /// Inserts an equity order record linking a filled order to its allocation.
-pub async fn insert_equity_order(pool: &PgPool, order: &EquityOrder) -> Result<(), sqlx::Error> {
+pub async fn insert_equity_order<'e>(
+    executor: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
+    order: &EquityOrder,
+) -> Result<(), sqlx::Error> {
     sqlx::query!(
         "INSERT INTO equity_orders \
          (id, allocation_id, submitted_at, ticker, side, quantity, order_type, limit_price, \
@@ -535,15 +541,15 @@ pub async fn insert_equity_order(pool: &PgPool, order: &EquityOrder) -> Result<(
         order.limit_price().copied(),
         order.alpaca_order_id()
     )
-    .execute(pool)
+    .execute(executor)
     .await?;
 
     Ok(())
 }
 
 /// Inserts an intraday portfolio snapshot recording the post-rebalance net asset value.
-pub async fn insert_portfolio_snapshot(
-    pool: &PgPool,
+pub async fn insert_portfolio_snapshot<'e>(
+    executor: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
     snapshot_timestamp: DateTime<Utc>,
     net_asset_value: Decimal,
     total_slippage_cost: Decimal,
@@ -556,7 +562,7 @@ pub async fn insert_portfolio_snapshot(
         net_asset_value,
         total_slippage_cost
     )
-    .execute(pool)
+    .execute(executor)
     .await?;
 
     info!(net_asset_value = %net_asset_value, "Portfolio snapshot inserted into PostgreSQL");

--- a/src/portfolio_manager/rebalance.rs
+++ b/src/portfolio_manager/rebalance.rs
@@ -428,24 +428,17 @@ pub async fn run_end_of_day_liquidation(state: &AppState) -> Result<usize, Rebal
     let closed_at = Utc::now();
     let pairs_closed = open_pairs.len();
 
-    let mut transaction = pool.begin().await?;
     for open_pair in &open_pairs {
-        close_equity_pair_with_reason(
-            &mut *transaction,
-            open_pair.id(),
-            closed_at,
-            &CloseReason::EndOfDay,
-        )
-        .await?;
+        close_equity_pair_with_reason(pool, open_pair.id(), closed_at, &CloseReason::EndOfDay)
+            .await?;
     }
 
     emit_event(
-        &mut *transaction,
+        pool,
         EventType::PortfolioLiquidationCompleted,
         &serde_json::json!({ "pairs_closed": pairs_closed }),
     )
     .await?;
-    transaction.commit().await?;
 
     info!(count = pairs_closed, "Open pairs closed at end of day");
 
@@ -640,17 +633,10 @@ async fn close_triggered_pairs(
         .map_err(RebalanceError::Execution)?;
 
     let closed_at = Utc::now();
-    let mut transaction = pool.begin().await?;
     for signal in signals {
-        close_equity_pair_with_reason(
-            &mut *transaction,
-            signal.open_pair.id(),
-            closed_at,
-            &signal.reason,
-        )
-        .await?;
+        close_equity_pair_with_reason(pool, signal.open_pair.id(), closed_at, &signal.reason)
+            .await?;
     }
-    transaction.commit().await?;
 
     info!(count = signals.len(), "Triggered pairs closed");
     Ok(signals.len())

--- a/src/portfolio_manager/rebalance.rs
+++ b/src/portfolio_manager/rebalance.rs
@@ -221,9 +221,21 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
         .collect();
     Portfolio::new(filled_pairs_only, state.constraints())?;
 
-    // Phase 8: persist session, pairs, allocations, orders, and snapshot.
+    // Phase 8: persist session, pairs, allocations, orders, and snapshot
+    // inside a single transaction so a mid-cycle failure rolls back all writes.
     let session_id = Uuid::new_v4();
     let now = Utc::now();
+
+    let net_asset_value_decimal = Decimal::try_from(current_equity).map_err(|_| {
+        RebalanceError::Conversion("current equity cannot be represented as Decimal".to_string())
+    })?;
+    let net_asset_value = net_asset_value_decimal.to_f64().ok_or_else(|| {
+        RebalanceError::Conversion(
+            "net_asset_value_decimal cannot be represented as f64".to_string(),
+        )
+    })?;
+
+    let mut transaction = pool.begin().await?;
 
     let session = EquityRebalanceSession::new(
         session_id,
@@ -233,25 +245,28 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
         None,
         RebalanceSessionStatus::Completed,
     );
-    insert_rebalance_session(pool, &session).await?;
+    insert_rebalance_session(&mut *transaction, &session).await?;
 
-    let total_slippage_cost = persist_filled_pairs(pool, session_id, now, &filled).await?;
+    let total_slippage_cost =
+        persist_filled_pairs(&mut transaction, session_id, now, &filled).await?;
 
-    let net_asset_value_decimal = Decimal::try_from(current_equity).map_err(|_| {
-        RebalanceError::Conversion("current equity cannot be represented as Decimal".to_string())
-    })?;
-    insert_portfolio_snapshot(pool, now, net_asset_value_decimal, total_slippage_cost).await?;
-    update_rebalance_session_status(pool, session_id, &RebalanceSessionStatus::Completed, now)
-        .await?;
-
-    let net_asset_value = net_asset_value_decimal.to_f64().ok_or_else(|| {
-        RebalanceError::Conversion(
-            "net_asset_value_decimal cannot be represented as f64".to_string(),
-        )
-    })?;
+    insert_portfolio_snapshot(
+        &mut *transaction,
+        now,
+        net_asset_value_decimal,
+        total_slippage_cost,
+    )
+    .await?;
+    update_rebalance_session_status(
+        &mut *transaction,
+        session_id,
+        &RebalanceSessionStatus::Completed,
+        now,
+    )
+    .await?;
 
     emit_event(
-        pool,
+        &mut *transaction,
         EventType::PortfolioRebalanceCompleted,
         &serde_json::json!({
             "session_id": session_id.to_string(),
@@ -262,6 +277,8 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
         }),
     )
     .await?;
+
+    transaction.commit().await?;
 
     info!(
         session_id = %session_id,
@@ -311,6 +328,17 @@ async fn run_monitor_cycle(
     let session_id = Uuid::new_v4();
     let now = Utc::now();
 
+    let net_asset_value_decimal = Decimal::try_from(current_equity).map_err(|_| {
+        RebalanceError::Conversion("current equity cannot be represented as Decimal".to_string())
+    })?;
+    let net_asset_value = net_asset_value_decimal.to_f64().ok_or_else(|| {
+        RebalanceError::Conversion(
+            "net_asset_value_decimal cannot be represented as f64".to_string(),
+        )
+    })?;
+
+    let mut transaction = pool.begin().await?;
+
     let session = EquityRebalanceSession::new(
         session_id,
         now,
@@ -319,23 +347,24 @@ async fn run_monitor_cycle(
         None,
         RebalanceSessionStatus::Completed,
     );
-    insert_rebalance_session(pool, &session).await?;
-
-    let net_asset_value_decimal = Decimal::try_from(current_equity).map_err(|_| {
-        RebalanceError::Conversion("current equity cannot be represented as Decimal".to_string())
-    })?;
-    insert_portfolio_snapshot(pool, now, net_asset_value_decimal, Decimal::ZERO).await?;
-    update_rebalance_session_status(pool, session_id, &RebalanceSessionStatus::Completed, now)
-        .await?;
-
-    let net_asset_value = net_asset_value_decimal.to_f64().ok_or_else(|| {
-        RebalanceError::Conversion(
-            "net_asset_value_decimal cannot be represented as f64".to_string(),
-        )
-    })?;
+    insert_rebalance_session(&mut *transaction, &session).await?;
+    insert_portfolio_snapshot(
+        &mut *transaction,
+        now,
+        net_asset_value_decimal,
+        Decimal::ZERO,
+    )
+    .await?;
+    update_rebalance_session_status(
+        &mut *transaction,
+        session_id,
+        &RebalanceSessionStatus::Completed,
+        now,
+    )
+    .await?;
 
     emit_event(
-        pool,
+        &mut *transaction,
         EventType::PortfolioRebalanceCompleted,
         &serde_json::json!({
             "session_id": session_id.to_string(),
@@ -346,6 +375,8 @@ async fn run_monitor_cycle(
         }),
     )
     .await?;
+
+    transaction.commit().await?;
 
     Ok(RebalanceOutcome {
         session_id,
@@ -395,20 +426,28 @@ pub async fn run_end_of_day_liquidation(state: &AppState) -> Result<usize, Rebal
         .map_err(RebalanceError::Execution)?;
 
     let closed_at = Utc::now();
+    let pairs_closed = open_pairs.len();
+
+    let mut transaction = pool.begin().await?;
     for open_pair in &open_pairs {
-        close_equity_pair_with_reason(pool, open_pair.id(), closed_at, &CloseReason::EndOfDay)
-            .await?;
+        close_equity_pair_with_reason(
+            &mut *transaction,
+            open_pair.id(),
+            closed_at,
+            &CloseReason::EndOfDay,
+        )
+        .await?;
     }
 
-    let pairs_closed = open_pairs.len();
-    info!(count = pairs_closed, "Open pairs closed at end of day");
-
     emit_event(
-        pool,
+        &mut *transaction,
         EventType::PortfolioLiquidationCompleted,
         &serde_json::json!({ "pairs_closed": pairs_closed }),
     )
     .await?;
+    transaction.commit().await?;
+
+    info!(count = pairs_closed, "Open pairs closed at end of day");
 
     Ok(pairs_closed)
 }
@@ -601,10 +640,17 @@ async fn close_triggered_pairs(
         .map_err(RebalanceError::Execution)?;
 
     let closed_at = Utc::now();
+    let mut transaction = pool.begin().await?;
     for signal in signals {
-        close_equity_pair_with_reason(pool, signal.open_pair.id(), closed_at, &signal.reason)
-            .await?;
+        close_equity_pair_with_reason(
+            &mut *transaction,
+            signal.open_pair.id(),
+            closed_at,
+            &signal.reason,
+        )
+        .await?;
     }
+    transaction.commit().await?;
 
     info!(count = signals.len(), "Triggered pairs closed");
     Ok(signals.len())
@@ -779,9 +825,11 @@ async fn select_size_execute(
 
 /// Persists pairs, allocations, and orders for a completed rebalance cycle.
 ///
-/// Returns the total estimated slippage cost across all pairs (1 bp per leg).
+/// Accepts a mutable transaction reference so all writes participate in the
+/// caller's transaction. Returns the total estimated slippage cost across all
+/// pairs (1 bp per leg).
 async fn persist_filled_pairs(
-    pool: &sqlx::PgPool,
+    transaction: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     session_id: Uuid,
     now: DateTime<Utc>,
     filled: &[(FilledPair, crate::portfolio_manager::sizing::SizedPair)],
@@ -826,7 +874,7 @@ async fn persist_filled_pairs(
             None,
             None,
         );
-        insert_equity_pair(pool, &equity_pair).await?;
+        insert_equity_pair(&mut **transaction, &equity_pair).await?;
 
         let long_notional_decimal = filled_pair.long_notional.value();
         let long_entry_price_decimal = filled_pair.long.fill_price.unwrap_or(Decimal::ZERO);
@@ -845,7 +893,7 @@ async fn persist_filled_pairs(
             None,
             Some(long_notional_decimal),
         );
-        insert_equity_allocation(pool, &long_allocation).await?;
+        insert_equity_allocation(&mut **transaction, &long_allocation).await?;
 
         let short_notional_decimal = filled_pair.short_notional.value();
         let short_entry_price_decimal = filled_pair.short.fill_price.unwrap_or(Decimal::ZERO);
@@ -865,7 +913,7 @@ async fn persist_filled_pairs(
             Some(short_quantity_decimal),
             None,
         );
-        insert_equity_allocation(pool, &short_allocation).await?;
+        insert_equity_allocation(&mut **transaction, &short_allocation).await?;
 
         let long_order_ticker = Ticker::new(&filled_pair.long.ticker)
             .unwrap_or_else(|| Ticker::new("UNKNOWN").expect("UNKNOWN is a valid ticker"));
@@ -880,7 +928,7 @@ async fn persist_filled_pairs(
             filled_pair.long.limit_price,
             filled_pair.long.alpaca_order_id.clone(),
         );
-        insert_equity_order(pool, &long_order).await?;
+        insert_equity_order(&mut **transaction, &long_order).await?;
 
         let short_order_ticker = Ticker::new(&filled_pair.short.ticker)
             .unwrap_or_else(|| Ticker::new("UNKNOWN").expect("UNKNOWN is a valid ticker"));
@@ -895,7 +943,7 @@ async fn persist_filled_pairs(
             filled_pair.short.limit_price,
             filled_pair.short.alpaca_order_id.clone(),
         );
-        insert_equity_order(pool, &short_order).await?;
+        insert_equity_order(&mut **transaction, &short_order).await?;
 
         // Slippage estimate: 1 bp per leg (0.01% of notional).
         let pair_notional = long_notional_decimal + short_notional_decimal;


### PR DESCRIPTION
# Overview

## Changes

- Fixes #939
- Portfolio manager write helpers (`insert_rebalance_session`, `update_rebalance_session_status`, `insert_equity_pair`, `close_equity_pair_with_reason`, `insert_equity_allocation`, `insert_equity_order`, `insert_portfolio_snapshot`) now accept a generic `impl sqlx::Executor` instead of `&PgPool` so callers can pass either a pool reference or a mutable transaction reference
- `emit_event` in `common/events.rs` accepts a generic executor for the same reason
- Rebalance orchestration (`run_build_cycle`, `run_monitor_cycle`, `run_end_of_day_liquidation`, `close_triggered_pairs`) opens a transaction before the first write and commits after the last, including event emission
- `persist_filled_pairs` now takes `&mut Transaction` directly and participates in the caller's transaction
- Chunked bulk inserts (`insert_equity_bars`, `insert_equity_quotes`, `insert_predictions`) wrap all 1000-row chunks in a single internal transaction so a mid-batch failure no longer leaves partial data
- Removed the documented known limitation comment about `insert_equity_bars` leaving partial writes since it is now transactional

## Context

During the PR #938 review it was noted that the five or more INSERT/UPDATE calls made during a rebalance cycle run as independent statements. A failure mid-cycle leaves the database in a partially written state with no rollback. This was deferred to issue #939 to keep the initial port focused.

This PR expands the scope beyond the original issue to also wrap chunked bulk inserts in the data manager and ensemble manager in transactions. The audit identified seven distinct transaction boundaries:

1. **Build cycle** (fresh portfolio construction) -- session, pairs, allocations, orders, snapshot, status, event
2. **Monitor cycle** (evaluate existing pairs) -- session, snapshot, status, event
3. **End-of-day liquidation** -- close all pairs, event
4. **Close triggered pairs** (intraday profit-take/stop-loss) -- close loop
5. **Equity bar ingestion** -- all 1000-row upsert chunks
6. **Equity quote ingestion** -- all 1000-row insert chunks
7. **Prediction ingestion** -- all 1000-row upsert chunks

Pure conversions (e.g., `f64` to `Decimal`) are hoisted before `pool.begin()` so a conversion error does not needlessly open and rollback a transaction. `pg_notify` from `emit_event` is deferred until transaction commit, which is correct since downstream consumers should only see the event after all data is committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency by grouping related database updates into single transactions.
  * Prevented partial saves when a multi-step operation encounters an error.
  * Ensured completion events are recorded together with their associated portfolio and trading updates.
  * Improved error handling for portfolio value conversions.
* **Reliability**
  * Updated persistence operations to support coordinated database workflows, improving consistency across rebalancing, monitoring, and liquidation activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->