### PR TITLE
Add consolidated fund binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,11 @@ name = "dashboard_service"
 path = "src/bin/dashboard_service.rs"
 required-features = ["dashboard_service"]
 
+[[bin]]
+name = "fund"
+path = "src/bin/fund.rs"
+required-features = ["data_manager", "ensemble_manager", "portfolio_manager"]
+
 [features]
 default = ["data_manager", "ensemble_manager", "portfolio_manager"]
 data_manager = [

--- a/src/bin/fund.rs
+++ b/src/bin/fund.rs
@@ -31,16 +31,14 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let s3_client = fund::common::aws::s3_client().await;
 
     // --- data_manager ---
-    let data_manager_state = {
+    {
         let _span = tracing::info_span!("data_manager").entered();
         let state = fund::data_manager::state::State::with_pool(pool.clone(), s3_client.clone());
         fund::data_manager::startup::migrate_equity_details(&state).await;
         fund::data_manager::scheduler::spawn_sync_scheduler(state.clone());
         fund::data_manager::equity_quotes::spawn_quote_stream(state.clone());
         info!("Data manager started");
-        state
-    };
-    let _ = data_manager_state;
+    }
 
     // --- ensemble_manager ---
     {

--- a/src/bin/fund.rs
+++ b/src/bin/fund.rs
@@ -1,0 +1,70 @@
+//! Consolidated fund binary.
+//!
+//! Runs all three services (data_manager, ensemble_manager, portfolio_manager)
+//! in a single process, sharing a single `PgPool` and `S3Client`. All work is
+//! driven by PostgreSQL LISTEN/NOTIFY events — no HTTP servers are started.
+
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() {
+    fund::common::crypto::install_default_crypto_provider();
+
+    let _tracing_guard = fund::common::observability::init_tracing("fund.log", None);
+
+    if let Err(error) = run().await {
+        error!("{}", error);
+        eprintln!("{}", error);
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    info!("Starting consolidated fund service");
+
+    // Shared infrastructure: one pool, one S3 client for all modules.
+    let database_url = std::env::var("DATABASE_URL")
+        .map_err(|_| "DATABASE_URL environment variable must be set")?;
+    let pool = sqlx::PgPool::connect(&database_url).await?;
+    info!("Connected to PostgreSQL");
+
+    let s3_client = fund::common::aws::s3_client().await;
+
+    // --- data_manager ---
+    let data_manager_state = {
+        let _span = tracing::info_span!("data_manager").entered();
+        let state = fund::data_manager::state::State::with_pool(pool.clone(), s3_client.clone());
+        fund::data_manager::startup::migrate_equity_details(&state).await;
+        fund::data_manager::scheduler::spawn_sync_scheduler(state.clone());
+        fund::data_manager::equity_quotes::spawn_quote_stream(state.clone());
+        info!("Data manager started");
+        state
+    };
+    let _ = data_manager_state;
+
+    // --- ensemble_manager ---
+    {
+        let _span = tracing::info_span!("ensemble_manager").entered();
+        let state =
+            fund::ensemble_manager::state::AppState::with_pool(pool.clone(), s3_client.clone());
+        fund::ensemble_manager::server::poll_artifact_once(&state).await;
+        tokio::spawn(fund::ensemble_manager::server::start_artifact_polling(
+            state.clone(),
+        ));
+        fund::ensemble_manager::consumer::spawn_event_consumer(state);
+        info!("Ensemble manager started");
+    }
+
+    // --- portfolio_manager ---
+    {
+        let _span = tracing::info_span!("portfolio_manager").entered();
+        let state = fund::portfolio_manager::state::AppState::with_pool(pool)?;
+        fund::portfolio_manager::consumer::spawn_event_consumer(state);
+        info!("Portfolio manager started");
+    }
+
+    info!("All modules running, waiting for events");
+    tokio::signal::ctrl_c().await?;
+    info!("Shutting down");
+    Ok(())
+}

--- a/src/data_manager/startup.rs
+++ b/src/data_manager/startup.rs
@@ -7,7 +7,7 @@ use crate::data_manager::scheduler::spawn_sync_scheduler;
 use crate::data_manager::state::State;
 use tokio::net::TcpListener;
 
-async fn migrate_equity_details(state: &State) {
+pub async fn migrate_equity_details(state: &State) {
     let pool = match state.database.pool() {
         Some(pool) => pool,
         None => {


### PR DESCRIPTION
## Summary

- Adds `src/bin/fund.rs`, a consolidated binary that runs all three services (data_manager, ensemble_manager, portfolio_manager) in a single process
- Shares one `PgPool` and one `S3Client` across all modules via the `with_pool()` constructors added in PR #988
- All work is event-driven via PostgreSQL LISTEN/NOTIFY — no HTTP servers are started
- Makes `data_manager::startup::migrate_equity_details()` public so the consolidated binary can call it at startup
- Existing standalone binaries are unchanged and continue to work

## Context

This is PR2 in the service consolidation sequence:
1. PR #988: Add shared state constructors (merged)
2. **This PR: Add consolidated binary alongside existing ones**
3. PR3: Remove ensemble_manager HTTP fallback
4. PR4: Remove HTTP servers, update devenv
5. PR5: Module renames

## Test plan

- [x] `cargo build --bin fund` compiles successfully
- [x] `devenv tasks run checks:rust` passes (format, lint, test, coverage)
- [x] Existing standalone binaries still compile and their tests pass
- [x] Manual: `secretspec run -- cargo run --release --bin fund` starts all three modules and processes events

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified service process that runs data, ensemble, and portfolio management together.
  * Added startup coordination for database and storage access, background synchronization, artifact polling, event processing, and graceful shutdown.
* **Bug Fixes**
  * Improved startup reliability by running required migrations and reporting initialization failures clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->