### PR TITLE
Remove ensemble_manager HTTP fallback path

### DIFF
--- a/src/ensemble_manager.rs
+++ b/src/ensemble_manager.rs
@@ -1,4 +1,5 @@
-//! Ensemble model service: loads trained TiDE artifacts from S3 and consumes
+//! Ensemble model service: loads trained TiDE artifacts from S3, serves
+//! predictions over HTTP (standalone mode), and consumes
 //! `predictions_requested` events from the Postgres event bus.
 
 pub mod artifact;

--- a/src/ensemble_manager.rs
+++ b/src/ensemble_manager.rs
@@ -1,6 +1,5 @@
-//! Ensemble model service: loads trained TiDE artifacts from S3, serves
-//! predictions over HTTP, and consumes `predictions_requested` events from the
-//! Postgres event bus.
+//! Ensemble model service: loads trained TiDE artifacts from S3 and consumes
+//! `predictions_requested` events from the Postgres event bus.
 
 pub mod artifact;
 pub mod consumer;
@@ -64,7 +63,6 @@ mod tests {
             make_s3_client(),
             "test-bucket".to_string(),
             "artifacts/tide/".to_string(),
-            "http://localhost:8080".to_string(),
             "latest".to_string(),
         );
         let app = server::create_router(state);

--- a/src/ensemble_manager/consumer.rs
+++ b/src/ensemble_manager/consumer.rs
@@ -221,7 +221,6 @@ mod tests {
             s3_client,
             "bucket".to_string(),
             "prefix/".to_string(),
-            "http://localhost".to_string(),
             "latest".to_string(),
         );
         // No pool configured; the function must log and return without spawning.

--- a/src/ensemble_manager/predict.rs
+++ b/src/ensemble_manager/predict.rs
@@ -1,5 +1,3 @@
-use std::io::Cursor;
-
 use burn::backend::NdArray;
 use chrono::{Duration, Utc};
 use polars::prelude::*;
@@ -33,98 +31,18 @@ pub enum PredictionError {
     Postprocessing(String),
 }
 
-pub async fn fetch_equity_bars(
-    base_url: &str,
-    http_client: &reqwest::Client,
-) -> Result<DataFrame, PredictionError> {
-    let end_date = Utc::now();
-    let start_date = end_date - Duration::days(70);
-
-    let start_timestamp = start_date.timestamp_millis();
-    let end_timestamp = end_date.timestamp_millis();
-
-    let url = format!(
-        "{base_url}/equity-bars?start_timestamp={start_timestamp}&end_timestamp={end_timestamp}"
-    );
-
-    info!(url = url, "Fetching equity bars");
-
-    let response = http_client
-        .get(&url)
-        .send()
+pub async fn fetch_equity_bars(pool: &PgPool) -> Result<DataFrame, PredictionError> {
+    info!("Fetching equity bars from PostgreSQL");
+    database::query_equity_bars(pool)
         .await
-        .map_err(|e| PredictionError::FetchEquityBars(e.to_string()))?;
-
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| PredictionError::FetchEquityBars(e.to_string()))?;
-
-    let cursor = Cursor::new(bytes);
-    let data = ParquetReader::new(cursor)
-        .finish()
-        .map_err(|e| PredictionError::FetchEquityBars(e.to_string()))?;
-
-    info!(rows = data.height(), "Equity bars fetched");
-    Ok(data)
+        .map_err(|e| PredictionError::FetchEquityBars(e.to_string()))
 }
 
-pub async fn fetch_equity_details(
-    base_url: &str,
-    http_client: &reqwest::Client,
-) -> Result<DataFrame, PredictionError> {
-    let url = format!("{base_url}/equity-details");
-
-    info!(url = url, "Fetching equity details");
-
-    let response = http_client
-        .get(&url)
-        .send()
+pub async fn fetch_equity_details(pool: &PgPool) -> Result<DataFrame, PredictionError> {
+    info!("Fetching equity details from PostgreSQL");
+    database::query_equity_details(pool)
         .await
-        .map_err(|e| PredictionError::FetchEquityDetails(e.to_string()))?;
-
-    let bytes = response
-        .bytes()
-        .await
-        .map_err(|e| PredictionError::FetchEquityDetails(e.to_string()))?;
-
-    let cursor = Cursor::new(bytes);
-    let data = CsvReader::new(cursor)
-        .finish()
-        .map_err(|e| PredictionError::FetchEquityDetails(e.to_string()))?;
-
-    info!(rows = data.height(), "Equity details fetched");
-    Ok(data)
-}
-
-pub async fn fetch_equity_bars_from_pool_or_service(
-    pool: Option<&PgPool>,
-    base_url: &str,
-    http_client: &reqwest::Client,
-) -> Result<DataFrame, PredictionError> {
-    if let Some(pool) = pool {
-        info!("Fetching equity bars from PostgreSQL");
-        database::query_equity_bars(pool)
-            .await
-            .map_err(|e| PredictionError::FetchEquityBars(e.to_string()))
-    } else {
-        fetch_equity_bars(base_url, http_client).await
-    }
-}
-
-pub async fn fetch_equity_details_from_pool_or_service(
-    pool: Option<&PgPool>,
-    base_url: &str,
-    http_client: &reqwest::Client,
-) -> Result<DataFrame, PredictionError> {
-    if let Some(pool) = pool {
-        info!("Fetching equity details from PostgreSQL");
-        database::query_equity_details(pool)
-            .await
-            .map_err(|e| PredictionError::FetchEquityDetails(e.to_string()))
-    } else {
-        fetch_equity_details(base_url, http_client).await
-    }
+        .map_err(|e| PredictionError::FetchEquityDetails(e.to_string()))
 }
 
 pub fn consolidate_data(
@@ -1129,121 +1047,5 @@ mod tests {
 
         let result = unscale_and_sort_quantiles(&[], &scaler);
         assert!(result.is_empty());
-    }
-
-    /// Serializes a Polars DataFrame to Parquet bytes in memory.
-    fn dataframe_to_parquet_bytes(mut dataframe: DataFrame) -> Vec<u8> {
-        let mut buffer = Vec::new();
-        polars::prelude::ParquetWriter::new(&mut buffer)
-            .finish(&mut dataframe)
-            .expect("parquet serialization must succeed");
-        buffer
-    }
-
-    #[tokio::test]
-    async fn test_fetch_equity_bars_returns_dataframe_on_valid_parquet_response() {
-        // Build a Parquet payload from a minimal equity bars DataFrame and serve
-        // it from a mock HTTP server. The function must parse it and return a
-        // non-error result.
-        let bars_dataframe = DataFrame::new(vec![
-            Column::new("ticker".into(), vec!["AAPL"]),
-            Column::new("timestamp".into(), vec![1_748_908_800_000i64]),
-            Column::new("open_price".into(), vec![150.0f64]),
-            Column::new("high_price".into(), vec![155.0f64]),
-            Column::new("low_price".into(), vec![149.0f64]),
-            Column::new("close_price".into(), vec![153.0f64]),
-            Column::new("volume".into(), vec![1_000_000i64]),
-            Column::new("volume_weighted_average_price".into(), vec![Some(152.0f64)]),
-            Column::new("sector".into(), vec!["Technology"]),
-            Column::new("industry".into(), vec!["Consumer Electronics"]),
-        ])
-        .unwrap();
-        let parquet_bytes = dataframe_to_parquet_bytes(bars_dataframe);
-
-        let mut server = mockito::Server::new_async().await;
-        let mock = server
-            .mock("GET", mockito::Matcher::Any)
-            .with_status(200)
-            .with_header("content-type", "application/octet-stream")
-            .with_body(parquet_bytes)
-            .create_async()
-            .await;
-
-        let http_client = reqwest::Client::new();
-        let result = fetch_equity_bars(&server.url(), &http_client).await;
-
-        mock.assert_async().await;
-        assert!(result.is_ok(), "expected Ok but got: {:?}", result.err());
-        let dataframe = result.unwrap();
-        assert_eq!(dataframe.height(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_fetch_equity_bars_returns_error_on_invalid_parquet() {
-        // When the server returns bytes that are not valid Parquet, the function
-        // must return a FetchEquityBars error rather than panicking.
-        let mut server = mockito::Server::new_async().await;
-        let mock = server
-            .mock("GET", mockito::Matcher::Any)
-            .with_status(200)
-            .with_body(b"not parquet data".as_ref())
-            .create_async()
-            .await;
-
-        let http_client = reqwest::Client::new();
-        let result = fetch_equity_bars(&server.url(), &http_client).await;
-
-        mock.assert_async().await;
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            PredictionError::FetchEquityBars(_)
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_fetch_equity_details_returns_dataframe_on_valid_csv() {
-        // A minimal CSV payload must be parsed into a DataFrame successfully.
-        let csv_body = "ticker,sector,industry\nAAPL,Technology,Consumer Electronics\nGOOG,Technology,Internet\n";
-
-        let mut server = mockito::Server::new_async().await;
-        let mock = server
-            .mock("GET", "/equity-details")
-            .with_status(200)
-            .with_header("content-type", "text/csv")
-            .with_body(csv_body)
-            .create_async()
-            .await;
-
-        let http_client = reqwest::Client::new();
-        let result = fetch_equity_details(&server.url(), &http_client).await;
-
-        mock.assert_async().await;
-        assert!(result.is_ok(), "expected Ok but got: {:?}", result.err());
-        let dataframe = result.unwrap();
-        assert_eq!(dataframe.height(), 2);
-        assert!(dataframe.column("ticker").is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_fetch_equity_details_returns_ok_on_valid_csv() {
-        // A minimal valid CSV response must parse successfully and return one row.
-        let csv_body = "ticker,sector,industry\nAAPL,Technology,Consumer Electronics\n";
-
-        let mut server = mockito::Server::new_async().await;
-        let mock = server
-            .mock("GET", "/equity-details")
-            .with_status(200)
-            .with_body(csv_body)
-            .create_async()
-            .await;
-
-        let http_client = reqwest::Client::new();
-        let result = fetch_equity_details(&server.url(), &http_client).await;
-
-        mock.assert_async().await;
-        // A valid CSV response must return Ok.
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().height(), 1);
     }
 }

--- a/src/ensemble_manager/server.rs
+++ b/src/ensemble_manager/server.rs
@@ -99,9 +99,20 @@ impl PipelineError {
 pub async fn run_predictions(state: &AppState) -> Result<PredictionRun, PipelineError> {
     let start = Instant::now();
 
-    let pool = state
-        .pool()
-        .ok_or_else(|| PipelineError::new("no_pool", "Database pool required".to_string()))?;
+    let pool = match state.pool() {
+        Some(pool) => pool,
+        None => {
+            let pipeline_error =
+                PipelineError::new("no_pool", "Database pool required".to_string());
+            error!(
+                stage = pipeline_error.stage(),
+                error = %pipeline_error.message(),
+                duration_ms = start.elapsed().as_millis() as u64,
+                "Prediction pipeline failed"
+            );
+            return Err(pipeline_error);
+        }
+    };
 
     let correlation_id = Uuid::new_v4();
 

--- a/src/ensemble_manager/server.rs
+++ b/src/ensemble_manager/server.rs
@@ -92,22 +92,21 @@ impl PipelineError {
 
 /// Run the full prediction pipeline once and persist the result.
 ///
-/// Shared by the HTTP handler and the Postgres event consumer. When a pool is
-/// configured, predictions are inserted into `equity_predictions` and a
-/// `predictions_completed` event is emitted on success; any stage failure emits
-/// `predictions_failed` (with the stage as the reason) so downstream consumers
-/// aren't left waiting. Without a pool, predictions are POSTed to the data
-/// manager as a fallback.
+/// Shared by the HTTP handler and the Postgres event consumer. Predictions are
+/// inserted into `equity_predictions` and a `predictions_completed` event is
+/// emitted on success; any stage failure emits `predictions_errored` (with the
+/// stage as the reason) so downstream consumers aren't left waiting.
 pub async fn run_predictions(state: &AppState) -> Result<PredictionRun, PipelineError> {
     let start = Instant::now();
 
+    let pool = state
+        .pool()
+        .ok_or_else(|| PipelineError::new("no_pool", "Database pool required".to_string()))?;
+
     let correlation_id = Uuid::new_v4();
-    let http_client = reqwest::Client::new();
 
-    let result = run_pipeline_and_persist(state, &http_client, correlation_id).await;
+    let result = run_pipeline_and_persist(state, pool, correlation_id).await;
 
-    // Observability lives in structured logs: every run records its duration
-    // and outcome here, and failures additionally carry their pipeline stage.
     info!(
         duration_ms = start.elapsed().as_millis() as u64,
         succeeded = result.is_ok(),
@@ -116,19 +115,17 @@ pub async fn run_predictions(state: &AppState) -> Result<PredictionRun, Pipeline
 
     if let Err(error) = &result {
         error!(stage = error.stage(), error = %error.message(), "Prediction pipeline failed");
-        if let Some(pool) = state.pool() {
-            if let Err(emit_error) = crate::common::events::emit_event(
-                pool,
-                crate::common::events::EventType::EquityPredictionsErrored,
-                &serde_json::json!({
-                    "correlation_id": correlation_id.to_string(),
-                    "reason": error.stage(),
-                }),
-            )
-            .await
-            {
-                warn!(error = %emit_error, "Failed to emit predictions_failed event");
-            }
+        if let Err(emit_error) = crate::common::events::emit_event(
+            pool,
+            crate::common::events::EventType::EquityPredictionsErrored,
+            &serde_json::json!({
+                "correlation_id": correlation_id.to_string(),
+                "reason": error.stage(),
+            }),
+        )
+        .await
+        {
+            warn!(error = %emit_error, "Failed to emit predictions_errored event");
         }
     }
 
@@ -137,33 +134,22 @@ pub async fn run_predictions(state: &AppState) -> Result<PredictionRun, Pipeline
 
 async fn run_pipeline_and_persist(
     state: &AppState,
-    http_client: &reqwest::Client,
+    pool: &sqlx::PgPool,
     correlation_id: Uuid,
 ) -> Result<PredictionRun, PipelineError> {
-    // Inference holds the model lock across the data-fetch awaits, matching the
-    // original handler. The block yields the predictions plus the run id so the
-    // lock is released before persistence.
     let (predictions, model_run_id) = {
         let guard = state.model_state().lock().await;
         let model_state = guard.as_ref().ok_or_else(|| {
             PipelineError::new("model_not_loaded", "Model not loaded".to_string())
         })?;
 
-        let equity_bars = predict::fetch_equity_bars_from_pool_or_service(
-            state.pool(),
-            state.data_manager_base_url(),
-            http_client,
-        )
-        .await
-        .map_err(|e| PipelineError::new("fetch_equity_bars", e.to_string()))?;
+        let equity_bars = predict::fetch_equity_bars(pool)
+            .await
+            .map_err(|e| PipelineError::new("fetch_equity_bars", e.to_string()))?;
 
-        let equity_details = predict::fetch_equity_details_from_pool_or_service(
-            state.pool(),
-            state.data_manager_base_url(),
-            http_client,
-        )
-        .await
-        .map_err(|e| PipelineError::new("fetch_equity_details", e.to_string()))?;
+        let equity_details = predict::fetch_equity_details(pool)
+            .await
+            .map_err(|e| PipelineError::new("fetch_equity_details", e.to_string()))?;
 
         let consolidated = predict::consolidate_data(equity_bars, equity_details)
             .map_err(|e| PipelineError::new("data_consolidation", e.to_string()))?;
@@ -191,43 +177,20 @@ async fn run_pipeline_and_persist(
 
     let row_count = predictions.as_array().map(|array| array.len()).unwrap_or(0);
 
-    if let Some(pool) = state.pool() {
-        if let Some(prediction_array) = predictions.as_array() {
-            let rows =
-                database::insert_predictions(pool, prediction_array, correlation_id, &model_run_id)
-                    .await
-                    .map_err(|e| PipelineError::new("insert_predictions", e.to_string()))?;
-            info!(rows = rows, "Predictions inserted into PostgreSQL");
-            if let Err(e) = crate::common::events::emit_event(
-                pool,
-                crate::common::events::EventType::EquityPredictionsCompleted,
-                &serde_json::json!({"correlation_id": correlation_id.to_string()}),
-            )
-            .await
-            {
-                warn!(error = %e, "Failed to emit predictions_completed event");
-            }
-        }
-    } else {
-        let save_result = http_client
-            .post(format!("{}/predictions", state.data_manager_base_url()))
-            .json(&serde_json::json!({
-                "timestamp": chrono::Utc::now().to_rfc3339(),
-                "data": predictions,
-            }))
-            .send()
-            .await;
-
-        match save_result {
-            Ok(resp) if resp.status().is_success() => {
-                info!("Predictions saved to data manager");
-            }
-            Ok(resp) => {
-                warn!(status = %resp.status(), "Failed to save predictions to data manager");
-            }
-            Err(e) => {
-                warn!(error = %e, "Failed to save predictions to data manager");
-            }
+    if let Some(prediction_array) = predictions.as_array() {
+        let rows =
+            database::insert_predictions(pool, prediction_array, correlation_id, &model_run_id)
+                .await
+                .map_err(|e| PipelineError::new("insert_predictions", e.to_string()))?;
+        info!(rows = rows, "Predictions inserted into PostgreSQL");
+        if let Err(e) = crate::common::events::emit_event(
+            pool,
+            crate::common::events::EventType::EquityPredictionsCompleted,
+            &serde_json::json!({"correlation_id": correlation_id.to_string()}),
+        )
+        .await
+        {
+            warn!(error = %e, "Failed to emit predictions_completed event");
         }
     }
 
@@ -368,7 +331,6 @@ mod tests {
             s3_client,
             "test-bucket".to_string(),
             "artifacts/tide/".to_string(),
-            "http://localhost:8080".to_string(),
             "latest".to_string(),
         )
     }
@@ -412,14 +374,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_run_predictions_without_model_reports_stage() {
+    async fn test_run_predictions_without_pool_reports_stage() {
         // The shared pipeline entrypoint surfaces the failing stage so the
-        // consumer can emit predictions_failed with a meaningful reason.
+        // consumer can emit predictions_errored with a meaningful reason.
         let state = make_test_state();
 
         let result = run_predictions(&state).await;
-        let error = result.err().expect("run must fail without a model");
-        assert_eq!(error.stage(), "model_not_loaded");
+        let error = result.err().expect("run must fail without a pool");
+        assert_eq!(error.stage(), "no_pool");
     }
 
     #[tokio::test]
@@ -478,6 +440,7 @@ mod tests {
         // Stage name strings are stored in structured logs and emitted as event
         // payloads; they must not change.
         let stages = [
+            "no_pool",
             "model_not_loaded",
             "fetch_equity_bars",
             "fetch_equity_details",
@@ -576,17 +539,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_run_predictions_error_stage_is_model_not_loaded() {
-        // Verifies that the error returned by run_predictions (with no model)
-        // carries the "model_not_loaded" stage string used in structured logs
-        // and event payloads. This exercises the error-logging block in
-        // run_predictions as well as the PipelineError accessors.
+    async fn test_run_predictions_error_stage_is_no_pool() {
+        // Verifies that the error returned by run_predictions (with no pool)
+        // carries the "no_pool" stage string used in structured logs and event
+        // payloads.
         let state = make_test_state();
         let error = run_predictions(&state)
             .await
             .err()
-            .expect("expected an error when no model is loaded");
-        assert_eq!(error.stage(), "model_not_loaded");
+            .expect("expected an error when no pool is configured");
+        assert_eq!(error.stage(), "no_pool");
         assert!(!error.message().is_empty());
     }
 

--- a/src/ensemble_manager/state.rs
+++ b/src/ensemble_manager/state.rs
@@ -132,7 +132,6 @@ mod tests {
         assert_eq!(state.artifact_bucket(), "test-bucket");
         assert_eq!(state.artifact_prefix(), "models/tide/");
         assert_eq!(state.model_version(), "latest");
-        assert!(state.data_manager_base_url().is_empty());
         assert!(state.local_artifact_dir().is_none());
 
         let guard = state.model_state().lock().await;
@@ -164,13 +163,11 @@ mod tests {
             make_s3_client(),
             "test-bucket".to_string(),
             "models/tide/".to_string(),
-            "http://data-manager:8080".to_string(),
             "latest".to_string(),
         );
 
         assert_eq!(state.artifact_bucket(), "test-bucket");
         assert_eq!(state.artifact_prefix(), "models/tide/");
-        assert_eq!(state.data_manager_base_url(), "http://data-manager:8080");
         assert_eq!(state.model_version(), "latest");
         assert!(state.pool().is_none());
         assert!(state.local_artifact_dir().is_none());
@@ -182,7 +179,6 @@ mod tests {
             make_s3_client(),
             "bucket".to_string(),
             "prefix/".to_string(),
-            "http://localhost".to_string(),
             "1.0".to_string(),
         );
 
@@ -196,7 +192,6 @@ mod tests {
             make_s3_client(),
             "bucket".to_string(),
             "prefix/".to_string(),
-            "http://localhost".to_string(),
             "latest".to_string(),
         );
         let cloned = state.clone();
@@ -213,7 +208,6 @@ mod tests {
             make_s3_client(),
             "bucket".to_string(),
             "prefix/".to_string(),
-            "http://localhost".to_string(),
             "latest".to_string(),
         );
         // Accessor must compile and return a reference without panicking.
@@ -285,7 +279,6 @@ pub struct AppState {
     s3_client: aws_sdk_s3::Client,
     artifact_bucket: String,
     artifact_prefix: String,
-    data_manager_base_url: String,
     model_version: String,
     local_artifact_dir: Option<std::path::PathBuf>,
     pool: Option<PgPool>,
@@ -308,10 +301,6 @@ impl AppState {
         &self.artifact_prefix
     }
 
-    pub fn data_manager_base_url(&self) -> &str {
-        &self.data_manager_base_url
-    }
-
     pub fn model_version(&self) -> &str {
         &self.model_version
     }
@@ -330,7 +319,6 @@ impl AppState {
         s3_client: aws_sdk_s3::Client,
         artifact_bucket: String,
         artifact_prefix: String,
-        data_manager_base_url: String,
         model_version: String,
     ) -> Self {
         AppState {
@@ -338,7 +326,6 @@ impl AppState {
             s3_client,
             artifact_bucket,
             artifact_prefix,
-            data_manager_base_url,
             model_version,
             local_artifact_dir: None,
             pool: None,
@@ -366,7 +353,6 @@ impl AppState {
             s3_client,
             artifact_bucket,
             artifact_prefix,
-            data_manager_base_url: String::new(),
             model_version,
             local_artifact_dir,
             pool: Some(pool),
@@ -378,8 +364,6 @@ impl AppState {
             std::env::var("AWS_S3_BUCKET_NAME").unwrap_or_else(|_| "fund-artifacts".to_string());
         let artifact_prefix = std::env::var("AWS_S3_MODEL_ARTIFACT_PATH")
             .unwrap_or_else(|_| "models/tide/".to_string());
-        let data_manager_base_url = std::env::var("FUND_DATA_MANAGER_BASE_URL")
-            .unwrap_or_else(|_| "http://data-manager:8080".to_string());
         let model_version = std::env::var("MODEL_VERSION").unwrap_or_else(|_| "latest".to_string());
         let local_artifact_dir = std::env::var("FUND_LOCAL_ARTIFACT_DIR")
             .ok()
@@ -394,7 +378,6 @@ impl AppState {
             s3_client,
             artifact_bucket,
             artifact_prefix,
-            data_manager_base_url,
             model_version,
             local_artifact_dir,
             pool,


### PR DESCRIPTION
## Summary

- Remove the HTTP fallback data-fetching path from ensemble_manager that fetched equity bars/details from data_manager over HTTP when no database pool was available
- Simplify `predict.rs` to query PostgreSQL directly (the database path already existed alongside the HTTP path)
- Remove `data_manager_base_url` field from `AppState` and the `FUND_DATA_MANAGER_BASE_URL` environment variable
- Require a database pool in `run_predictions`, failing early with a `no_pool` stage error if missing

## Test plan

- [x] All existing tests updated and passing (`devenv tasks run checks:rust`)
- [x] HTTP-only tests removed (tested code no longer exists)
- [x] Tests that previously expected `model_not_loaded` now correctly expect `no_pool` when no pool configured
- [x] CI checks pass

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Prediction data is now retrieved directly from the database.
  - Generated predictions are saved to the database and completion status is recorded.

- **Bug Fixes**
  - Prediction processing now reports a clear error when database connectivity is unavailable.
  - Improved failure reporting identifies the stage where processing stopped.

- **Documentation**
  - Updated service documentation to accurately describe its prediction workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->