### PR TITLE
Trim unused Rust dependencies and add cargo-machete check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -2852,15 +2851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,7 +2982,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "urlencoding",
  "uuid",
 ]
 
@@ -3636,16 +3625,6 @@ dependencies = [
  "rand_distr 0.5.1",
  "serde",
  "zerocopy",
-]
-
-[[package]]
-name = "halfbrown"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2c385c6df70fd180bbb673d93039dbd2cd34e41d782600bdf6e1ca7bce39aa"
-dependencies = [
- "hashbrown 0.15.5",
- "serde",
 ]
 
 [[package]]
@@ -4364,17 +4343,6 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonpath_lib_polars_vendor"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4bd9354947622f7471ff713eacaabdb683ccb13bba4edccaab9860abf480b7d"
-dependencies = [
- "log",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -5771,7 +5739,6 @@ dependencies = [
  "polars-arrow",
  "polars-core",
  "polars-error",
- "polars-json",
  "polars-parquet",
  "polars-schema",
  "polars-time",
@@ -5782,32 +5749,10 @@ dependencies = [
  "ryu",
  "serde",
  "serde_json",
- "simd-json",
  "simdutf8",
  "tokio",
  "tokio-util",
  "url",
-]
-
-[[package]]
-name = "polars-json"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26d1a04292a82183c8eba94fdf1584f200bfac5ac2f4a6c5652c8c8ed3bb41c"
-dependencies = [
- "chrono",
- "fallible-streaming-iterator",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "itoa",
- "num-traits",
- "polars-arrow",
- "polars-compute",
- "polars-error",
- "polars-utils",
- "ryu",
- "simd-json",
- "streaming-iterator",
 ]
 
 [[package]]
@@ -5825,7 +5770,6 @@ dependencies = [
  "polars-core",
  "polars-expr",
  "polars-io",
- "polars-json",
  "polars-mem-engine",
  "polars-ops",
  "polars-plan",
@@ -5849,7 +5793,6 @@ dependencies = [
  "polars-error",
  "polars-expr",
  "polars-io",
- "polars-json",
  "polars-ops",
  "polars-plan",
  "polars-time",
@@ -5874,7 +5817,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "hex",
  "indexmap 2.14.0",
- "jsonpath_lib_polars_vendor",
  "libm",
  "memchr",
  "num-traits",
@@ -5882,13 +5824,11 @@ dependencies = [
  "polars-compute",
  "polars-core",
  "polars-error",
- "polars-json",
  "polars-schema",
  "polars-utils",
  "rayon",
  "regex",
  "regex-syntax",
- "serde_json",
  "strum_macros 0.27.2",
  "unicode-normalization",
  "unicode-reverse",
@@ -5955,7 +5895,6 @@ dependencies = [
  "polars-core",
  "polars-error",
  "polars-io",
- "polars-json",
  "polars-ops",
  "polars-parquet",
  "polars-time",
@@ -7521,7 +7460,6 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -7735,23 +7673,6 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simd-json"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c962f626b54771990066e5435ec8331d1462576cd2d1e62f24076ae014f92112"
-dependencies = [
- "ahash 0.8.12",
- "getrandom 0.3.4",
- "halfbrown",
- "once_cell",
- "ref-cast",
- "serde",
- "serde_json",
- "simdutf8",
- "value-trait",
-]
 
 [[package]]
 name = "simd_cesu8"
@@ -9208,18 +9129,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-trait"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0508fce11ad19e0aab49ce20b6bec7f8f82902ded31df1c9fc61b90f0eb396b8"
-dependencies = [
- "float-cmp",
- "halfbrown",
- "itoa",
- "ryu",
-]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,7 @@ required-features = ["data", "inference", "portfolio"]
 
 [features]
 default = ["data", "inference", "portfolio"]
-data = [
-  "dep:chrono-tz",
-  "dep:urlencoding",
-  "dep:tokio-tungstenite",
-  "dep:futures-util",
-]
+data = ["dep:chrono-tz", "dep:tokio-tungstenite", "dep:futures-util"]
 inference = ["dep:burn", "dep:ndarray", "dep:flate2", "dep:tar", "dep:tempfile"]
 portfolio = ["dep:chrono-tz"]
 dashboard_service = ["dep:ratatui", "dep:crossterm"]
@@ -54,11 +49,8 @@ train = ["inference", "dep:rand"]
 # Shared / base (always compiled)
 chrono = { version = "0.4.44", features = ["serde"] }
 polars = { version = "0.51.0", features = [
-  "json",
   "lazy",
   "parquet",
-  "temporal",
-  "serde",
   "strings",
   "is_in",
   "semi_anti_join",
@@ -98,7 +90,6 @@ rustls = { version = "0.23", features = ["aws_lc_rs"] }
 
 # data-only (optional; enabled by the `data` feature)
 chrono-tz = { version = "0.10", optional = true }
-urlencoding = { version = "2.1.3", optional = true }
 tokio-tungstenite = { version = "0.26", features = [
   "rustls-tls-native-roots",
 ], optional = true }

--- a/devenv.nix
+++ b/devenv.nix
@@ -173,6 +173,7 @@ in {
     clang
     bacon
     cargo-llvm-cov
+    cargo-machete
     cargo-watch
     curl
     duckdb # retained for local data exploration and experimentation
@@ -258,6 +259,13 @@ in {
     echo "Running Rust lint checks"
     cargo clippy --workspace --all-features --all-targets
     echo "Rust linting completed successfully"
+  '';
+
+  scripts.check-unused-dependencies.exec = ''
+    set -euo pipefail
+    echo "Checking for unused Rust dependencies"
+    cargo machete
+    echo "No unused dependencies found"
   '';
 
   scripts.test-rust.exec = ''
@@ -416,6 +424,10 @@ in {
       exec = "test-rust";
       after = ["checks:rust:format"];
     };
+    "checks:rust:unused-dependencies" = {
+      exec = "check-unused-dependencies";
+      after = ["checks:rust:format"];
+    };
 
     # --- Standalone checks ---
 
@@ -528,6 +540,7 @@ in {
         "checks:rust:format"
         "checks:rust:lint"
         "checks:rust:test"
+        "checks:rust:unused-dependencies"
       ];
     };
   };
@@ -596,7 +609,7 @@ in {
       echo ""
       echo "  Tasks (devenv tasks run):"
       echo "    checks:base                    Non-language checks (nix, markdown, yaml, toml, sql)"
-      echo "    checks:rust                    All Rust checks (sequential: format, lint, test)"
+      echo "    checks:rust                    All Rust checks (sequential: format, then lint + test + unused-deps)"
       echo "    checks:markdown                Markdown lint"
       echo "    checks:yaml                    YAML lint"
       echo "    checks:toml                    TOML format check"


### PR DESCRIPTION
# Overview

## Changes

- Remove three unused Polars features (`json`, `temporal`, `serde`) confirmed unused via codebase audit and successful `cargo check --workspace --all-features`
- Remove the unused `urlencoding` crate detected by cargo-machete
- Add `cargo-machete` to devenv packages for heuristic-based unused dependency detection
- Add `checks:rust:unused-dependencies` task that runs after format, parallel with lint and test
- Wire the new task into `checks:continuous-integration`

## Context

Polars is one of the heavier compile-time dependencies. An audit of all enabled features against actual usage in `src/` found three features with no corresponding API calls in the codebase. Removing them trims unnecessary compilation work. The `urlencoding` crate had zero imports across all Rust files.

Adding cargo-machete as a CI check prevents dependency drift going forward. It uses heuristic text scanning (no compilation required) so it runs in under a second.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused URL encoding support from the project configuration.
  * Streamlined enabled data-processing capabilities.
  * Added automated checks to detect unused dependencies during continuous integration.
  * Updated development environment guidance to reflect the expanded Rust checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->