### PR TITLE
Bump tokio-tungstenite to 0.30.0 and uuid to 1.23.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8686,9 +8686,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
@@ -8900,21 +8900,20 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
 dependencies = [
  "bytes",
  "data-encoding",
  "http 1.4.2",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.10.2",
  "rustls 0.23.41",
  "rustls-pki-types",
- "sha1 0.10.7",
+ "sha1 0.11.0",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -9082,12 +9081,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9101,9 +9094,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "atomic",
  "getrandom 0.4.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ rustls = { version = "0.23", features = ["aws_lc_rs"] }
 
 # data-only (optional; enabled by the `data` feature)
 chrono-tz = { version = "0.10", optional = true }
-tokio-tungstenite = { version = "0.26", features = [
+tokio-tungstenite = { version = "0.30", features = [
   "rustls-tls-native-roots",
 ], optional = true }
 futures-util = { version = "0.3", optional = true }


### PR DESCRIPTION
# Overview

## Changes

- Bump `tokio-tungstenite` from 0.26.2 to 0.30.0 (updates underlying `tungstenite` to 0.30.0)
- Bump `uuid` from 1.23.4 to 1.23.5
- Consolidates Dependabot PRs #995 and #996 into a single change

## Context

**tokio-tungstenite 0.30.0** updates the underlying `tungstenite` to 0.30.0, which changes `Message::Text` from `String` to `Utf8Bytes` and `Message::Ping`/`Message::Pong` from `Vec<u8>` to `Bytes`. Our usage in `equity_quotes.rs` is compatible without code changes because `Utf8Bytes` implements `Deref<Target=str>` and `From<String>`.

**uuid 1.23.5** is a patch release with optimized hex parsing/formatting performance.

Both changes compile cleanly and all unit tests pass.