### PR TITLE
Split fund binary into separate processes and normalize structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,13 @@ devenv --profile application up
 For remote development or production instances, you can provision VMs on `exe.dev`.
 
 ```sh
-# Include the --production flag for production instances
-bash tools/provision-application-vm
-bash tools/provision-trainer-vm
+# Development
+provision-development-application-vm
+provision-development-trainer-vm
+
+# Production
+provision-production-application-vm
+provision-production-trainer-vm
 ```
 
 #### Data

--- a/devenv.nix
+++ b/devenv.nix
@@ -366,10 +366,10 @@ in {
     '{}')"
   '';
 
-  scripts.provision-development-application-vm.exec = "bash tools/provision-application-vm";
-  scripts.provision-production-application-vm.exec = "bash tools/provision-application-vm --production";
-  scripts.provision-development-trainer-vm.exec = "bash tools/provision-trainer-vm";
-  scripts.provision-production-trainer-vm.exec = "bash tools/provision-trainer-vm --production";
+  scripts.provision-development-application-vm.exec = "bash tools/provision-application-vm --environment development";
+  scripts.provision-production-application-vm.exec = "bash tools/provision-application-vm --environment production";
+  scripts.provision-development-trainer-vm.exec = "bash tools/provision-trainer-vm --environment development";
+  scripts.provision-production-trainer-vm.exec = "bash tools/provision-trainer-vm --environment production";
 
   scripts.seed-equity-bars.exec = ''
     set -euo pipefail
@@ -558,7 +558,9 @@ in {
       MODEL_VERSION = "latest";
     };
 
-    processes.fund.exec = ''
+    # Shared setup: wait for PostgreSQL and apply schema before any module starts.
+    # process-compose `depends_on` ensures this completes first.
+    processes.database.exec = ''
       set -euo pipefail
       ${runtimeEnv}
       attempt=0
@@ -572,8 +574,34 @@ in {
         sleep 2
       done
       ${applySchema}
-      exec secretspec run -- cargo run --release --bin fund
     '';
+
+    processes.data = {
+      exec = ''
+        set -euo pipefail
+        ${runtimeEnv}
+        exec secretspec run -- cargo run --release --bin fund -- --module data
+      '';
+      process-compose.depends_on.database.condition = "process_completed_successfully";
+    };
+
+    processes.inference = {
+      exec = ''
+        set -euo pipefail
+        ${runtimeEnv}
+        exec secretspec run -- cargo run --release --bin fund -- --module inference
+      '';
+      process-compose.depends_on.database.condition = "process_completed_successfully";
+    };
+
+    processes.portfolio = {
+      exec = ''
+        set -euo pipefail
+        ${runtimeEnv}
+        exec secretspec run -- cargo run --release --bin fund -- --module portfolio
+      '';
+      process-compose.depends_on.database.condition = "process_completed_successfully";
+    };
   };
 
   profiles.trainer.module = {
@@ -596,7 +624,9 @@ in {
       echo "    devenv --profile trainer shell     Model training environment"
       echo ""
       echo "  Services (application profile):"
-      echo "    Fund:         consolidated event-driven binary"
+      echo "    Data:         market data sync, quote streaming, nightly exports"
+      echo "    Inference:    model artifact polling, prediction pipeline"
+      echo "    Portfolio:    rebalance orchestration, liquidation"
       echo "    PostgreSQL:   localhost:5432/fund"
       echo ""
       echo "  Secrets (secretspec):"

--- a/src/bin/fund.rs
+++ b/src/bin/fund.rs
@@ -1,28 +1,84 @@
 //! Consolidated fund binary.
 //!
-//! Runs the data, inference, and portfolio services in a single process,
-//! sharing a single `PgPool` and `S3Client`. All work is driven by PostgreSQL
-//! LISTEN/NOTIFY events — no HTTP servers are started.
+//! Runs the data, inference, and portfolio services either together (default)
+//! or individually via `--module <data|inference|portfolio>`. When split into
+//! separate processes (e.g. via devenv process-compose), each process gets its
+//! own log stream and TUI panel while still sharing the same PostgreSQL
+//! event bus for inter-service coordination.
 
 use tracing::{error, info};
+
+const USAGE: &str = "Usage: fund [--module <data|inference|portfolio>]";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Module {
+    Data,
+    Inference,
+    Portfolio,
+}
+
+impl Module {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "data" => Ok(Self::Data),
+            "inference" => Ok(Self::Inference),
+            "portfolio" => Ok(Self::Portfolio),
+            _ => Err(format!(
+                "Unknown module '{}': expected 'data', 'inference', or 'portfolio'",
+                value
+            )),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Data => "data",
+            Self::Inference => "inference",
+            Self::Portfolio => "portfolio",
+        }
+    }
+}
+
+fn parse_args() -> Result<Option<Module>, String> {
+    let arguments: Vec<String> = std::env::args().skip(1).collect();
+    if arguments.is_empty() {
+        return Ok(None);
+    }
+    if arguments.len() == 2 && arguments[0] == "--module" {
+        return Module::parse(&arguments[1]).map(Some);
+    }
+    Err(USAGE.to_string())
+}
 
 #[tokio::main]
 async fn main() {
     fund::common::crypto::install_default_crypto_provider();
 
-    let _tracing_guard = fund::common::observability::init_tracing("fund.log", None);
+    let module = match parse_args() {
+        Ok(module) => module,
+        Err(message) => {
+            eprintln!("{}", message);
+            std::process::exit(1);
+        }
+    };
 
-    if let Err(error) = run().await {
+    let service_name = module.map(Module::as_str).unwrap_or("fund");
+    let log_file = format!("{}.log", service_name);
+    let _tracing_guard = fund::common::observability::init_tracing(&log_file, None, service_name);
+
+    if let Err(error) = run(module).await {
         error!("{}", error);
         eprintln!("{}", error);
         std::process::exit(1);
     }
 }
 
-async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    info!("Starting consolidated fund service");
+async fn run(module: Option<Module>) -> Result<(), Box<dyn std::error::Error>> {
+    match module {
+        Some(module) => info!(module = module.as_str(), "Starting fund service"),
+        None => info!("Starting consolidated fund service"),
+    }
 
-    // Shared infrastructure: one pool, one S3 client for all modules.
     let database_url = std::env::var("DATABASE_URL")
         .map_err(|_| "DATABASE_URL environment variable must be set")?;
     let pool = sqlx::PgPool::connect(&database_url).await?;
@@ -30,18 +86,18 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let s3_client = fund::common::aws::s3_client().await;
 
-    // --- data ---
-    {
-        let _span = tracing::info_span!("data").entered();
+    let run_data = module.is_none() || module == Some(Module::Data);
+    let run_inference = module.is_none() || module == Some(Module::Inference);
+    let run_portfolio = module.is_none() || module == Some(Module::Portfolio);
+
+    if run_data {
         let state = fund::data::state::State::with_pool(pool.clone(), s3_client.clone());
         fund::data::scheduler::spawn_sync_scheduler(state.clone());
         fund::data::equity_quotes::spawn_quote_stream(state.clone());
         info!("Data service started");
     }
 
-    // --- inference ---
-    {
-        let _span = tracing::info_span!("inference").entered();
+    if run_inference {
         let state = fund::inference::state::AppState::with_pool(pool.clone(), s3_client.clone());
         fund::inference::pipeline::poll_artifact_once(&state).await;
         tokio::spawn(fund::inference::pipeline::start_artifact_polling(
@@ -51,16 +107,39 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         info!("Inference service started");
     }
 
-    // --- portfolio ---
-    {
-        let _span = tracing::info_span!("portfolio").entered();
+    if run_portfolio {
         let state = fund::portfolio::state::AppState::with_pool(pool)?;
         fund::portfolio::consumer::spawn_event_consumer(state);
         info!("Portfolio service started");
     }
 
-    info!("All modules running, waiting for events");
+    info!("Waiting for events");
     tokio::signal::ctrl_c().await?;
     info!("Shutting down");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_module_parse_valid_values() {
+        assert_eq!(Module::parse("data").unwrap(), Module::Data);
+        assert_eq!(Module::parse("inference").unwrap(), Module::Inference);
+        assert_eq!(Module::parse("portfolio").unwrap(), Module::Portfolio);
+    }
+
+    #[test]
+    fn test_module_parse_rejects_unknown() {
+        assert!(Module::parse("unknown").is_err());
+        assert!(Module::parse("").is_err());
+    }
+
+    #[test]
+    fn test_module_as_str_round_trips() {
+        for module in [Module::Data, Module::Inference, Module::Portfolio] {
+            assert_eq!(Module::parse(module.as_str()).unwrap(), module);
+        }
+    }
 }

--- a/src/bin/fund.rs
+++ b/src/bin/fund.rs
@@ -67,7 +67,7 @@ async fn main() {
     let _tracing_guard = fund::common::observability::init_tracing(&log_file, None, service_name);
 
     if let Err(error) = run(module).await {
-        error!("{}", error);
+        error!(error = %error, "Run failed");
         eprintln!("{}", error);
         std::process::exit(1);
     }

--- a/src/bin/seed_equity_bars.rs
+++ b/src/bin/seed_equity_bars.rs
@@ -131,7 +131,11 @@ fn parse_arguments(arguments: &[String]) -> Result<Arguments, String> {
 async fn main() {
     fund::common::crypto::install_default_crypto_provider();
 
-    let _tracing_guard = init_tracing("seed-equity-bars-errors.log", Some("warn"));
+    let _tracing_guard = init_tracing(
+        "seed-equity-bars-errors.log",
+        Some("warn"),
+        "seed-equity-bars",
+    );
 
     let raw_arguments: Vec<String> = std::env::args().skip(1).collect();
     let arguments = match parse_arguments(&raw_arguments) {

--- a/src/bin/seed_equity_details.rs
+++ b/src/bin/seed_equity_details.rs
@@ -72,7 +72,7 @@ async fn upload_to_s3(state: &State) -> Result<(), String> {
         .await
         .map_err(|error| format!("Failed to upload equity details to S3: {}", error))?;
 
-    tracing::info!("Uploaded equity details CSV to S3: {}", S3_KEY);
+    tracing::info!(key = S3_KEY, "Uploaded equity details CSV to S3");
     Ok(())
 }
 
@@ -97,7 +97,11 @@ async fn insert_into_postgresql(state: &State) -> Result<u64, String> {
 async fn main() {
     fund::common::crypto::install_default_crypto_provider();
 
-    let _tracing_guard = init_tracing("seed-equity-details-errors.log", Some("warn"));
+    let _tracing_guard = init_tracing(
+        "seed-equity-details-errors.log",
+        Some("warn"),
+        "seed-equity-details",
+    );
 
     let raw_arguments: Vec<String> = std::env::args().skip(1).collect();
     let target = match parse_arguments(&raw_arguments) {

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -41,7 +41,7 @@ const DRIFT_DEGRADATION_THRESHOLD: f64 = 0.20;
 
 #[tokio::main]
 async fn main() {
-    let _tracing_guard = init_tracing("tide-model-trainer.log", Some("info"));
+    let _tracing_guard = init_tracing("tide-model-trainer.log", Some("info"), "tide-model-trainer");
     if let Err(error) = run().await {
         error!("Training failed: {}", error);
         eprintln!("Training failed: {}", error);

--- a/src/common/observability.rs
+++ b/src/common/observability.rs
@@ -7,6 +7,10 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
 /// Initialize structured JSON tracing for a service.
 ///
+/// The `service` parameter identifies which service is emitting logs
+/// (e.g. `"data"`, `"inference"`, `"portfolio"`) and is included in the
+/// initial `Tracing initialized` log line for correlation.
+///
 /// Logs to stdout at the `RUST_LOG` level (default `info`). When the log
 /// directory is writable, also logs to a rolling daily file there; the
 /// directory is `FUND_LOG_DIR` when set, otherwise `/var/log/fund` (local
@@ -25,7 +29,11 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 /// Services that own stdout for terminal rendering (e.g. the dashboard TUI)
 /// should call [`init_tracing_file_only`] instead to avoid corrupting the
 /// alternate screen with JSON log output.
-pub fn init_tracing(log_file: &str, file_filter: Option<&str>) -> Option<WorkerGuard> {
+pub fn init_tracing(
+    log_file: &str,
+    file_filter: Option<&str>,
+    service: &str,
+) -> Option<WorkerGuard> {
     let fund_profile = env::var("FUND_PROFILE").unwrap_or_else(|_| "unknown".to_string());
 
     let stdout_layer = tracing_subscriber::fmt::layer().json().with_target(true);
@@ -78,7 +86,11 @@ pub fn init_tracing(log_file: &str, file_filter: Option<&str>) -> Option<WorkerG
         }
     };
 
-    tracing::info!(fund_profile = %fund_profile, "Tracing initialized");
+    tracing::info!(
+        service = service,
+        fund_profile = %fund_profile,
+        "Tracing initialized"
+    );
     guard
 }
 
@@ -90,7 +102,7 @@ pub fn init_tracing(log_file: &str, file_filter: Option<&str>) -> Option<WorkerG
 ///
 /// When the log directory is not writable, tracing is silently disabled rather
 /// than falling back to stdout.
-pub fn init_tracing_file_only(log_file: &str) -> Option<WorkerGuard> {
+pub fn init_tracing_file_only(log_file: &str, service: &str) -> Option<WorkerGuard> {
     let fund_profile = env::var("FUND_PROFILE").unwrap_or_else(|_| "unknown".to_string());
 
     let log_dir = env::var("FUND_LOG_DIR").unwrap_or_else(|_| "/var/log/fund".to_string());
@@ -126,7 +138,11 @@ pub fn init_tracing_file_only(log_file: &str) -> Option<WorkerGuard> {
         }
     };
 
-    tracing::info!(fund_profile = %fund_profile, "Tracing initialized");
+    tracing::info!(
+        service = service,
+        fund_profile = %fund_profile,
+        "Tracing initialized"
+    );
     guard
 }
 
@@ -168,34 +184,23 @@ mod tests {
     #[test]
     #[serial]
     fn test_init_tracing_is_idempotent() {
-        // Exercises both the fixed-directive file filter and the RUST_LOG-derived
-        // one, and confirms a second initialization is a no-op (try_init). Works
-        // whether or not the log directory is writable.
-        let _first = init_tracing("test-observability.log", Some("warn"));
-        let _second = init_tracing("test-observability.log", None);
+        let _first = init_tracing("test-observability.log", Some("warn"), "test");
+        let _second = init_tracing("test-observability.log", None, "test");
     }
 
     #[test]
     #[serial]
     fn test_fund_log_dir_override_enables_file_logging() {
-        // FUND_LOG_DIR pointing at a writable directory activates file logging
-        // (a returned guard) and the directory is created on demand. This is the
-        // local-dev path where /var/log/fund is not writable.
         let log_dir = env::temp_dir().join("fund-observability-test");
         let _ = std::fs::remove_dir_all(&log_dir);
         let previous_log_dir = env::var("FUND_LOG_DIR").ok();
         env::set_var("FUND_LOG_DIR", &log_dir);
 
-        let guard = init_tracing("test-observability.log", None);
+        let guard = init_tracing("test-observability.log", None, "test");
 
-        // try_init is global, so file logging is only guaranteed active when this
-        // test wins the initialization race; in either case the directory the
-        // override names must have been created.
         assert!(log_dir.is_dir());
         let _ = guard;
 
-        // Restore the runner's value rather than unconditionally unsetting it,
-        // so later tests see the environment they started with.
         match previous_log_dir {
             Some(value) => env::set_var("FUND_LOG_DIR", value),
             None => env::remove_var("FUND_LOG_DIR"),
@@ -206,22 +211,18 @@ mod tests {
     #[test]
     #[serial]
     fn test_fund_profile_env_var_is_read() {
-        // When FUND_PROFILE is set, init_tracing uses it without panicking.
-        // Since try_init is idempotent, this mainly confirms the env-var read path
-        // is exercised rather than hitting the unwrap_or_else default.
         let _restore = EnvVarRestoreGuard::save("FUND_PROFILE");
         // SAFETY: Protected by #[serial_test::serial] — no concurrent env access.
         unsafe { env::set_var("FUND_PROFILE", "test-profile") };
-        let _tracing_guard = init_tracing("test-profile-observability.log", None);
+        let _tracing_guard = init_tracing("test-profile-observability.log", None, "test");
     }
 
     #[test]
     #[serial]
     fn test_fund_profile_env_var_absent_uses_unknown() {
-        // When FUND_PROFILE is not set, init_tracing must not panic.
         let _restore = EnvVarRestoreGuard::save("FUND_PROFILE");
         // SAFETY: Protected by #[serial_test::serial] — no concurrent env access.
         unsafe { env::remove_var("FUND_PROFILE") };
-        let _tracing_guard = init_tracing("test-no-profile-observability.log", None);
+        let _tracing_guard = init_tracing("test-no-profile-observability.log", None, "test");
     }
 }

--- a/src/dashboard_service.rs
+++ b/src/dashboard_service.rs
@@ -38,7 +38,7 @@ const POOL_MAX_CONNECTIONS: u32 = 4;
 ///
 /// Panics on startup if `DATABASE_URL` is unset or the database is unreachable.
 pub async fn run() {
-    let _tracing_guard = init_tracing_file_only("dashboard-service.log");
+    let _tracing_guard = init_tracing_file_only("dashboard-service.log", "dashboard");
     info!("Starting dashboard service");
 
     let database_url =

--- a/src/data/database.rs
+++ b/src/data/database.rs
@@ -75,7 +75,7 @@ pub async fn insert_equity_bars(pool: &PgPool, bars: &[EquityBar]) -> Result<u64
     }
 
     transaction.commit().await?;
-    info!("Inserted {} equity bars into PostgreSQL", rows_affected);
+    info!(rows = rows_affected, "Inserted equity bars into PostgreSQL");
     Ok(rows_affected)
 }
 
@@ -110,7 +110,10 @@ pub async fn insert_equity_quotes(
     }
 
     transaction.commit().await?;
-    debug!("Inserted {} equity quotes into PostgreSQL", rows_affected);
+    debug!(
+        rows = rows_affected,
+        "Inserted equity quotes into PostgreSQL"
+    );
     Ok(rows_affected)
 }
 
@@ -129,7 +132,10 @@ pub async fn get_active_tickers(pool: &PgPool) -> Result<Vec<Ticker>, sqlx::Erro
         .into_iter()
         .filter_map(|row| Ticker::new(&row.ticker))
         .collect();
-    debug!("Queried {} active tickers from PostgreSQL", tickers.len());
+    debug!(
+        rows = tickers.len(),
+        "Queried active tickers from PostgreSQL"
+    );
     Ok(tickers)
 }
 
@@ -211,7 +217,7 @@ pub async fn query_equity_quotes_for_date(
         })
         .collect::<Result<Vec<_>, sqlx::Error>>()?;
 
-    debug!("Queried {} equity quotes for {}", quotes.len(), date);
+    debug!(rows = quotes.len(), date = %date, "Queried equity quotes from PostgreSQL");
     Ok(quotes)
 }
 
@@ -276,7 +282,7 @@ pub async fn query_equity_bars_for_date(
         })
         .collect::<Result<Vec<_>, sqlx::Error>>()?;
 
-    debug!("Queried {} equity bars for {}", bars.len(), date);
+    debug!(rows = bars.len(), date = %date, "Queried equity bars from PostgreSQL");
     Ok(bars)
 }
 
@@ -505,11 +511,7 @@ pub async fn query_equity_predictions_for_date(
         })
         .collect::<Result<Vec<_>, sqlx::Error>>()?;
 
-    debug!(
-        "Queried {} equity predictions for {}",
-        predictions.len(),
-        date
-    );
+    debug!(rows = predictions.len(), date = %date, "Queried equity predictions from PostgreSQL");
     Ok(predictions)
 }
 

--- a/src/data/equity_bars.rs
+++ b/src/data/equity_bars.rs
@@ -114,7 +114,7 @@ async fn write_equity_bars_to_s3(
         .await
         .map_err(|error| format!("Failed to upload to S3: {}", error))?;
 
-    info!("Wrote equity bars Parquet to S3: {}", key);
+    info!(key = key, "Wrote equity bars Parquet to S3");
     Ok(())
 }
 
@@ -157,10 +157,7 @@ async fn fetch_equity_bars_for_date(
             "Failed to send API request".to_string()
         })?;
 
-    info!(
-        "Received response from Massive API, status: {}",
-        response.status()
-    );
+    info!(status = %response.status(), "Received response from Massive API");
 
     let text_content = response
         .error_for_status()
@@ -175,23 +172,23 @@ async fn fetch_equity_bars_for_date(
         .text()
         .await
         .map_err(|err| {
-            warn!("Failed to read response text: {}", err);
+            warn!(error = %err, "Failed to read response text");
             "Failed to read API response".to_string()
         })?;
 
-    info!(
-        "Received response body, length: {} bytes",
-        text_content.len()
-    );
+    info!(bytes = text_content.len(), "Received response body");
 
     let massive_response: MassiveResponse = serde_json::from_str(&text_content).map_err(|err| {
-        warn!("Failed to parse JSON response: {}", err);
+        warn!(error = %err, "Failed to parse JSON response");
         let truncated: String = text_content.chars().take(500).collect();
-        warn!("Raw response (first 500 chars): {}", truncated);
+        warn!(response = truncated, "Raw response preview");
         "Invalid JSON response from API".to_string()
     })?;
 
-    info!("API results count: {}", massive_response.results_count);
+    info!(
+        rows = massive_response.results_count,
+        "Massive API results received"
+    );
 
     let Some(results) = massive_response.results else {
         warn!("No results field in API response");
@@ -211,9 +208,9 @@ async fn fetch_equity_bars_for_date(
         .collect();
 
     debug!(
-        "Converted {}/{} results to valid equity bars",
-        equity_bars.len(),
-        raw_count
+        rows = equity_bars.len(),
+        total = raw_count,
+        "Converted results to valid equity bars"
     );
 
     Ok(Some(equity_bars))
@@ -233,13 +230,13 @@ pub async fn fetch_and_store_equity_bars(
         database::insert_equity_bars(pool, &equity_bars)
             .await
             .map_err(|error| {
-                warn!("Failed to write equity bars to PostgreSQL: {}", error);
+                warn!(error = %error, "Failed to write equity bars to PostgreSQL");
                 format!("Failed to insert equity bars: {}", error)
             })?;
     }
 
     if let Err(error) = write_equity_bars_to_s3(state, trading_date, &equity_bars).await {
-        warn!("Failed to write equity bars to S3: {}", error);
+        warn!(error = %error, "Failed to write equity bars to S3");
     }
 
     Ok(Some(equity_bars.len()))
@@ -514,11 +511,11 @@ pub async fn seed(
                     Ok(bar_count) => {
                         summary.days_processed += 1;
                         summary.total_bars += bar_count;
-                        info!("Seeded {} bars for {}", bar_count, date.format("%Y-%m-%d"));
+                        info!(rows = bar_count, date = %date.format("%Y-%m-%d"), "Seeded equity bars");
                     }
                     Err(error) => {
                         summary.days_failed += 1;
-                        warn!("Failed to seed {}: {}", date.format("%Y-%m-%d"), error);
+                        warn!(date = %date.format("%Y-%m-%d"), error = %error, "Failed to seed equity bars");
                     }
                 }
             }

--- a/src/data/equity_details.rs
+++ b/src/data/equity_details.rs
@@ -76,8 +76,8 @@ fn parse_equity_details_csv(csv_content: &str) -> Result<Vec<EquityDetail>, Erro
 
     if rejected_rows > 0 {
         warn!(
-            "Discarded {} row(s) with invalid ticker symbols while parsing equity details CSV",
-            rejected_rows
+            rows = rejected_rows,
+            "Discarded rows with invalid ticker symbols"
         );
     }
 
@@ -87,7 +87,10 @@ fn parse_equity_details_csv(csv_content: &str) -> Result<Vec<EquityDetail>, Erro
 /// Parses the compile-time-embedded equity details CSV.
 pub fn parse_embedded_equity_details() -> Result<Vec<EquityDetail>, Error> {
     let details = parse_equity_details_csv(EQUITY_DETAILS_CSV)?;
-    info!("Parsed {} equity details from embedded CSV", details.len());
+    info!(
+        rows = details.len(),
+        "Parsed equity details from embedded CSV"
+    );
     Ok(details)
 }
 

--- a/src/data/equity_quotes.rs
+++ b/src/data/equity_quotes.rs
@@ -87,11 +87,11 @@ async fn refresh_active_symbols(state: &State, pool: &sqlx::PgPool) {
     match database::get_active_tickers(pool).await {
         Ok(tickers) => {
             let symbol_set: HashSet<Ticker> = tickers.into_iter().collect();
-            info!("Refreshed active symbols, count: {}", symbol_set.len());
+            info!(rows = symbol_set.len(), "Refreshed active symbols");
             let mut guard = state.active_symbols.write().await;
             *guard = symbol_set;
         }
-        Err(error) => warn!("Failed to refresh active symbols: {}", error),
+        Err(error) => warn!(error = %error, "Failed to refresh active symbols"),
     }
 }
 
@@ -109,8 +109,8 @@ async fn run_quote_stream(state: &State) -> Result<(), Box<dyn std::error::Error
 
     let url = format!("{}/{}", ALPACA_WS_BASE_URL, credentials.feed());
     info!(
-        "Connecting to Alpaca quote stream, feed: {}",
-        credentials.feed()
+        feed = credentials.feed(),
+        "Connecting to Alpaca quote stream"
     );
 
     let (ws_stream, _) = connect_async(&url).await?;
@@ -174,7 +174,7 @@ async fn run_quote_stream(state: &State) -> Result<(), Box<dyn std::error::Error
             })
             .to_string();
             write.send(Message::Text(subscribe_json.into())).await?;
-            info!("Subscribed to {} symbol(s)", symbols.len());
+            info!(rows = symbols.len(), "Subscribed to symbols");
         } else {
             info!("No active symbols, skipping initial subscription");
         }
@@ -269,7 +269,7 @@ async fn run_quote_stream(state: &State) -> Result<(), Box<dyn std::error::Error
                                     })
                                     .to_string();
                                     write.send(Message::Text(subscribe_json.into())).await?;
-                                    info!("Resubscribed to {} symbol(s)", symbols.len());
+                                    info!(rows = symbols.len(), "Resubscribed to symbols");
                                 }
                             }
                             Some(event_type)
@@ -290,7 +290,7 @@ async fn run_quote_stream(state: &State) -> Result<(), Box<dyn std::error::Error
                         }
                     }
                     Err(error) => {
-                        warn!("PostgreSQL events listener error: {}", error);
+                        warn!(error = %error, "PostgreSQL events listener error");
                         return Err(error.into());
                     }
                 }
@@ -315,9 +315,9 @@ async fn flush_quotes(pool: &sqlx::PgPool, buffer: &mut Vec<EquityQuote>) {
     let quotes = std::mem::take(buffer);
     let count = quotes.len();
     match database::insert_equity_quotes(pool, &quotes).await {
-        Ok(_) => info!("Flushed {} quote(s) to database", count),
+        Ok(_) => info!(rows = count, "Flushed quotes to database"),
         Err(error) => {
-            error!("Failed to flush quotes to database: {}", error);
+            error!(error = %error, "Failed to flush quotes to database");
             *buffer = quotes;
         }
     }

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -30,14 +30,14 @@ pub async fn export_equity_bars(state: &State, date: NaiveDate) -> Result<usize,
     let count = bars.len();
 
     if count == 0 {
-        info!("No equity bars to export for {}", date);
+        info!(date = %date, "No equity bars to export");
         return Ok(0);
     }
 
     let mut dataframe = create_equity_bar_export_dataframe(&bars)?;
     let key = date_partitioned_key("data/equity/bars", date);
     write_dataframe_to_s3(state, &mut dataframe, &key).await?;
-    info!("Exported {} equity bars to S3: {}", count, key);
+    info!(rows = count, key = key, "Exported equity bars to S3");
 
     Ok(count)
 }
@@ -72,7 +72,7 @@ pub async fn export_equity_trading_history(
             .await
             .map_err(|error| format!("Failed to delete equity quotes: {}", error))?;
     } else {
-        info!("No equity quotes to export for {}", date);
+        info!(date = %date, "No equity quotes to export");
     }
 
     let predictions = database::query_equity_predictions_for_date(pool, date)
@@ -88,7 +88,7 @@ pub async fn export_equity_trading_history(
         )
         .await?;
     } else {
-        info!("No equity predictions to export for {}", date);
+        info!(date = %date, "No equity predictions to export");
     }
 
     let sessions = database::query_equity_rebalance_sessions(pool)

--- a/src/data/scheduler.rs
+++ b/src/data/scheduler.rs
@@ -100,8 +100,8 @@ async fn sync_loop(state: State) {
     loop {
         let wait_duration = duration_until_next_sync(Utc::now());
         info!(
-            "Waiting for next equity bar sync, seconds_until_sync: {}",
-            wait_duration.as_secs()
+            seconds = wait_duration.as_secs(),
+            "Waiting for next equity bar sync"
         );
         sleep(wait_duration).await;
 
@@ -112,14 +112,14 @@ async fn sync_loop(state: State) {
 
         match run_equity_bar_sync(&state).await {
             Ok(Some(bar_count)) => {
-                info!("Equity bar sync completed, bar_count: {}", bar_count);
+                info!(rows = bar_count, "Equity bar sync completed");
                 state.mark_synced();
             }
             Ok(None) => {
                 info!("No equity bar data available for scheduled sync");
             }
             Err(error) => {
-                error!("Equity bar sync failed: {}", error);
+                error!(error = %error, "Equity bar sync failed");
             }
         }
     }
@@ -246,12 +246,12 @@ async fn handle_equity_bars_sync(state: &State, pool: &sqlx::PgPool, event_id: i
     )
     .await
     {
-        warn!("Failed to emit equity_bars_sync_started: {}", error);
+        warn!(error = %error, "Failed to emit equity_bars_sync_started");
     }
 
     match run_equity_bar_sync(state).await {
         Ok(Some(bar_count)) => {
-            info!("Equity bar sync completed, bar_count: {}", bar_count);
+            info!(rows = bar_count, "Equity bar sync completed");
             if let Err(error) = emit_event(
                 pool,
                 EventType::EquityBarsSyncCompleted,
@@ -259,7 +259,7 @@ async fn handle_equity_bars_sync(state: &State, pool: &sqlx::PgPool, event_id: i
             )
             .await
             {
-                warn!("Failed to emit equity_bars_sync_completed: {}", error);
+                warn!(error = %error, "Failed to emit equity_bars_sync_completed");
             }
             state.mark_synced();
         }
@@ -272,11 +272,11 @@ async fn handle_equity_bars_sync(state: &State, pool: &sqlx::PgPool, event_id: i
             )
             .await
             {
-                warn!("Failed to emit equity_bars_sync_completed: {}", error);
+                warn!(error = %error, "Failed to emit equity_bars_sync_completed");
             }
         }
         Err(ref error) => {
-            error!("Equity bar sync errored: {}", error);
+            error!(error = %error, "Equity bar sync errored");
             if let Err(emit_error) = emit_event(
                 pool,
                 EventType::EquityBarsSyncErrored,
@@ -284,17 +284,14 @@ async fn handle_equity_bars_sync(state: &State, pool: &sqlx::PgPool, event_id: i
             )
             .await
             {
-                warn!("Failed to emit equity_bars_sync_errored: {}", emit_error);
+                warn!(error = %emit_error, "Failed to emit equity_bars_sync_errored");
             }
         }
     }
 
     if let Err(error) = update_consumer_offset(pool, CONSUMER_DATA_EQUITY_BARS_SYNC, event_id).await
     {
-        warn!(
-            "Failed to update equity-bars-sync consumer offset: {}",
-            error
-        );
+        warn!(error = %error, "Failed to update equity-bars-sync consumer offset");
     }
 }
 
@@ -312,12 +309,12 @@ async fn handle_equity_bars_export(
     )
     .await
     {
-        warn!("Failed to emit equity_bars_export_started: {}", error);
+        warn!(error = %error, "Failed to emit equity_bars_export_started");
     }
 
     match run_export_job(state, "export-equity-bars", export_date).await {
         Ok(count) => {
-            info!("Equity bars export completed, count: {}", count);
+            info!(rows = count, "Equity bars export completed");
             if let Err(error) = emit_event(
                 pool,
                 EventType::EquityBarsExportCompleted,
@@ -325,11 +322,11 @@ async fn handle_equity_bars_export(
             )
             .await
             {
-                warn!("Failed to emit equity_bars_export_completed: {}", error);
+                warn!(error = %error, "Failed to emit equity_bars_export_completed");
             }
         }
         Err(ref error) => {
-            error!("Equity bars export errored: {}", error);
+            error!(error = %error, "Equity bars export errored");
             if let Err(emit_error) = emit_event(
                 pool,
                 EventType::EquityBarsExportErrored,
@@ -337,7 +334,7 @@ async fn handle_equity_bars_export(
             )
             .await
             {
-                warn!("Failed to emit equity_bars_export_errored: {}", emit_error);
+                warn!(error = %emit_error, "Failed to emit equity_bars_export_errored");
             }
         }
     }
@@ -345,10 +342,7 @@ async fn handle_equity_bars_export(
     if let Err(error) =
         update_consumer_offset(pool, CONSUMER_DATA_EQUITY_BARS_EXPORT, event_id).await
     {
-        warn!(
-            "Failed to update equity-bars-export consumer offset: {}",
-            error
-        );
+        warn!(error = %error, "Failed to update equity-bars-export consumer offset");
     }
 }
 
@@ -366,12 +360,12 @@ async fn handle_trading_history_export(
     )
     .await
     {
-        warn!("Failed to emit trading_history_export_started: {}", error);
+        warn!(error = %error, "Failed to emit trading_history_export_started");
     }
 
     match run_export_job(state, "export-trading-history", export_date).await {
         Ok(count) => {
-            info!("Trading history export completed, count: {}", count);
+            info!(rows = count, "Trading history export completed");
             if let Err(error) = emit_event(
                 pool,
                 EventType::TradingHistoryExportCompleted,
@@ -379,11 +373,11 @@ async fn handle_trading_history_export(
             )
             .await
             {
-                warn!("Failed to emit trading_history_export_completed: {}", error);
+                warn!(error = %error, "Failed to emit trading_history_export_completed");
             }
         }
         Err(ref error) => {
-            error!("Trading history export errored: {}", error);
+            error!(error = %error, "Trading history export errored");
             if let Err(emit_error) = emit_event(
                 pool,
                 EventType::TradingHistoryExportErrored,
@@ -391,10 +385,7 @@ async fn handle_trading_history_export(
             )
             .await
             {
-                warn!(
-                    "Failed to emit trading_history_export_errored: {}",
-                    emit_error
-                );
+                warn!(error = %emit_error, "Failed to emit trading_history_export_errored");
             }
         }
     }
@@ -402,10 +393,7 @@ async fn handle_trading_history_export(
     if let Err(error) =
         update_consumer_offset(pool, CONSUMER_DATA_TRADING_HISTORY_EXPORT, event_id).await
     {
-        warn!(
-            "Failed to update trading-history-export consumer offset: {}",
-            error
-        );
+        warn!(error = %error, "Failed to update trading-history-export consumer offset");
     }
 }
 
@@ -417,12 +405,12 @@ async fn handle_database_backup(state: &State, pool: &sqlx::PgPool, event_id: i6
     )
     .await
     {
-        warn!("Failed to emit database_backup_started: {}", error);
+        warn!(error = %error, "Failed to emit database_backup_started");
     }
 
     match run_backup_job(state).await {
         Ok(byte_count) => {
-            info!("Database backup completed, byte_count: {}", byte_count);
+            info!(bytes = byte_count, "Database backup completed");
             if let Err(error) = emit_event(
                 pool,
                 EventType::DatabaseBackupCompleted,
@@ -430,11 +418,11 @@ async fn handle_database_backup(state: &State, pool: &sqlx::PgPool, event_id: i6
             )
             .await
             {
-                warn!("Failed to emit database_backup_completed: {}", error);
+                warn!(error = %error, "Failed to emit database_backup_completed");
             }
         }
         Err(ref error) => {
-            error!("Database backup errored: {}", error);
+            error!(error = %error, "Database backup errored");
             if let Err(emit_error) = emit_event(
                 pool,
                 EventType::DatabaseBackupErrored,
@@ -442,17 +430,14 @@ async fn handle_database_backup(state: &State, pool: &sqlx::PgPool, event_id: i6
             )
             .await
             {
-                warn!("Failed to emit database_backup_errored: {}", emit_error);
+                warn!(error = %emit_error, "Failed to emit database_backup_errored");
             }
         }
     }
 
     if let Err(error) = update_consumer_offset(pool, CONSUMER_DATA_DATABASE_BACKUP, event_id).await
     {
-        warn!(
-            "Failed to update database-backup consumer offset: {}",
-            error
-        );
+        warn!(error = %error, "Failed to update database-backup consumer offset");
     }
 }
 
@@ -488,7 +473,7 @@ async fn run_backup_job(state: &State) -> Result<usize, String> {
     let backup_key = std::env::var("AWS_S3_DATABASE_BACKUP_KEY")
         .unwrap_or_else(|_| "database/backups/fund-latest.dump.gz".to_string());
 
-    info!("Starting database backup to {}", backup_key);
+    info!(key = backup_key, "Starting database backup");
 
     let dump_path = "/tmp/fund-backup.dump";
     let dump_gz_path = "/tmp/fund-backup.dump.gz";
@@ -558,8 +543,9 @@ async fn run_backup_job(state: &State) -> Result<usize, String> {
     let _ = tokio::fs::remove_file(dump_gz_path).await;
 
     info!(
-        "Database backup uploaded, byte_count: {}, key: {}",
-        byte_count, backup_key
+        bytes = byte_count,
+        key = backup_key,
+        "Database backup uploaded"
     );
     Ok(byte_count)
 }

--- a/src/data/state.rs
+++ b/src/data/state.rs
@@ -118,24 +118,24 @@ impl State {
             .region()
             .map(|r| r.as_ref().to_string())
             .unwrap_or_else(|| "not configured".to_string());
-        info!("AWS region: {}", region);
+        info!(region = region, "AWS region configured");
 
         let s3_client = S3Client::new(&config);
 
         let bucket_name = std::env::var("AWS_S3_BUCKET_NAME")
             .expect("AWS_S3_BUCKET_NAME environment variable must be set");
-        info!("Using S3 bucket: {}", bucket_name);
+        info!(bucket = bucket_name, "S3 bucket configured");
 
         let massive_base_url = std::env::var("MASSIVE_BASE_URL")
             .expect("MASSIVE_BASE_URL environment variable must be set");
-        info!("Using Massive API base URL: {}", massive_base_url);
+        info!(url = massive_base_url, "Massive API configured");
 
         let massive_api_key = std::env::var("MASSIVE_API_KEY")
             .expect("MASSIVE_API_KEY environment variable must be set");
 
         let alpaca_credentials = AlpacaCredentials::from_env();
         if let Some(ref credentials) = alpaca_credentials {
-            info!("Using Alpaca feed: {}", credentials.feed());
+            info!(feed = credentials.feed(), "Alpaca feed configured");
         } else {
             info!("Alpaca credentials not configured");
         }
@@ -149,7 +149,7 @@ impl State {
                         DatabaseState::Connected(pool)
                     }
                     Err(error) => {
-                        warn!("Failed to connect to PostgreSQL: {}", error);
+                        warn!(error = %error, "Failed to connect to PostgreSQL");
                         DatabaseState::ConnectFailed
                     }
                 }

--- a/src/portfolio/database.rs
+++ b/src/portfolio/database.rs
@@ -140,7 +140,7 @@ pub async fn fetch_equity_predictions(
         .collect::<Result<Vec<_>, sqlx::Error>>()?;
 
     info!(
-        count = predictions.len(),
+        rows = predictions.len(),
         "Predictions fetched from PostgreSQL"
     );
     Ok(Fresh::new(predictions, StalenessWindow::predictions()))
@@ -205,7 +205,7 @@ pub async fn fetch_spy_equity_prices(pool: &PgPool) -> Result<Vec<f64>, sqlx::Er
 
     let prices: Vec<f64> = rows.into_iter().map(|row| row.close_price).collect();
 
-    info!(count = prices.len(), "SPY prices fetched from PostgreSQL");
+    info!(rows = prices.len(), "SPY prices fetched from PostgreSQL");
     Ok(prices)
 }
 
@@ -343,7 +343,7 @@ pub async fn fetch_open_pairs(pool: &PgPool) -> Result<Vec<OpenPair>, sqlx::Erro
         .collect::<Result<_, sqlx::Error>>()?;
 
     info!(
-        count = pairs.len(),
+        rows = pairs.len(),
         "Open equity pairs fetched from PostgreSQL"
     );
     Ok(pairs)

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -440,7 +440,7 @@ pub async fn run_end_of_day_liquidation(state: &AppState) -> Result<usize, Rebal
     )
     .await?;
 
-    info!(count = pairs_closed, "Open pairs closed at end of day");
+    info!(rows = pairs_closed, "Open pairs closed at end of day");
 
     Ok(pairs_closed)
 }
@@ -638,7 +638,7 @@ async fn close_triggered_pairs(
             .await?;
     }
 
-    info!(count = signals.len(), "Triggered pairs closed");
+    info!(rows = signals.len(), "Triggered pairs closed");
     Ok(signals.len())
 }
 

--- a/tools/provision-application-vm
+++ b/tools/provision-application-vm
@@ -4,34 +4,43 @@ set -euo pipefail
 # --------------------------------------------------------------------------- #
 # provision-application-vm -- Provision a fund application VM on exe.dev
 #
-# Run locally: bash tools/provision-application-vm [--production]
+# Run locally: bash tools/provision-application-vm --environment <development|production>
 # --------------------------------------------------------------------------- #
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 VM_ROLE="application"
 PRODUCTION=false
+ENVIRONMENT=""
 
 usage() {
-  echo "Usage: $(basename "$0") [--production]"
+  echo "Usage: $(basename "$0") --environment <development|production>"
   echo ""
   echo "Provision an oscm-fund application VM on exe.dev."
-  echo "Runs the consolidated fund binary (data, inference, and portfolio services)"
-  echo "under devenv --profile application."
+  echo "Runs the data, inference, and portfolio services under devenv --profile application."
   echo ""
   echo "Options:"
-  echo "  --production    Provision as a production VM (default: development)"
+  echo "  --environment   Required. Either 'development' or 'production'."
   echo "  -h, --help      Show this help message"
   exit "${1:-0}"
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --production) PRODUCTION=true; shift ;;
+    --environment)
+      [[ -z "${2:-}" ]] && { echo "Error: --environment requires a value" >&2; usage 1; }
+      ENVIRONMENT="$2"; shift 2 ;;
     -h|--help) usage ;;
     *) echo "Error: unknown option '$1'" >&2; usage 1 ;;
   esac
 done
+
+case "$ENVIRONMENT" in
+  production) PRODUCTION=true ;;
+  development) PRODUCTION=false ;;
+  "") echo "Error: --environment is required" >&2; usage 1 ;;
+  *) echo "Error: --environment must be 'development' or 'production', got '$ENVIRONMENT'" >&2; usage 1 ;;
+esac
 
 # shellcheck source=provision-common-vm
 source "$SCRIPT_DIR/provision-common-vm"

--- a/tools/provision-trainer-vm
+++ b/tools/provision-trainer-vm
@@ -4,7 +4,7 @@ set -euo pipefail
 # --------------------------------------------------------------------------- #
 # provision-trainer-vm -- Provision a fund model trainer VM on exe.dev
 #
-# Run locally: bash tools/provision-trainer-vm [--production]
+# Run locally: bash tools/provision-trainer-vm --environment <development|production>
 #
 # The trainer VM runs no persistent services. It bootstraps the devenv
 # environment and installs a cron job that runs model training daily at
@@ -15,26 +15,36 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 VM_ROLE="trainer"
 PRODUCTION=false
+ENVIRONMENT=""
 
 usage() {
-  echo "Usage: $(basename "$0") [--production]"
+  echo "Usage: $(basename "$0") --environment <development|production>"
   echo ""
   echo "Provision an oscm-fund trainer VM on exe.dev."
   echo "Installs a daily training cron job (weekdays 06:00 UTC)."
   echo ""
   echo "Options:"
-  echo "  --production    Provision as a production VM (default: development)"
+  echo "  --environment   Required. Either 'development' or 'production'."
   echo "  -h, --help      Show this help message"
   exit "${1:-0}"
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --production) PRODUCTION=true; shift ;;
+    --environment)
+      [[ -z "${2:-}" ]] && { echo "Error: --environment requires a value" >&2; usage 1; }
+      ENVIRONMENT="$2"; shift 2 ;;
     -h|--help) usage ;;
     *) echo "Error: unknown option '$1'" >&2; usage 1 ;;
   esac
 done
+
+case "$ENVIRONMENT" in
+  production) PRODUCTION=true ;;
+  development) PRODUCTION=false ;;
+  "") echo "Error: --environment is required" >&2; usage 1 ;;
+  *) echo "Error: --environment must be 'development' or 'production', got '$ENVIRONMENT'" >&2; usage 1 ;;
+esac
 
 # shellcheck source=provision-common-vm
 source "$SCRIPT_DIR/provision-common-vm"


### PR DESCRIPTION
# Overview

## Changes

- Split single `processes.fund` devenv entry into `database`, `data`, `inference`, and `portfolio` processes so each gets its own process-compose TUI panel
- Add `--module <data|inference|portfolio>` flag to the `fund` binary; runs all modules when omitted (backward compatible)
- Add `service` parameter to `init_tracing` and `init_tracing_file_only` for service identification in log output
- Standardize structured logging fields across all modules: `rows =` for counts, `error = %error` for errors, structured fields for dates/keys/bytes/feeds/URLs
- Update README to reference devenv provisioning script names instead of raw `bash tools/` paths
- Require explicit `--environment <development|production>` flag in VM provisioning scripts

## Context

The consolidated fund binary ran all three services (data, inference, portfolio) in a single process. While functionally correct (services coordinate via PostgreSQL LISTEN/NOTIFY, not shared memory), this made the production process-compose TUI show a single pane with interleaved logs from all services plus PostgreSQL, making it difficult to monitor individual service behavior.

The `--module` flag lets the same binary run a single service, and the devenv profile defines each as a separate process with `depends_on` ordering against a one-shot `database` process that waits for PostgreSQL and applies the schema. Each process gets its own TUI panel while maintaining the same event-driven coordination.

Logging was also audited and normalized: inline format strings converted to structured tracing fields, field names standardized (`rows` instead of `count`/`rows_affected`/`bar_count`), and error formatting unified to `error = %error` across all modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development and production services can now be launched independently for Data, Inference, and Portfolio.
  * Local startup now verifies the database and applies schema updates before launching services.

* **Bug Fixes**
  * VM provisioning now clearly distinguishes development and production environments with validated options.

* **Documentation**
  * Updated provisioning instructions to reflect the separate development and production workflows.

* **Refactor**
  * Improved service-specific logging and diagnostics for clearer operational monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->