### PR TITLE
Gate `market_hours` module behind `data`/`portfolio` features

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -506,7 +506,7 @@ in {
     #   Reset  — drop and recreate the empty database. Run before create after breaking changes.
 
     # Opens an interactive psql session against the local fund database.
-    "database:connect".exec = "psql -h localhost -p 5432 -d fund";
+    "database:connect".exec = "exec psql -h localhost -p 5432 -d fund";
 
     # Drops and recreates the empty fund database. Run before database:create when
     # recovering from a breaking schema change.

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,5 +7,6 @@ pub mod aws;
 pub mod crypto;
 pub mod database;
 pub mod events;
+#[cfg(any(feature = "data", feature = "portfolio"))]
 pub mod market_hours;
 pub mod observability;


### PR DESCRIPTION
# Overview

## Changes

- Gate `market_hours` module declaration in `src/common.rs` with `#[cfg(any(feature = "data", feature = "portfolio"))]`
- `market_hours` uses `chrono_tz` which is only included as a dependency under `data` and `portfolio` features
- The `train` feature (which only enables `inference`) failed to compile because `market_hours` was declared unconditionally
- No consumers outside `data` and `portfolio` import `market_hours`, so the gate is safe

## Context

The `train` feature is used on the trainer VM to build the `tide_model_trainer` binary. This compilation error blocked model training in production. The root cause is that `chrono-tz` is an optional dependency gated behind `data` and `portfolio` features in `Cargo.toml`, but the module using it was exposed unconditionally.

Verified that both `--features train` and default features (`data`, `inference`, `portfolio`) compile cleanly after this change.

---

> Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature-specific builds by limiting market-hours functionality to configurations that support data or portfolio features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->