### PR TITLE
Fix generate-fund-report secret paths to match SecretSpec layout

### DIFF
--- a/.claude/skills/generate-fund-report/SKILL.md
+++ b/.claude/skills/generate-fund-report/SKILL.md
@@ -62,6 +62,8 @@ Retrieve Alpaca credentials from AWS Secrets Manager. SecretSpec stores each key
 individually under `secretspec/fund/production/<KEY>`:
 
 ```bash
+set -euo pipefail
+
 ALPACA_KEY=$(aws secretsmanager get-secret-value --profile <PROFILE> --region us-east-1 \
   --secret-id 'secretspec/fund/production/ALPACA_API_KEY_ID' \
   --query 'SecretString' --output text)
@@ -76,7 +78,7 @@ IS_PAPER=$(aws secretsmanager get-secret-value --profile <PROFILE> --region us-e
 ```
 
 Determine the base URL:
-- If `IS_PAPER` is `"true"`: `https://paper-api.alpaca.markets`
+- If `IS_PAPER` is `true`: `https://paper-api.alpaca.markets`
 - Otherwise: `https://api.alpaca.markets`
 
 If credential retrieval fails, skip Group B and suggest `aws sso login --profile <PROFILE>`.

--- a/.claude/skills/generate-fund-report/SKILL.md
+++ b/.claude/skills/generate-fund-report/SKILL.md
@@ -58,19 +58,22 @@ artifact freshness check, and note them as SKIPPED in the report.
 
 ## Phase 1: Credential retrieval
 
-Retrieve Alpaca credentials from AWS Secrets Manager for direct API calls:
+Retrieve Alpaca credentials from AWS Secrets Manager. SecretSpec stores each key
+individually under `secretspec/fund/production/<KEY>`:
 
 ```bash
-aws secretsmanager get-secret-value --profile <PROFILE> --region us-east-1 \
-  --secret-id 'fund/production/portfolio-manager/all' \
-  --query 'SecretString' --output text \
-  | jq -r '{key: .ALPACA_API_KEY_ID, secret: .ALPACA_API_SECRET, paper: .ALPACA_IS_PAPER}'
-```
+ALPACA_KEY=$(aws secretsmanager get-secret-value --profile <PROFILE> --region us-east-1 \
+  --secret-id 'secretspec/fund/production/ALPACA_API_KEY_ID' \
+  --query 'SecretString' --output text)
 
-Extract:
-- `ALPACA_KEY` = `.key`
-- `ALPACA_SECRET` = `.secret`
-- `IS_PAPER` = `.paper` (string `"true"` or `"false"`)
+ALPACA_SECRET=$(aws secretsmanager get-secret-value --profile <PROFILE> --region us-east-1 \
+  --secret-id 'secretspec/fund/production/ALPACA_API_SECRET' \
+  --query 'SecretString' --output text)
+
+IS_PAPER=$(aws secretsmanager get-secret-value --profile <PROFILE> --region us-east-1 \
+  --secret-id 'secretspec/fund/production/ALPACA_IS_PAPER' \
+  --query 'SecretString' --output text)
+```
 
 Determine the base URL:
 - If `IS_PAPER` is `"true"`: `https://paper-api.alpaca.markets`


### PR DESCRIPTION
# Overview

## Changes

- Update generate-fund-report skill to fetch Alpaca credentials as individual SecretSpec keys (`secretspec/fund/production/ALPACA_API_KEY_ID`, `secretspec/fund/production/ALPACA_API_SECRET`, `secretspec/fund/production/ALPACA_IS_PAPER`) instead of a non-existent bundled secret at `fund/production/portfolio-manager/all`

## Context

The daily fund report skill was failing during credential retrieval because it referenced a bundled secret path that does not exist. SecretSpec stores each credential as an individual key under `secretspec/fund/production/<KEY>`. This was discovered during the morning report run and confirmed by checking the actual Secrets Manager entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated fund report instructions to retrieve Alpaca credentials as separate secure values.
  * Clarified paper/live account selection and the conditions for skipping Alpaca API processing when credentials cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->