### PR TITLE
Add symmetric mismatch detection, durable order tracking, and fill polling improvements

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -81,7 +81,7 @@ BEGIN
         ALTER TABLE equity_pairs DROP CONSTRAINT equity_pairs_close_reason_check;
     END IF;
     ALTER TABLE equity_pairs ADD CONSTRAINT equity_pairs_close_reason_check
-        CHECK (close_reason IN ('profit_taken', 'stop_loss', 'end_of_day', 'reconciliation_alpaca_missing'));
+        CHECK (close_reason IN ('profit_taken', 'stop_loss', 'end_of_day', 'reconciliation_alpaca_missing')) NOT VALID;
 END;
 $do$;
 

--- a/schema.sql
+++ b/schema.sql
@@ -66,9 +66,24 @@ CREATE TABLE IF NOT EXISTS equity_pairs (
     closed_at                  TIMESTAMPTZ,
     realized_profit_and_loss   NUMERIC,
     return_percent             NUMERIC,
-    close_reason               TEXT        CHECK (close_reason IN ('profit_taken', 'stop_loss', 'end_of_day')),
+    close_reason               TEXT        CHECK (close_reason IN ('profit_taken', 'stop_loss', 'end_of_day', 'reconciliation_alpaca_missing')),
     UNIQUE (pair_id, opened_at)
 );
+
+-- Idempotent constraint replacement: updates close_reason CHECK to include reconciliation_alpaca_missing
+-- for existing deployments where CREATE TABLE was a no-op.
+DO $do$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'equity_pairs_close_reason_check' AND conrelid = 'equity_pairs'::regclass
+    ) THEN
+        ALTER TABLE equity_pairs DROP CONSTRAINT equity_pairs_close_reason_check;
+    END IF;
+    ALTER TABLE equity_pairs ADD CONSTRAINT equity_pairs_close_reason_check
+        CHECK (close_reason IN ('profit_taken', 'stop_loss', 'end_of_day', 'reconciliation_alpaca_missing'));
+END;
+$do$;
 
 -- equity_allocations: one row per ticker leg per rebalance cycle
 -- side and action match PositionSide/PositionAction enums in portfolio_schema.py
@@ -95,16 +110,20 @@ CREATE TABLE IF NOT EXISTS equity_allocations (
 CREATE INDEX IF NOT EXISTS idx_equity_allocations_rebalance_id ON equity_allocations (rebalance_id); -- noqa: PG01
 
 -- equity_orders: orders submitted to Alpaca, linked to allocations
+-- allocation_id is nullable: submitted orders are tracked before allocations exist.
+-- status tracks the order lifecycle: submitted → filled or cancelled.
 CREATE TABLE IF NOT EXISTS equity_orders (
     id               UUID        PRIMARY KEY,
-    allocation_id    UUID        NOT NULL REFERENCES equity_allocations(id),
+    allocation_id    UUID        REFERENCES equity_allocations(id),
     submitted_at     TIMESTAMPTZ NOT NULL,
     ticker           TEXT        NOT NULL,
     side             TEXT        NOT NULL CHECK (side IN ('LONG', 'SHORT')),
     quantity         NUMERIC     NOT NULL,
     order_type       TEXT        NOT NULL,
     limit_price      NUMERIC,
-    alpaca_order_id  TEXT        NOT NULL
+    alpaca_order_id  TEXT        NOT NULL,
+    status           TEXT        NOT NULL DEFAULT 'filled' CHECK (status IN ('submitted', 'filled', 'cancelled')),
+    filled_at        TIMESTAMPTZ
 );
 
 CREATE INDEX IF NOT EXISTS idx_equity_orders_allocation_id ON equity_orders (allocation_id); -- noqa: PG01
@@ -119,6 +138,34 @@ BEGIN
     ) THEN
         ALTER TABLE equity_orders ADD CONSTRAINT equity_orders_side_check CHECK (side IN ('LONG', 'SHORT')) NOT VALID;
     END IF;
+END;
+$do$;
+
+-- Idempotent column backfill: adds status and filled_at columns, relaxes allocation_id NOT NULL
+-- for existing deployments where CREATE TABLE was a no-op.
+DO $do$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'equity_orders' AND column_name = 'status'
+    ) THEN
+        ALTER TABLE equity_orders ADD COLUMN status TEXT NOT NULL DEFAULT 'filled';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'equity_orders' AND column_name = 'filled_at'
+    ) THEN
+        ALTER TABLE equity_orders ADD COLUMN filled_at TIMESTAMPTZ;
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'equity_orders_status_check' AND conrelid = 'equity_orders'::regclass
+    ) THEN
+        ALTER TABLE equity_orders ADD CONSTRAINT equity_orders_status_check
+            CHECK (status IN ('submitted', 'filled', 'cancelled')) NOT VALID;
+    END IF;
+    -- Relax allocation_id NOT NULL so submitted orders can be tracked before allocations exist.
+    ALTER TABLE equity_orders ALTER COLUMN allocation_id DROP NOT NULL;
 END;
 $do$;
 

--- a/src/domain/trading.rs
+++ b/src/domain/trading.rs
@@ -151,7 +151,7 @@ impl SnapshotType {
 /// Reason a long-short pair position was closed.
 ///
 /// Mirrors the `CHECK` constraint on `equity_pairs.close_reason`:
-/// `('profit_taken', 'stop_loss', 'end_of_day')`.
+/// `('profit_taken', 'stop_loss', 'end_of_day', 'reconciliation_alpaca_missing')`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "text", rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
@@ -162,6 +162,8 @@ pub enum CloseReason {
     StopLoss,
     /// All positions closed before market close (go to cash).
     EndOfDay,
+    /// Reconciliation detected that Alpaca no longer holds positions for this pair.
+    ReconciliationAlpacaMissing,
 }
 
 impl CloseReason {
@@ -171,6 +173,7 @@ impl CloseReason {
             Self::ProfitTaken => "profit_taken",
             Self::StopLoss => "stop_loss",
             Self::EndOfDay => "end_of_day",
+            Self::ReconciliationAlpacaMissing => "reconciliation_alpaca_missing",
         }
     }
 
@@ -180,6 +183,43 @@ impl CloseReason {
             "profit_taken" => Some(Self::ProfitTaken),
             "stop_loss" => Some(Self::StopLoss),
             "end_of_day" => Some(Self::EndOfDay),
+            "reconciliation_alpaca_missing" => Some(Self::ReconciliationAlpacaMissing),
+            _ => None,
+        }
+    }
+}
+
+/// Lifecycle status of an order submitted to Alpaca.
+///
+/// Mirrors the `CHECK` constraint on `equity_orders.status`:
+/// `('submitted', 'filled', 'cancelled')`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrderStatus {
+    /// Order has been submitted to Alpaca but fill has not been confirmed.
+    Submitted,
+    /// Order fill has been confirmed by Alpaca.
+    Filled,
+    /// Order was cancelled (by reconciliation or compensation).
+    Cancelled,
+}
+
+impl OrderStatus {
+    /// Returns the database string identifier for this order status.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Submitted => "submitted",
+            Self::Filled => "filled",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    /// Parses a stored database value. Returns `None` for unknown values.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "submitted" => Some(Self::Submitted),
+            "filled" => Some(Self::Filled),
+            "cancelled" => Some(Self::Cancelled),
             _ => None,
         }
     }
@@ -764,6 +804,7 @@ mod tests {
             CloseReason::ProfitTaken,
             CloseReason::StopLoss,
             CloseReason::EndOfDay,
+            CloseReason::ReconciliationAlpacaMissing,
         ] {
             assert_eq!(CloseReason::parse(reason.as_str()), Some(reason.clone()));
             let serialized = serde_json::to_string(&reason).unwrap();
@@ -785,6 +826,10 @@ mod tests {
         assert_eq!(CloseReason::ProfitTaken.to_string(), "profit_taken");
         assert_eq!(CloseReason::StopLoss.to_string(), "stop_loss");
         assert_eq!(CloseReason::EndOfDay.to_string(), "end_of_day");
+        assert_eq!(
+            CloseReason::ReconciliationAlpacaMissing.to_string(),
+            "reconciliation_alpaca_missing"
+        );
     }
 
     #[test]
@@ -793,6 +838,31 @@ mod tests {
         assert_eq!(CloseReason::ProfitTaken.as_str(), "profit_taken");
         assert_eq!(CloseReason::StopLoss.as_str(), "stop_loss");
         assert_eq!(CloseReason::EndOfDay.as_str(), "end_of_day");
+        assert_eq!(
+            CloseReason::ReconciliationAlpacaMissing.as_str(),
+            "reconciliation_alpaca_missing"
+        );
+    }
+
+    #[test]
+    fn test_order_status_round_trip() {
+        for status in [
+            OrderStatus::Submitted,
+            OrderStatus::Filled,
+            OrderStatus::Cancelled,
+        ] {
+            assert_eq!(OrderStatus::parse(status.as_str()), Some(status.clone()));
+            let serialized = serde_json::to_string(&status).unwrap();
+            assert_eq!(serialized, format!("\"{}\"", status.as_str()));
+            let deserialized: OrderStatus = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(deserialized, status);
+        }
+    }
+
+    #[test]
+    fn test_order_status_parse_rejects_unknown() {
+        assert_eq!(OrderStatus::parse("pending"), None);
+        assert_eq!(OrderStatus::parse("FILLED"), None);
     }
 
     #[test]

--- a/src/portfolio/database.rs
+++ b/src/portfolio/database.rs
@@ -547,6 +547,163 @@ pub async fn insert_equity_order<'e>(
     Ok(())
 }
 
+/// A submitted order awaiting fill confirmation or reconciliation resolution.
+///
+/// Returned by [`fetch_submitted_orders`] for reconciliation to check against Alpaca.
+#[derive(Debug, Clone)]
+pub struct SubmittedOrder {
+    id: Uuid,
+    alpaca_order_id: String,
+    ticker: String,
+    side: String,
+    submitted_at: DateTime<Utc>,
+}
+
+impl SubmittedOrder {
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    pub fn alpaca_order_id(&self) -> &str {
+        &self.alpaca_order_id
+    }
+
+    pub fn ticker(&self) -> &str {
+        &self.ticker
+    }
+
+    pub fn side(&self) -> &str {
+        &self.side
+    }
+
+    pub fn submitted_at(&self) -> DateTime<Utc> {
+        self.submitted_at
+    }
+}
+
+/// Inserts a submitted order record before polling for fills.
+///
+/// This creates a durable breadcrumb so that if the process crashes between
+/// order submission and fill confirmation, the reconciliation process can
+/// find and resolve the order.
+#[allow(clippy::too_many_arguments)]
+pub async fn insert_submitted_order(
+    pool: &PgPool,
+    id: Uuid,
+    alpaca_order_id: &str,
+    ticker: &str,
+    side: &str,
+    quantity: Decimal,
+    order_type: &str,
+    submitted_at: DateTime<Utc>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO equity_orders \
+         (id, submitted_at, ticker, side, quantity, order_type, alpaca_order_id, status) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, 'submitted')",
+    )
+    .bind(id)
+    .bind(submitted_at)
+    .bind(ticker)
+    .bind(side)
+    .bind(quantity)
+    .bind(order_type)
+    .bind(alpaca_order_id)
+    .execute(pool)
+    .await?;
+
+    info!(
+        alpaca_order_id = alpaca_order_id,
+        ticker = ticker,
+        "Submitted order tracked in PostgreSQL"
+    );
+    Ok(())
+}
+
+/// Marks a submitted order as filled and sets the fill timestamp.
+///
+/// Accepts a generic executor so it can participate in an existing transaction.
+pub async fn mark_order_filled<'e>(
+    executor: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
+    id: Uuid,
+    allocation_id: Uuid,
+    filled_at: DateTime<Utc>,
+) -> Result<(), sqlx::Error> {
+    let result = sqlx::query(
+        "UPDATE equity_orders \
+         SET status = 'filled', filled_at = $1, allocation_id = $2 \
+         WHERE id = $3 AND status = 'submitted'",
+    )
+    .bind(filled_at)
+    .bind(allocation_id)
+    .bind(id)
+    .execute(executor)
+    .await?;
+
+    if result.rows_affected() != 1 {
+        warn!(
+            order_id = %id,
+            "Order not found or not in submitted status"
+        );
+    }
+
+    Ok(())
+}
+
+/// Marks a submitted order as cancelled.
+pub async fn mark_order_cancelled(pool: &PgPool, id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE equity_orders \
+         SET status = 'cancelled' \
+         WHERE id = $1 AND status = 'submitted'",
+    )
+    .bind(id)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Fetches all orders with `status = 'submitted'` older than the given threshold.
+///
+/// These represent orders that were submitted to Alpaca but never confirmed as
+/// filled. The reconciliation process uses this to check Alpaca for the order
+/// status and resolve them.
+pub async fn fetch_submitted_orders(
+    pool: &PgPool,
+    older_than: DateTime<Utc>,
+) -> Result<Vec<SubmittedOrder>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT id, alpaca_order_id, ticker, side, submitted_at \
+         FROM equity_orders \
+         WHERE status = 'submitted' AND submitted_at < $1 \
+         ORDER BY submitted_at ASC",
+    )
+    .bind(older_than)
+    .fetch_all(pool)
+    .await?;
+
+    let orders: Vec<SubmittedOrder> = rows
+        .into_iter()
+        .map(|row| {
+            use sqlx::Row;
+            SubmittedOrder {
+                id: row.get("id"),
+                alpaca_order_id: row.get("alpaca_order_id"),
+                ticker: row.get("ticker"),
+                side: row.get("side"),
+                submitted_at: row.get("submitted_at"),
+            }
+        })
+        .collect();
+
+    info!(
+        rows = orders.len(),
+        "Submitted orders fetched from PostgreSQL"
+    );
+    Ok(orders)
+}
+
 /// Inserts an intraday portfolio snapshot recording the post-rebalance net asset value.
 pub async fn insert_portfolio_snapshot<'e>(
     executor: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
@@ -760,6 +917,7 @@ mod tests {
                 CloseReason::ProfitTaken,
                 CloseReason::StopLoss,
                 CloseReason::EndOfDay,
+                CloseReason::ReconciliationAlpacaMissing,
             ] {
                 assert!(close_equity_pair_with_reason(
                     &lazy_pool(),
@@ -819,6 +977,89 @@ mod tests {
                 "alpaca-order-xyz".to_string(),
             );
             assert!(insert_equity_order(&lazy_pool(), &order).await.is_err());
+        });
+    }
+
+    // --- SubmittedOrder accessors ---
+
+    #[test]
+    fn test_submitted_order_accessors() {
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let order = SubmittedOrder {
+            id,
+            alpaca_order_id: "alpaca-123".to_string(),
+            ticker: "AAPL".to_string(),
+            side: "LONG".to_string(),
+            submitted_at: now,
+        };
+        assert_eq!(order.id(), id);
+        assert_eq!(order.alpaca_order_id(), "alpaca-123");
+        assert_eq!(order.ticker(), "AAPL");
+        assert_eq!(order.side(), "LONG");
+        assert_eq!(order.submitted_at(), now);
+    }
+
+    #[test]
+    fn test_submitted_order_clone() {
+        let order = SubmittedOrder {
+            id: Uuid::new_v4(),
+            alpaca_order_id: "alpaca-456".to_string(),
+            ticker: "MSFT".to_string(),
+            side: "SHORT".to_string(),
+            submitted_at: Utc::now(),
+        };
+        let cloned = order.clone();
+        assert_eq!(cloned.alpaca_order_id(), order.alpaca_order_id());
+        assert_eq!(cloned.ticker(), order.ticker());
+    }
+
+    // --- compile / connection-error coverage for durable order tracking ---
+
+    #[test]
+    fn test_insert_submitted_order_compiles() {
+        make_runtime().block_on(async {
+            assert!(insert_submitted_order(
+                &lazy_pool(),
+                Uuid::new_v4(),
+                "alpaca-order-001",
+                "AAPL",
+                "LONG",
+                Decimal::from(100),
+                "market",
+                Utc::now(),
+            )
+            .await
+            .is_err());
+        });
+    }
+
+    #[test]
+    fn test_mark_order_filled_compiles() {
+        make_runtime().block_on(async {
+            assert!(
+                mark_order_filled(&lazy_pool(), Uuid::new_v4(), Uuid::new_v4(), Utc::now(),)
+                    .await
+                    .is_err()
+            );
+        });
+    }
+
+    #[test]
+    fn test_mark_order_cancelled_compiles() {
+        make_runtime().block_on(async {
+            assert!(mark_order_cancelled(&lazy_pool(), Uuid::new_v4())
+                .await
+                .is_err());
+        });
+    }
+
+    #[test]
+    fn test_fetch_submitted_orders_compiles() {
+        make_runtime().block_on(async {
+            assert!(fetch_submitted_orders(&lazy_pool(), Utc::now())
+                .await
+                .is_err());
         });
     }
 

--- a/src/portfolio/database.rs
+++ b/src/portfolio/database.rs
@@ -13,7 +13,7 @@ use crate::domain::freshness::{Fresh, StalenessWindow};
 use crate::domain::market::{PairID, Ticker};
 use crate::domain::predictions::EquityPrediction;
 use crate::domain::trading::{
-    CloseReason, EquityAllocation, EquityOrder, EquityPair, EquityRebalanceSession,
+    CloseReason, EquityAllocation, EquityOrder, EquityPair, EquityRebalanceSession, OrderStatus,
     RebalanceSessionStatus,
 };
 
@@ -600,7 +600,7 @@ pub async fn insert_submitted_order(
     sqlx::query(
         "INSERT INTO equity_orders \
          (id, submitted_at, ticker, side, quantity, order_type, alpaca_order_id, status) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, 'submitted')",
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
     )
     .bind(id)
     .bind(submitted_at)
@@ -609,6 +609,7 @@ pub async fn insert_submitted_order(
     .bind(quantity)
     .bind(order_type)
     .bind(alpaca_order_id)
+    .bind(OrderStatus::Submitted.as_str())
     .execute(pool)
     .await?;
 
@@ -631,12 +632,14 @@ pub async fn mark_order_filled<'e>(
 ) -> Result<(), sqlx::Error> {
     let result = sqlx::query(
         "UPDATE equity_orders \
-         SET status = 'filled', filled_at = $1, allocation_id = $2 \
-         WHERE id = $3 AND status = 'submitted'",
+         SET status = $1, filled_at = $2, allocation_id = $3 \
+         WHERE id = $4 AND status = $5",
     )
+    .bind(OrderStatus::Filled.as_str())
     .bind(filled_at)
     .bind(allocation_id)
     .bind(id)
+    .bind(OrderStatus::Submitted.as_str())
     .execute(executor)
     .await?;
 
@@ -654,10 +657,12 @@ pub async fn mark_order_filled<'e>(
 pub async fn mark_order_cancelled(pool: &PgPool, id: Uuid) -> Result<(), sqlx::Error> {
     sqlx::query(
         "UPDATE equity_orders \
-         SET status = 'cancelled' \
-         WHERE id = $1 AND status = 'submitted'",
+         SET status = $1 \
+         WHERE id = $2 AND status = $3",
     )
+    .bind(OrderStatus::Cancelled.as_str())
     .bind(id)
+    .bind(OrderStatus::Submitted.as_str())
     .execute(pool)
     .await?;
 

--- a/src/portfolio/execution.rs
+++ b/src/portfolio/execution.rs
@@ -241,7 +241,7 @@ pub async fn confirm_fills(
 
 /// Polls Alpaca for a filled order, returning a `FilledOrder` on success.
 ///
-/// Uses exponential backoff: 500ms, 1s, 2s, 3s, 3.5s (total ~10s).
+/// Uses increasing backoff: 500ms, 1s, 2s, 3s, 3.5s (total ~10s).
 /// Returns `None` after `FILL_POLL_ATTEMPTS` failed attempts or when the
 /// Alpaca order status does not indicate a fill.
 async fn poll_fill(alpaca: &TradingClient, alpaca_order_id: &str) -> Option<FilledOrder> {
@@ -288,8 +288,10 @@ async fn poll_fill(alpaca: &TradingClient, alpaca_order_id: &str) -> Option<Fill
                 );
             }
         }
-        let backoff = FILL_POLL_BACKOFF_MILLIS[attempt - 1];
-        tokio::time::sleep(Duration::from_millis(backoff)).await;
+        if attempt < FILL_POLL_ATTEMPTS {
+            let backoff = FILL_POLL_BACKOFF_MILLIS[attempt - 1];
+            tokio::time::sleep(Duration::from_millis(backoff)).await;
+        }
     }
 
     warn!(

--- a/src/portfolio/execution.rs
+++ b/src/portfolio/execution.rs
@@ -17,6 +17,9 @@ use crate::portfolio::sizing::SizedPair;
 /// Maximum number of fill-poll attempts per order before giving up.
 const FILL_POLL_ATTEMPTS: usize = 5;
 
+/// Backoff durations for fill polling: 500ms, 1s, 2s, 3s, 3.5s (total 10s).
+const FILL_POLL_BACKOFF_MILLIS: [u64; FILL_POLL_ATTEMPTS] = [500, 1000, 2000, 3000, 3500];
+
 /// Error produced during the open-positions execution phase.
 #[derive(Debug)]
 pub enum ExecutionError {
@@ -238,6 +241,7 @@ pub async fn confirm_fills(
 
 /// Polls Alpaca for a filled order, returning a `FilledOrder` on success.
 ///
+/// Uses exponential backoff: 500ms, 1s, 2s, 3s, 3.5s (total ~10s).
 /// Returns `None` after `FILL_POLL_ATTEMPTS` failed attempts or when the
 /// Alpaca order status does not indicate a fill.
 async fn poll_fill(alpaca: &TradingClient, alpaca_order_id: &str) -> Option<FilledOrder> {
@@ -284,13 +288,14 @@ async fn poll_fill(alpaca: &TradingClient, alpaca_order_id: &str) -> Option<Fill
                 );
             }
         }
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        let backoff = FILL_POLL_BACKOFF_MILLIS[attempt - 1];
+        tokio::time::sleep(Duration::from_millis(backoff)).await;
     }
 
     warn!(
         alpaca_order_id = alpaca_order_id,
         attempts = FILL_POLL_ATTEMPTS,
-        "Fill poll exhausted; order not confirmed"
+        "Fill poll exhausted after 10 seconds; order will be resolved by reconciliation"
     );
     None
 }
@@ -342,6 +347,31 @@ pub async fn close_positions(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_fill_poll_backoff_total_duration() {
+        let total_millis: u64 = FILL_POLL_BACKOFF_MILLIS.iter().sum();
+        assert_eq!(total_millis, 10_000, "Total backoff should be 10 seconds");
+    }
+
+    #[test]
+    fn test_fill_poll_backoff_is_monotonically_increasing() {
+        for window in FILL_POLL_BACKOFF_MILLIS.windows(2) {
+            assert!(
+                window[1] >= window[0],
+                "Backoff durations should be monotonically increasing"
+            );
+        }
+    }
+
+    #[test]
+    fn test_fill_poll_backoff_length_matches_attempts() {
+        assert_eq!(
+            FILL_POLL_BACKOFF_MILLIS.len(),
+            FILL_POLL_ATTEMPTS,
+            "Backoff array length must match FILL_POLL_ATTEMPTS"
+        );
+    }
 
     #[test]
     fn test_execution_error_display_order_submission() {

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -32,7 +32,7 @@ use uuid::Uuid;
 
 use crate::common::events::{emit_event, EventType};
 use crate::domain::market::Ticker;
-use crate::domain::orders::FilledPair;
+use crate::domain::orders::{FilledPair, Order, Pending};
 use crate::domain::portfolio::{Portfolio, PortfolioError};
 use crate::domain::predictions::EquityPrediction;
 use crate::domain::trading::{
@@ -46,8 +46,8 @@ use crate::portfolio::database::{
     close_equity_pair_with_reason, fetch_equity_details, fetch_equity_predictions,
     fetch_historical_equity_prices, fetch_latest_portfolio_net_asset_value, fetch_open_pairs,
     fetch_spy_equity_prices, insert_equity_allocation, insert_equity_order, insert_equity_pair,
-    insert_portfolio_snapshot, insert_rebalance_session, insert_submitted_order,
-    mark_order_cancelled, mark_order_filled, update_rebalance_session_status, OpenPair,
+    insert_portfolio_snapshot, insert_rebalance_session, insert_submitted_order, mark_order_filled,
+    update_rebalance_session_status, OpenPair,
 };
 use crate::portfolio::execution::{
     close_positions, confirm_fills, execute_open_pairs, ExecutionError,
@@ -739,6 +739,31 @@ async fn check_drawdown(
     Ok((current_equity, buying_power))
 }
 
+/// Persists a single submitted order record for durable tracking.
+///
+/// Logs a warning and continues if the insert fails — the order has already
+/// been submitted to Alpaca, so we must not abort the pipeline.
+async fn persist_submitted_order(pool: &sqlx::PgPool, leg: &Order<Pending>) {
+    if let Err(error) = insert_submitted_order(
+        pool,
+        leg.id,
+        &leg.alpaca_order_id,
+        &leg.ticker,
+        &leg.side.to_string(),
+        leg.quantity,
+        &leg.order_type,
+        leg.submitted_at,
+    )
+    .await
+    {
+        warn!(
+            alpaca_order_id = leg.alpaca_order_id.as_str(),
+            error = %error,
+            "Failed to persist submitted order; continuing without durable tracking"
+        );
+    }
+}
+
 /// Selects candidate pairs, sizes them, filters to shortable tickers, and executes orders.
 ///
 /// Submitted orders are persisted to the database before polling for fills,
@@ -866,71 +891,11 @@ async fn select_size_execute(
     // a durable breadcrumb so that if the process crashes during fill polling,
     // the reconciliation process can find and resolve these orders.
     for (pending_pair, _sized_pair) in &pending {
-        let long = pending_pair.long();
-        if let Err(error) = insert_submitted_order(
-            pool,
-            long.id,
-            &long.alpaca_order_id,
-            &long.ticker,
-            &long.side.to_string(),
-            long.quantity,
-            &long.order_type,
-            long.submitted_at,
-        )
-        .await
-        {
-            warn!(
-                alpaca_order_id = long.alpaca_order_id.as_str(),
-                error = %error,
-                "Failed to persist submitted order; continuing without durable tracking"
-            );
-        }
-        let short = pending_pair.short();
-        if let Err(error) = insert_submitted_order(
-            pool,
-            short.id,
-            &short.alpaca_order_id,
-            &short.ticker,
-            &short.side.to_string(),
-            short.quantity,
-            &short.order_type,
-            short.submitted_at,
-        )
-        .await
-        {
-            warn!(
-                alpaca_order_id = short.alpaca_order_id.as_str(),
-                error = %error,
-                "Failed to persist submitted order; continuing without durable tracking"
-            );
-        }
+        persist_submitted_order(pool, pending_pair.long()).await;
+        persist_submitted_order(pool, pending_pair.short()).await;
     }
-
-    // Collect all submitted order IDs before confirm_fills consumes the pending pairs.
-    let all_submitted_order_ids: Vec<Uuid> = pending
-        .iter()
-        .flat_map(|(pending_pair, _)| [pending_pair.long().id, pending_pair.short().id])
-        .collect();
 
     let filled = confirm_fills(alpaca, pending).await;
-
-    // Cancel tracking records for orders that did not fill. Filled orders will
-    // be updated with allocation_id in persist_filled_pairs.
-    let filled_order_ids: std::collections::HashSet<Uuid> = filled
-        .iter()
-        .flat_map(|(filled_pair, _)| [filled_pair.long.id, filled_pair.short.id])
-        .collect();
-    for order_id in &all_submitted_order_ids {
-        if !filled_order_ids.contains(order_id) {
-            if let Err(error) = mark_order_cancelled(pool, *order_id).await {
-                warn!(
-                    order_id = %order_id,
-                    error = %error,
-                    "Failed to mark unfilled order as cancelled"
-                );
-            }
-        }
-    }
 
     if filled.is_empty() {
         warn!("No pairs filled; aborting rebalance session");

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -27,7 +27,7 @@ use chrono::{DateTime, Utc};
 use num_traits::ToPrimitive;
 use rust_decimal::Decimal;
 use tokio::sync::RwLock;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::common::events::{emit_event, EventType};
@@ -46,7 +46,8 @@ use crate::portfolio::database::{
     close_equity_pair_with_reason, fetch_equity_details, fetch_equity_predictions,
     fetch_historical_equity_prices, fetch_latest_portfolio_net_asset_value, fetch_open_pairs,
     fetch_spy_equity_prices, insert_equity_allocation, insert_equity_order, insert_equity_pair,
-    insert_portfolio_snapshot, insert_rebalance_session, update_rebalance_session_status, OpenPair,
+    insert_portfolio_snapshot, insert_rebalance_session, insert_submitted_order,
+    mark_order_cancelled, mark_order_filled, update_rebalance_session_status, OpenPair,
 };
 use crate::portfolio::execution::{
     close_positions, confirm_fills, execute_open_pairs, ExecutionError,
@@ -175,6 +176,27 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
         return run_monitor_cycle(state, pool, alpaca, &open_pairs, &historical_prices).await;
     }
 
+    // Alpaca has no positions. If DB still has open pairs, they were closed
+    // externally (manual close, Alpaca risk controls, corporate action). Mark
+    // them closed with a reconciliation-specific reason and continue as cold start.
+    if !open_pairs.is_empty() {
+        error!(
+            open_pairs = open_pairs.len(),
+            "Database has open pairs but Alpaca has no positions; \
+             marking stale pairs closed with reconciliation_alpaca_missing"
+        );
+        let closed_at = Utc::now();
+        for pair in &open_pairs {
+            close_equity_pair_with_reason(
+                pool,
+                pair.id(),
+                closed_at,
+                &CloseReason::ReconciliationAlpacaMissing,
+            )
+            .await?;
+        }
+    }
+
     // Cold start: no Alpaca positions. Build a fresh portfolio.
     info!("No Alpaca positions; building fresh portfolio");
 
@@ -209,6 +231,7 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
     // Phase 6: select, size, and execute new pairs using current_equity.
     let required_pairs = state.constraints().minimum_pairs().0.get() as usize;
     let filled = select_size_execute(
+        pool,
         alpaca,
         state.tradable_assets(),
         &signals,
@@ -718,10 +741,15 @@ async fn check_drawdown(
 
 /// Selects candidate pairs, sizes them, filters to shortable tickers, and executes orders.
 ///
+/// Submitted orders are persisted to the database before polling for fills,
+/// ensuring that a crash between submission and fill confirmation leaves a
+/// durable breadcrumb for reconciliation to resolve.
+///
 /// Returns the filled pairs paired with their sizing metadata. Errors with
 /// `InsufficientPairs` when no fills are confirmed.
 #[allow(clippy::too_many_arguments)]
 async fn select_size_execute(
+    pool: &sqlx::PgPool,
     alpaca: &TradingClient,
     tradable_assets_cache: &Arc<RwLock<Option<Arc<TradableAssets>>>>,
     signals: &[ConsolidatedSignal],
@@ -833,7 +861,76 @@ async fn select_size_execute(
         .collect();
 
     let pending = execute_open_pairs(alpaca, &eligible_pairs).await;
+
+    // Persist submitted order records before polling for fills. Each order gets
+    // a durable breadcrumb so that if the process crashes during fill polling,
+    // the reconciliation process can find and resolve these orders.
+    for (pending_pair, _sized_pair) in &pending {
+        let long = pending_pair.long();
+        if let Err(error) = insert_submitted_order(
+            pool,
+            long.id,
+            &long.alpaca_order_id,
+            &long.ticker,
+            &long.side.to_string(),
+            long.quantity,
+            &long.order_type,
+            long.submitted_at,
+        )
+        .await
+        {
+            warn!(
+                alpaca_order_id = long.alpaca_order_id.as_str(),
+                error = %error,
+                "Failed to persist submitted order; continuing without durable tracking"
+            );
+        }
+        let short = pending_pair.short();
+        if let Err(error) = insert_submitted_order(
+            pool,
+            short.id,
+            &short.alpaca_order_id,
+            &short.ticker,
+            &short.side.to_string(),
+            short.quantity,
+            &short.order_type,
+            short.submitted_at,
+        )
+        .await
+        {
+            warn!(
+                alpaca_order_id = short.alpaca_order_id.as_str(),
+                error = %error,
+                "Failed to persist submitted order; continuing without durable tracking"
+            );
+        }
+    }
+
+    // Collect all submitted order IDs before confirm_fills consumes the pending pairs.
+    let all_submitted_order_ids: Vec<Uuid> = pending
+        .iter()
+        .flat_map(|(pending_pair, _)| [pending_pair.long().id, pending_pair.short().id])
+        .collect();
+
     let filled = confirm_fills(alpaca, pending).await;
+
+    // Cancel tracking records for orders that did not fill. Filled orders will
+    // be updated with allocation_id in persist_filled_pairs.
+    let filled_order_ids: std::collections::HashSet<Uuid> = filled
+        .iter()
+        .flat_map(|(filled_pair, _)| [filled_pair.long.id, filled_pair.short.id])
+        .collect();
+    for order_id in &all_submitted_order_ids {
+        if !filled_order_ids.contains(order_id) {
+            if let Err(error) = mark_order_cancelled(pool, *order_id).await {
+                warn!(
+                    order_id = %order_id,
+                    error = %error,
+                    "Failed to mark unfilled order as cancelled"
+                );
+            }
+        }
+    }
 
     if filled.is_empty() {
         warn!("No pairs filled; aborting rebalance session");
@@ -969,6 +1066,19 @@ async fn persist_filled_pairs(
             filled_pair.short.alpaca_order_id.clone(),
         );
         insert_equity_order(&mut **transaction, &short_order).await?;
+
+        // Mark the original submitted order tracking records as filled.
+        // Uses the Order ID from the filled pair (same UUID that was used in
+        // insert_submitted_order). Silently handles the case where the submitted
+        // record was never persisted (e.g., DB was unavailable at submission time).
+        mark_order_filled(&mut **transaction, filled_pair.long.id, long_alloc_id, now).await?;
+        mark_order_filled(
+            &mut **transaction,
+            filled_pair.short.id,
+            short_alloc_id,
+            now,
+        )
+        .await?;
 
         // Slippage estimate: 1 bp per leg (0.01% of notional).
         let pair_notional = long_notional_decimal + short_notional_decimal;


### PR DESCRIPTION
# Overview

## Changes

- Add symmetric mismatch detection to the rebalance entry guard: when Alpaca has no positions but the database has open pairs, mark them closed with `reconciliation_alpaca_missing` and continue as cold start (previously only the reverse direction was detected)
- Add durable order tracking: persist submitted order records to `equity_orders` before polling for fills, closing the window where a crash or timeout loses track of submitted orders
- Replace fixed 500ms fill poll interval with exponential backoff (500ms, 1s, 2s, 3s, 3.5s = 10s total), reducing unnecessary Alpaca API calls
- Add `ReconciliationAlpacaMissing` variant to `CloseReason` enum with schema CHECK constraint update
- Add `OrderStatus` enum (`Submitted`, `Filled`, `Cancelled`) for order lifecycle tracking
- Add `status` and `filled_at` columns to `equity_orders` table; make `allocation_id` nullable so submitted orders can be tracked before allocations exist
- Add database functions: `insert_submitted_order`, `mark_order_filled`, `mark_order_cancelled`, `fetch_submitted_orders`
- Add idempotent DO blocks for all schema changes to support existing deployments

This is the first of two PRs for Phase 0 Project 2 (Database-Alpaca Sync Hardening). The second PR will add the reconciliation check, `equity_reconciliation_events` table, and compensation failure escalation.

## Context

Derived from `.scratchpad/phase_0_project_2_database_alpaca_sync_hardening.md`. The portfolio manager maintains two authoritative views of position state: PostgreSQL tracks pair lifecycle while Alpaca holds actual positions. These must stay synchronized. Current defensive measures left windows where the two sources could silently diverge:

1. **Asymmetric detection**: The rebalance entry guard only checked "Alpaca has positions, DB does not" -- missing the reverse case entirely where positions were closed externally (manual close, Alpaca risk controls, corporate action).

2. **Fire-and-forget fill polling**: If the 2.5s poll window expired, order IDs were dropped from memory. The order would eventually fill on Alpaca but DB had no record, making the position invisible until EOD liquidation.

3. **Fixed poll interval**: No backoff meant 5 rapid API calls in 2.5 seconds for orders that typically fill in under 1 second.

The durable order tracking foundation (submitted orders persisted before polling, `fetch_submitted_orders` for stale order queries) is designed for the reconciliation module in PR 2 to build on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable tracking for submitted, filled, and cancelled equity orders.
  * Added reconciliation for orders that remain submitted beyond the expected timeframe.
  * Added handling for positions missing from the brokerage while still open in the portfolio.
  * Added a new reconciliation close reason for missing brokerage positions.

* **Improvements**
  * Order fill polling now uses progressive backoff, reducing unnecessary repeated checks.
  * Submitted orders can now be recorded before allocations are created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->