### PR TITLE
Add reconciliation module and compensation failure escalation

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -234,6 +234,26 @@ CREATE TABLE IF NOT EXISTS model_runs (
 CREATE INDEX IF NOT EXISTS idx_model_runs_status ON model_runs (status); -- noqa: PG01
 CREATE INDEX IF NOT EXISTS idx_model_runs_started_at ON model_runs (started_at DESC); -- noqa: PG01
 
+-- equity_reconciliation_events: audit trail for DB-Alpaca state discrepancies.
+-- Append-only during detection; resolved_at is updated when corrective action succeeds.
+-- Designed for Phase 2b continuous reconciliation without schema migration.
+CREATE TABLE IF NOT EXISTS equity_reconciliation_events (
+    id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    detected_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    event_type        TEXT        NOT NULL,
+    ticker            TEXT        NOT NULL,
+    expected_quantity NUMERIC,
+    actual_quantity   NUMERIC,
+    equity_pair_id    UUID        REFERENCES equity_pairs(id),
+    alpaca_order_id   TEXT,
+    action_taken      TEXT        NOT NULL,
+    resolved_at       TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_equity_reconciliation_events_unresolved -- noqa: PG01
+    ON equity_reconciliation_events (event_type)
+    WHERE resolved_at IS NULL;
+
 -- Nightly equity bar sync: weekdays at 05:00 UTC
 DO $do$
 BEGIN

--- a/schema.sql
+++ b/schema.sql
@@ -251,7 +251,7 @@ CREATE TABLE IF NOT EXISTS equity_reconciliation_events (
 );
 
 CREATE INDEX IF NOT EXISTS idx_equity_reconciliation_events_unresolved -- noqa: PG01
-    ON equity_reconciliation_events (event_type)
+    ON equity_reconciliation_events (detected_at)
     WHERE resolved_at IS NULL;
 
 -- Nightly equity bar sync: weekdays at 05:00 UTC

--- a/src/domain/trading.rs
+++ b/src/domain/trading.rs
@@ -238,6 +238,8 @@ pub enum ReconciliationEventType {
     DatabaseOnly,
     /// Both agree the ticker is held, but quantities differ.
     QuantityMismatch,
+    /// One leg of a pair is missing from Alpaca, leaving a naked directional position.
+    PartialPositionLoss,
     /// Orphan compensation (cancel + close) failed and needs retry.
     CompensationFailure,
     /// A submitted order exceeded the staleness threshold without confirmation.
@@ -251,6 +253,7 @@ impl ReconciliationEventType {
             Self::AlpacaOnly => "alpaca_only",
             Self::DatabaseOnly => "database_only",
             Self::QuantityMismatch => "quantity_mismatch",
+            Self::PartialPositionLoss => "partial_position_loss",
             Self::CompensationFailure => "compensation_failure",
             Self::StaleSubmittedOrder => "stale_submitted_order",
         }
@@ -262,6 +265,7 @@ impl ReconciliationEventType {
             "alpaca_only" => Some(Self::AlpacaOnly),
             "database_only" => Some(Self::DatabaseOnly),
             "quantity_mismatch" => Some(Self::QuantityMismatch),
+            "partial_position_loss" => Some(Self::PartialPositionLoss),
             "compensation_failure" => Some(Self::CompensationFailure),
             "stale_submitted_order" => Some(Self::StaleSubmittedOrder),
             _ => None,
@@ -274,6 +278,8 @@ impl ReconciliationEventType {
 pub enum ReconciliationAction {
     /// Closed an orphaned Alpaca position not tracked by the database.
     ClosedOrphan,
+    /// Closed the surviving leg of a partial pair to eliminate directional risk.
+    ClosedSurvivingLeg,
     /// Marked a database pair as closed because Alpaca no longer holds it.
     MarkedPairClosed,
     /// Confirmed a fill for a stale submitted order after querying Alpaca.
@@ -289,6 +295,7 @@ impl ReconciliationAction {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::ClosedOrphan => "closed_orphan",
+            Self::ClosedSurvivingLeg => "closed_surviving_leg",
             Self::MarkedPairClosed => "marked_pair_closed",
             Self::ConfirmedFill => "confirmed_fill",
             Self::CancelledStaleOrder => "cancelled_stale_order",
@@ -300,6 +307,7 @@ impl ReconciliationAction {
     pub fn parse(value: &str) -> Option<Self> {
         match value {
             "closed_orphan" => Some(Self::ClosedOrphan),
+            "closed_surviving_leg" => Some(Self::ClosedSurvivingLeg),
             "marked_pair_closed" => Some(Self::MarkedPairClosed),
             "confirmed_fill" => Some(Self::ConfirmedFill),
             "cancelled_stale_order" => Some(Self::CancelledStaleOrder),
@@ -1406,6 +1414,7 @@ mod tests {
             ReconciliationEventType::AlpacaOnly,
             ReconciliationEventType::DatabaseOnly,
             ReconciliationEventType::QuantityMismatch,
+            ReconciliationEventType::PartialPositionLoss,
             ReconciliationEventType::CompensationFailure,
             ReconciliationEventType::StaleSubmittedOrder,
         ] {
@@ -1426,6 +1435,7 @@ mod tests {
     fn test_reconciliation_action_round_trip() {
         for action in [
             ReconciliationAction::ClosedOrphan,
+            ReconciliationAction::ClosedSurvivingLeg,
             ReconciliationAction::MarkedPairClosed,
             ReconciliationAction::ConfirmedFill,
             ReconciliationAction::CancelledStaleOrder,

--- a/src/domain/trading.rs
+++ b/src/domain/trading.rs
@@ -225,6 +225,90 @@ impl OrderStatus {
     }
 }
 
+/// Type of discrepancy detected during reconciliation.
+///
+/// Event types are stored as free-text in `equity_reconciliation_events.event_type`
+/// to support future extensibility (e.g., Phase 2b risk limit breaches) without
+/// schema migration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReconciliationEventType {
+    /// Alpaca holds a position the database does not track.
+    AlpacaOnly,
+    /// Database has an open pair but Alpaca has no corresponding position.
+    DatabaseOnly,
+    /// Both agree the ticker is held, but quantities differ.
+    QuantityMismatch,
+    /// Orphan compensation (cancel + close) failed and needs retry.
+    CompensationFailure,
+    /// A submitted order exceeded the staleness threshold without confirmation.
+    StaleSubmittedOrder,
+}
+
+impl ReconciliationEventType {
+    /// Returns the database string identifier for this event type.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::AlpacaOnly => "alpaca_only",
+            Self::DatabaseOnly => "database_only",
+            Self::QuantityMismatch => "quantity_mismatch",
+            Self::CompensationFailure => "compensation_failure",
+            Self::StaleSubmittedOrder => "stale_submitted_order",
+        }
+    }
+
+    /// Parses a stored database value. Returns `None` for unknown values.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "alpaca_only" => Some(Self::AlpacaOnly),
+            "database_only" => Some(Self::DatabaseOnly),
+            "quantity_mismatch" => Some(Self::QuantityMismatch),
+            "compensation_failure" => Some(Self::CompensationFailure),
+            "stale_submitted_order" => Some(Self::StaleSubmittedOrder),
+            _ => None,
+        }
+    }
+}
+
+/// Corrective action taken (or deferred) for a reconciliation event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReconciliationAction {
+    /// Closed an orphaned Alpaca position not tracked by the database.
+    ClosedOrphan,
+    /// Marked a database pair as closed because Alpaca no longer holds it.
+    MarkedPairClosed,
+    /// Confirmed a fill for a stale submitted order after querying Alpaca.
+    ConfirmedFill,
+    /// Cancelled a stale submitted order that Alpaca had not filled.
+    CancelledStaleOrder,
+    /// No corrective action taken; discrepancy logged for human review.
+    LoggedOnly,
+}
+
+impl ReconciliationAction {
+    /// Returns the database string identifier for this action.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ClosedOrphan => "closed_orphan",
+            Self::MarkedPairClosed => "marked_pair_closed",
+            Self::ConfirmedFill => "confirmed_fill",
+            Self::CancelledStaleOrder => "cancelled_stale_order",
+            Self::LoggedOnly => "logged_only",
+        }
+    }
+
+    /// Parses a stored database value. Returns `None` for unknown values.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "closed_orphan" => Some(Self::ClosedOrphan),
+            "marked_pair_closed" => Some(Self::MarkedPairClosed),
+            "confirmed_fill" => Some(Self::ConfirmedFill),
+            "cancelled_stale_order" => Some(Self::CancelledStaleOrder),
+            "logged_only" => Some(Self::LoggedOnly),
+            _ => None,
+        }
+    }
+}
+
 impl std::fmt::Display for CloseReason {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str(self.as_str())
@@ -1314,6 +1398,47 @@ mod tests {
         assert_eq!(order.order_type(), "limit");
         assert!(order.limit_price().is_some());
         assert_eq!(order.alpaca_order_id(), "alpaca-001");
+    }
+
+    #[test]
+    fn test_reconciliation_event_type_round_trip() {
+        for event_type in [
+            ReconciliationEventType::AlpacaOnly,
+            ReconciliationEventType::DatabaseOnly,
+            ReconciliationEventType::QuantityMismatch,
+            ReconciliationEventType::CompensationFailure,
+            ReconciliationEventType::StaleSubmittedOrder,
+        ] {
+            assert_eq!(
+                ReconciliationEventType::parse(event_type.as_str()),
+                Some(event_type)
+            );
+        }
+    }
+
+    #[test]
+    fn test_reconciliation_event_type_parse_rejects_unknown() {
+        assert_eq!(ReconciliationEventType::parse("unknown_type"), None);
+        assert_eq!(ReconciliationEventType::parse("ALPACA_ONLY"), None);
+    }
+
+    #[test]
+    fn test_reconciliation_action_round_trip() {
+        for action in [
+            ReconciliationAction::ClosedOrphan,
+            ReconciliationAction::MarkedPairClosed,
+            ReconciliationAction::ConfirmedFill,
+            ReconciliationAction::CancelledStaleOrder,
+            ReconciliationAction::LoggedOnly,
+        ] {
+            assert_eq!(ReconciliationAction::parse(action.as_str()), Some(action));
+        }
+    }
+
+    #[test]
+    fn test_reconciliation_action_parse_rejects_unknown() {
+        assert_eq!(ReconciliationAction::parse("unknown_action"), None);
+        assert_eq!(ReconciliationAction::parse("CLOSED_ORPHAN"), None);
     }
 
     #[test]

--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -10,6 +10,7 @@ pub mod database;
 pub mod execution;
 pub mod math;
 pub mod rebalance;
+pub mod reconciliation;
 pub mod regime;
 pub mod sizing;
 pub mod state;

--- a/src/portfolio/alpaca.rs
+++ b/src/portfolio/alpaca.rs
@@ -60,6 +60,8 @@ pub struct Position {
     pub symbol: String,
     /// Position side (`"long"` or `"short"`).
     pub side: String,
+    /// Absolute number of shares held.
+    pub quantity: f64,
     /// Current market value (negative for shorts).
     pub market_value: f64,
     /// Unrealised profit or loss on this position.
@@ -509,6 +511,12 @@ impl TradingClient {
         let result: Vec<Position> = positions
             .into_iter()
             .map(|position| {
+                let quantity = position.qty.parse::<f64>().map_err(|error| {
+                    ClientError::Parse(format!(
+                        "Failed to parse qty '{}' for {}: {error}",
+                        position.qty, position.symbol
+                    ))
+                })?;
                 let market_value = position.market_value.parse::<f64>().map_err(|error| {
                     ClientError::Parse(format!(
                         "Failed to parse market_value '{}' for {}: {error}",
@@ -525,6 +533,7 @@ impl TradingClient {
                 Ok(Position {
                     symbol: position.symbol,
                     side: position.side,
+                    quantity: quantity.abs(),
                     market_value,
                     unrealized_profit_and_loss,
                 })
@@ -679,6 +688,7 @@ struct ClockResponse {
 struct PositionResponse {
     symbol: String,
     side: String,
+    qty: String,
     market_value: String,
     unrealized_pl: String,
 }
@@ -994,8 +1004,8 @@ mod tests {
             .with_status(200)
             .with_body(
                 r#"[
-                {"symbol": "AAPL", "side": "long", "market_value": "15000.50", "unrealized_pl": "500.25"},
-                {"symbol": "MSFT", "side": "short", "market_value": "-8000.00", "unrealized_pl": "-200.75"}
+                {"symbol": "AAPL", "side": "long", "qty": "100", "market_value": "15000.50", "unrealized_pl": "500.25"},
+                {"symbol": "MSFT", "side": "short", "qty": "-50", "market_value": "-8000.00", "unrealized_pl": "-200.75"}
             ]"#,
             )
             .create_async()
@@ -1007,10 +1017,12 @@ mod tests {
         assert_eq!(positions.len(), 2);
         assert_eq!(positions[0].symbol, "AAPL");
         assert_eq!(positions[0].side, "long");
+        assert!((positions[0].quantity - 100.0).abs() < 1e-6);
         assert!((positions[0].market_value - 15_000.50).abs() < 1e-6);
         assert!((positions[0].unrealized_profit_and_loss - 500.25).abs() < 1e-6);
         assert_eq!(positions[1].symbol, "MSFT");
         assert_eq!(positions[1].side, "short");
+        assert!((positions[1].quantity - 50.0).abs() < 1e-6);
         assert!((positions[1].market_value - (-8_000.0)).abs() < 1e-6);
         assert!((positions[1].unrealized_profit_and_loss - (-200.75)).abs() < 1e-6);
         mock.assert_async().await;

--- a/src/portfolio/consumer.rs
+++ b/src/portfolio/consumer.rs
@@ -19,6 +19,7 @@ use crate::common::events::{
 };
 use crate::common::market_hours::is_within_trading_session;
 use crate::portfolio::rebalance::{run_end_of_day_liquidation, run_rebalance, RebalanceError};
+use crate::portfolio::reconciliation;
 use crate::portfolio::state::AppState;
 
 /// Spawns the event consumer as a background task.
@@ -43,6 +44,23 @@ async fn run_consumer(state: &AppState, pool: &PgPool) -> Result<(), sqlx::Error
     let mut listener = PgListener::connect_with(pool).await?;
     listener.listen("events").await?;
     info!("Event consumer connected, listening on channel 'events'");
+
+    // Run startup reconciliation to resolve any DB-Alpaca drift accumulated
+    // while the service was down.
+    match reconciliation::reconcile(pool, state.alpaca_client()).await {
+        Ok(report) => {
+            info!(
+                orphans_closed = report.orphans_closed,
+                pairs_marked_closed = report.pairs_marked_closed,
+                stale_orders_resolved = report.stale_orders_resolved,
+                compensation_retries = report.compensation_retries,
+                "Startup reconciliation completed"
+            );
+        }
+        Err(error) => {
+            warn!(error = %error, "Startup reconciliation failed; continuing with event loop");
+        }
+    }
 
     // Catch up on equity_predictions_completed that arrived while we were down.
     // Periodic market_session_check ticks are intentionally not caught up because

--- a/src/portfolio/database.rs
+++ b/src/portfolio/database.rs
@@ -627,7 +627,7 @@ pub async fn insert_submitted_order(
 pub async fn mark_order_filled<'e>(
     executor: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
     id: Uuid,
-    allocation_id: Uuid,
+    allocation_id: Option<Uuid>,
     filled_at: DateTime<Utc>,
 ) -> Result<(), sqlx::Error> {
     let result = sqlx::query(
@@ -1162,11 +1162,14 @@ mod tests {
     #[test]
     fn test_mark_order_filled_compiles() {
         make_runtime().block_on(async {
-            assert!(
-                mark_order_filled(&lazy_pool(), Uuid::new_v4(), Uuid::new_v4(), Utc::now(),)
-                    .await
-                    .is_err()
-            );
+            assert!(mark_order_filled(
+                &lazy_pool(),
+                Uuid::new_v4(),
+                Some(Uuid::new_v4()),
+                Utc::now(),
+            )
+            .await
+            .is_err());
         });
     }
 

--- a/src/portfolio/database.rs
+++ b/src/portfolio/database.rs
@@ -14,7 +14,7 @@ use crate::domain::market::{PairID, Ticker};
 use crate::domain::predictions::EquityPrediction;
 use crate::domain::trading::{
     CloseReason, EquityAllocation, EquityOrder, EquityPair, EquityRebalanceSession, OrderStatus,
-    RebalanceSessionStatus,
+    RebalanceSessionStatus, ReconciliationAction, ReconciliationEventType,
 };
 
 /// Lookback window for historical close prices (calendar days).
@@ -709,6 +709,126 @@ pub async fn fetch_submitted_orders(
     Ok(orders)
 }
 
+/// An unresolved reconciliation event awaiting retry or human review.
+///
+/// Returned by [`fetch_unresolved_reconciliation_events`] for the reconciliation
+/// process to retry corrective actions.
+#[derive(Debug, Clone)]
+pub struct UnresolvedReconciliationEvent {
+    id: i64,
+    event_type: String,
+    ticker: String,
+    alpaca_order_id: Option<String>,
+}
+
+impl UnresolvedReconciliationEvent {
+    pub fn id(&self) -> i64 {
+        self.id
+    }
+
+    pub fn event_type(&self) -> &str {
+        &self.event_type
+    }
+
+    pub fn ticker(&self) -> &str {
+        &self.ticker
+    }
+
+    pub fn alpaca_order_id(&self) -> Option<&str> {
+        self.alpaca_order_id.as_deref()
+    }
+}
+
+/// Inserts a reconciliation event recording a detected discrepancy and the action taken.
+#[allow(clippy::too_many_arguments)]
+pub async fn insert_reconciliation_event(
+    pool: &PgPool,
+    event_type: &ReconciliationEventType,
+    ticker: &str,
+    expected_quantity: Option<Decimal>,
+    actual_quantity: Option<Decimal>,
+    equity_pair_id: Option<Uuid>,
+    alpaca_order_id: Option<&str>,
+    action_taken: &ReconciliationAction,
+    resolved_at: Option<DateTime<Utc>>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO equity_reconciliation_events \
+         (event_type, ticker, expected_quantity, actual_quantity, equity_pair_id, \
+          alpaca_order_id, action_taken, resolved_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+    )
+    .bind(event_type.as_str())
+    .bind(ticker)
+    .bind(expected_quantity)
+    .bind(actual_quantity)
+    .bind(equity_pair_id)
+    .bind(alpaca_order_id)
+    .bind(action_taken.as_str())
+    .bind(resolved_at)
+    .execute(pool)
+    .await?;
+
+    info!(
+        event_type = event_type.as_str(),
+        ticker = ticker,
+        action = action_taken.as_str(),
+        "Reconciliation event recorded"
+    );
+    Ok(())
+}
+
+/// Fetches all unresolved reconciliation events (where `resolved_at IS NULL`).
+///
+/// Used by the reconciliation process to retry compensation failures and
+/// other events that need follow-up.
+pub async fn fetch_unresolved_reconciliation_events(
+    pool: &PgPool,
+) -> Result<Vec<UnresolvedReconciliationEvent>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT id, event_type, ticker, alpaca_order_id \
+         FROM equity_reconciliation_events \
+         WHERE resolved_at IS NULL \
+         ORDER BY detected_at ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let events: Vec<UnresolvedReconciliationEvent> = rows
+        .into_iter()
+        .map(|row| {
+            use sqlx::Row;
+            UnresolvedReconciliationEvent {
+                id: row.get("id"),
+                event_type: row.get("event_type"),
+                ticker: row.get("ticker"),
+                alpaca_order_id: row.get("alpaca_order_id"),
+            }
+        })
+        .collect();
+
+    info!(
+        rows = events.len(),
+        "Unresolved reconciliation events fetched from PostgreSQL"
+    );
+    Ok(events)
+}
+
+/// Marks a reconciliation event as resolved by setting `resolved_at`.
+pub async fn resolve_reconciliation_event(pool: &PgPool, event_id: i64) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE equity_reconciliation_events \
+         SET resolved_at = now() \
+         WHERE id = $1",
+    )
+    .bind(event_id)
+    .execute(pool)
+    .await?;
+
+    info!(event_id = event_id, "Reconciliation event resolved");
+    Ok(())
+}
+
 /// Inserts an intraday portfolio snapshot recording the post-rebalance net asset value.
 pub async fn insert_portfolio_snapshot<'e>(
     executor: impl sqlx::Executor<'e, Database = sqlx::Postgres>,
@@ -1065,6 +1185,84 @@ mod tests {
             assert!(fetch_submitted_orders(&lazy_pool(), Utc::now())
                 .await
                 .is_err());
+        });
+    }
+
+    // --- UnresolvedReconciliationEvent accessors ---
+
+    #[test]
+    fn test_unresolved_reconciliation_event_accessors() {
+        let event = UnresolvedReconciliationEvent {
+            id: 42,
+            event_type: "compensation_failure".to_string(),
+            ticker: "AAPL".to_string(),
+            alpaca_order_id: Some("alpaca-order-001".to_string()),
+        };
+        assert_eq!(event.id(), 42);
+        assert_eq!(event.event_type(), "compensation_failure");
+        assert_eq!(event.ticker(), "AAPL");
+        assert_eq!(event.alpaca_order_id(), Some("alpaca-order-001"));
+    }
+
+    #[test]
+    fn test_unresolved_reconciliation_event_without_order_id() {
+        let event = UnresolvedReconciliationEvent {
+            id: 1,
+            event_type: "database_only".to_string(),
+            ticker: "MSFT".to_string(),
+            alpaca_order_id: None,
+        };
+        assert!(event.alpaca_order_id().is_none());
+    }
+
+    #[test]
+    fn test_unresolved_reconciliation_event_clone() {
+        let event = UnresolvedReconciliationEvent {
+            id: 5,
+            event_type: "alpaca_only".to_string(),
+            ticker: "GOOG".to_string(),
+            alpaca_order_id: None,
+        };
+        let cloned = event.clone();
+        assert_eq!(cloned.id(), event.id());
+        assert_eq!(cloned.ticker(), event.ticker());
+    }
+
+    // --- compile / connection-error coverage for reconciliation DB functions ---
+
+    #[test]
+    fn test_insert_reconciliation_event_compiles() {
+        make_runtime().block_on(async {
+            use crate::domain::trading::{ReconciliationAction, ReconciliationEventType};
+            assert!(insert_reconciliation_event(
+                &lazy_pool(),
+                &ReconciliationEventType::AlpacaOnly,
+                "AAPL",
+                None,
+                Some(Decimal::from(100)),
+                None,
+                None,
+                &ReconciliationAction::ClosedOrphan,
+                Some(Utc::now()),
+            )
+            .await
+            .is_err());
+        });
+    }
+
+    #[test]
+    fn test_fetch_unresolved_reconciliation_events_compiles() {
+        make_runtime().block_on(async {
+            assert!(fetch_unresolved_reconciliation_events(&lazy_pool())
+                .await
+                .is_err());
+        });
+    }
+
+    #[test]
+    fn test_resolve_reconciliation_event_compiles() {
+        make_runtime().block_on(async {
+            assert!(resolve_reconciliation_event(&lazy_pool(), 1).await.is_err());
         });
     }
 

--- a/src/portfolio/execution.rs
+++ b/src/portfolio/execution.rs
@@ -6,12 +6,15 @@
 
 use chrono::Utc;
 use rust_decimal::Decimal;
+use sqlx::PgPool;
 use tokio::time::Duration;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::domain::orders::{FilledOrder, Order, OrderSide, PendingPair};
+use crate::domain::trading::{ReconciliationAction, ReconciliationEventType};
 use crate::portfolio::alpaca::{ClientError, TradingClient};
+use crate::portfolio::database;
 use crate::portfolio::sizing::SizedPair;
 
 /// Maximum number of fill-poll attempts per order before giving up.
@@ -78,6 +81,7 @@ impl std::error::Error for ExecutionError {}
 /// borrowing issues.
 pub async fn execute_open_pairs(
     alpaca: &TradingClient,
+    pool: &PgPool,
     sized_pairs: &[SizedPair],
 ) -> Vec<(PendingPair, SizedPair)> {
     let mut results: Vec<(PendingPair, SizedPair)> = Vec::new();
@@ -102,8 +106,13 @@ pub async fn execute_open_pairs(
                     error = %error,
                     "Short order submission failed; cancelling orphaned long order"
                 );
-                compensate_orphaned_order(alpaca, &long_id, sized_pair.long_ticker().as_str())
-                    .await;
+                compensate_orphaned_order(
+                    alpaca,
+                    pool,
+                    &long_id,
+                    sized_pair.long_ticker().as_str(),
+                )
+                .await;
                 continue;
             }
             (Ok(short_id), Err(error)) => {
@@ -112,8 +121,13 @@ pub async fn execute_open_pairs(
                     error = %error,
                     "Long order submission failed; cancelling orphaned short order"
                 );
-                compensate_orphaned_order(alpaca, &short_id, sized_pair.short_ticker().as_str())
-                    .await;
+                compensate_orphaned_order(
+                    alpaca,
+                    pool,
+                    &short_id,
+                    sized_pair.short_ticker().as_str(),
+                )
+                .await;
                 continue;
             }
             (Err(short_error), Err(long_error)) => {
@@ -171,7 +185,15 @@ pub async fn execute_open_pairs(
 /// Cancels an orphaned order, falling back to closing the resulting position
 /// if the order has already filled by the time compensation runs (Alpaca
 /// returns 422 for terminal-state orders).
-async fn compensate_orphaned_order(alpaca: &TradingClient, alpaca_order_id: &str, ticker: &str) {
+///
+/// When both cancellation and position close fail, persists a `compensation_failure`
+/// event to the reconciliation table so it can be retried on the next pass.
+async fn compensate_orphaned_order(
+    alpaca: &TradingClient,
+    pool: &PgPool,
+    alpaca_order_id: &str,
+    ticker: &str,
+) {
     match alpaca.cancel_order(alpaca_order_id).await {
         Ok(true) => {
             info!(
@@ -182,22 +204,59 @@ async fn compensate_orphaned_order(alpaca: &TradingClient, alpaca_order_id: &str
         }
         Ok(false) => {
             // Order already in a terminal state; close the filled position.
-            if let Err(error) = alpaca.close_position(ticker).await {
-                warn!(
+            if let Err(close_error) = alpaca.close_position(ticker).await {
+                error!(
                     ticker = ticker,
-                    error = %error,
-                    "Failed to close orphaned position after order already filled"
+                    alpaca_order_id = alpaca_order_id,
+                    error = %close_error,
+                    "Failed to close orphaned position after order already filled; persisting compensation failure"
                 );
+                persist_compensation_failure(pool, ticker, alpaca_order_id).await;
             }
         }
-        Err(error) => {
+        Err(cancel_error) => {
+            // Cancel failed — try closing the position directly.
             warn!(
                 alpaca_order_id = alpaca_order_id,
                 ticker = ticker,
-                error = %error,
-                "Failed to cancel orphaned order"
+                error = %cancel_error,
+                "Failed to cancel orphaned order; attempting close_position fallback"
             );
+            if let Err(close_error) = alpaca.close_position(ticker).await {
+                error!(
+                    ticker = ticker,
+                    alpaca_order_id = alpaca_order_id,
+                    cancel_error = %cancel_error,
+                    close_error = %close_error,
+                    "Both cancel and close failed; persisting compensation failure"
+                );
+                persist_compensation_failure(pool, ticker, alpaca_order_id).await;
+            }
         }
+    }
+}
+
+/// Persists a compensation failure event so reconciliation can retry it.
+async fn persist_compensation_failure(pool: &PgPool, ticker: &str, alpaca_order_id: &str) {
+    if let Err(error) = database::insert_reconciliation_event(
+        pool,
+        &ReconciliationEventType::CompensationFailure,
+        ticker,
+        None,
+        None,
+        None,
+        Some(alpaca_order_id),
+        &ReconciliationAction::LoggedOnly,
+        None,
+    )
+    .await
+    {
+        error!(
+            error = %error,
+            ticker = ticker,
+            alpaca_order_id = alpaca_order_id,
+            "Failed to persist compensation failure event"
+        );
     }
 }
 

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -1042,11 +1042,17 @@ async fn persist_filled_pairs(
         // Uses the Order ID from the filled pair (same UUID that was used in
         // insert_submitted_order). Silently handles the case where the submitted
         // record was never persisted (e.g., DB was unavailable at submission time).
-        mark_order_filled(&mut **transaction, filled_pair.long.id, long_alloc_id, now).await?;
+        mark_order_filled(
+            &mut **transaction,
+            filled_pair.long.id,
+            Some(long_alloc_id),
+            now,
+        )
+        .await?;
         mark_order_filled(
             &mut **transaction,
             filled_pair.short.id,
-            short_alloc_id,
+            Some(short_alloc_id),
             now,
         )
         .await?;

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -27,7 +27,7 @@ use chrono::{DateTime, Utc};
 use num_traits::ToPrimitive;
 use rust_decimal::Decimal;
 use tokio::sync::RwLock;
-use tracing::{error, info, warn};
+use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::common::events::{emit_event, EventType};
@@ -53,6 +53,7 @@ use crate::portfolio::execution::{
     close_positions, confirm_fills, execute_open_pairs, ExecutionError,
 };
 use crate::portfolio::math::z_score_last;
+use crate::portfolio::reconciliation;
 use crate::portfolio::regime::classify_regime;
 use crate::portfolio::sizing::{size_pairs_with_volatility_parity, SizingError};
 use crate::portfolio::state::AppState;
@@ -152,22 +153,48 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
     let pool = state.pool();
     let alpaca = state.alpaca_client();
 
-    // Phase 1: check Alpaca positions to decide build vs monitor path.
+    // Phase 1: reconcile DB state against Alpaca positions, then decide path.
+    let reconciliation_report = match reconciliation::reconcile(pool, alpaca).await {
+        Ok(report) => report,
+        Err(reconciliation::ReconciliationError::AlpacaFetch(error)) => {
+            return Err(RebalanceError::Execution(ExecutionError::PositionFetch {
+                source: error,
+            }));
+        }
+        Err(reconciliation::ReconciliationError::Database(error)) => {
+            return Err(RebalanceError::Database(error));
+        }
+    };
+
+    if reconciliation_report.orphans_closed > 0
+        || reconciliation_report.pairs_marked_closed > 0
+        || reconciliation_report.stale_orders_resolved > 0
+    {
+        info!(
+            orphans_closed = reconciliation_report.orphans_closed,
+            pairs_marked_closed = reconciliation_report.pairs_marked_closed,
+            stale_orders_resolved = reconciliation_report.stale_orders_resolved,
+            "Reconciliation resolved discrepancies before rebalance"
+        );
+    }
+
+    // Re-fetch state after reconciliation to get the corrected view.
     let alpaca_positions = alpaca.fetch_positions().await.map_err(|error| {
         RebalanceError::Execution(ExecutionError::PositionFetch { source: error })
     })?;
-
     let open_pairs = fetch_open_pairs(pool).await?;
 
     if !alpaca_positions.is_empty() {
         // Alpaca has live positions — enter monitor mode.
         if open_pairs.is_empty() {
+            // Reconciliation should have resolved this, but if it persists, halt.
             warn!(
                 alpaca_positions = alpaca_positions.len(),
-                "Alpaca has positions but database has no open pairs; state mismatch"
+                "Alpaca has positions but database has no open pairs after reconciliation"
             );
             return Err(RebalanceError::Execution(ExecutionError::StateMismatch {
-                message: "Alpaca has positions but database has no open pairs".to_string(),
+                message: "Alpaca has positions but database has no open pairs after reconciliation"
+                    .to_string(),
             }));
         }
 
@@ -176,28 +203,7 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
         return run_monitor_cycle(state, pool, alpaca, &open_pairs, &historical_prices).await;
     }
 
-    // Alpaca has no positions. If DB still has open pairs, they were closed
-    // externally (manual close, Alpaca risk controls, corporate action). Mark
-    // them closed with a reconciliation-specific reason and continue as cold start.
-    if !open_pairs.is_empty() {
-        error!(
-            open_pairs = open_pairs.len(),
-            "Database has open pairs but Alpaca has no positions; \
-             marking stale pairs closed with reconciliation_alpaca_missing"
-        );
-        let closed_at = Utc::now();
-        for pair in &open_pairs {
-            close_equity_pair_with_reason(
-                pool,
-                pair.id(),
-                closed_at,
-                &CloseReason::ReconciliationAlpacaMissing,
-            )
-            .await?;
-        }
-    }
-
-    // Cold start: no Alpaca positions. Build a fresh portfolio.
+    // Cold start: no Alpaca positions, no open DB pairs. Build a fresh portfolio.
     info!("No Alpaca positions; building fresh portfolio");
 
     // Phase 2: load predictions and market data.
@@ -885,7 +891,7 @@ async fn select_size_execute(
         })
         .collect();
 
-    let pending = execute_open_pairs(alpaca, &eligible_pairs).await;
+    let pending = execute_open_pairs(alpaca, pool, &eligible_pairs).await;
 
     // Persist submitted order records before polling for fills. Each order gets
     // a durable breadcrumb so that if the process crashes during fill polling,

--- a/src/portfolio/reconciliation.rs
+++ b/src/portfolio/reconciliation.rs
@@ -9,7 +9,6 @@
 //! - **Alpaca-only**: Alpaca holds a position the DB does not track → close orphan.
 //! - **DB-only**: DB has an open pair but Alpaca has no position → mark pair closed.
 //! - **Partial position loss**: One leg of a pair is missing → close surviving leg.
-//! - **Quantity mismatch**: Both agree the ticker is held, but quantities differ → log only.
 //! - **Stale submitted order**: An order exceeded the staleness threshold → query Alpaca
 //!   and either confirm fill or cancel.
 //! - **Compensation failure retry**: A prior compensation failure is retried.
@@ -37,8 +36,6 @@ pub struct ReconciliationReport {
     pub pairs_marked_closed: usize,
     /// Number of partial position losses handled (surviving leg closed).
     pub partial_positions_closed: usize,
-    /// Number of quantity mismatches logged.
-    pub quantity_mismatches_logged: usize,
     /// Number of stale submitted orders resolved (confirmed or cancelled).
     pub stale_orders_resolved: usize,
     /// Number of compensation failures retried.
@@ -92,7 +89,6 @@ pub async fn reconcile(
         orphans_closed: 0,
         pairs_marked_closed: 0,
         partial_positions_closed: 0,
-        quantity_mismatches_logged: 0,
         stale_orders_resolved: 0,
         compensation_retries: 0,
     };
@@ -168,7 +164,7 @@ pub async fn reconcile(
                 "DB pair has no Alpaca positions; marking closed"
             );
             let closed_at = Utc::now();
-            if let Err(error) = database::close_equity_pair_with_reason(
+            let pair_closed = match database::close_equity_pair_with_reason(
                 pool,
                 pair.id(),
                 closed_at,
@@ -176,12 +172,23 @@ pub async fn reconcile(
             )
             .await
             {
-                error!(error = %error, "Failed to mark DB pair as closed");
-            } else {
-                closed_pair_ids.insert(pair.id());
-                report.pairs_marked_closed += 1;
-            }
+                Ok(()) => {
+                    closed_pair_ids.insert(pair.id());
+                    report.pairs_marked_closed += 1;
+                    true
+                }
+                Err(error) => {
+                    error!(error = %error, "Failed to mark DB pair as closed");
+                    false
+                }
+            };
             // Record event for both tickers.
+            let action = if pair_closed {
+                ReconciliationAction::MarkedPairClosed
+            } else {
+                ReconciliationAction::LoggedOnly
+            };
+            let resolved_at = if pair_closed { Some(closed_at) } else { None };
             for ticker in [pair.long_ticker().as_str(), pair.short_ticker().as_str()] {
                 if let Err(error) = database::insert_reconciliation_event(
                     pool,
@@ -191,8 +198,8 @@ pub async fn reconcile(
                     None,
                     Some(pair.id()),
                     None,
-                    &ReconciliationAction::MarkedPairClosed,
-                    Some(closed_at),
+                    &action,
+                    resolved_at,
                 )
                 .await
                 {
@@ -270,8 +277,8 @@ pub async fn reconcile(
             // ticker is shared (the position belongs to another pair). If the
             // close failed, leave the pair open so compensation retry picks it up.
             let closed_at = Utc::now();
-            if close_succeeded || ticker_shared_by_other_pair {
-                if let Err(error) = database::close_equity_pair_with_reason(
+            let pair_closed = if close_succeeded || ticker_shared_by_other_pair {
+                match database::close_equity_pair_with_reason(
                     pool,
                     pair.id(),
                     closed_at,
@@ -279,19 +286,28 @@ pub async fn reconcile(
                 )
                 .await
                 {
-                    error!(error = %error, "Failed to mark partial pair as closed");
-                } else {
-                    closed_pair_ids.insert(pair.id());
-                    report.pairs_marked_closed += 1;
+                    Ok(()) => {
+                        closed_pair_ids.insert(pair.id());
+                        report.pairs_marked_closed += 1;
+                        true
+                    }
+                    Err(error) => {
+                        error!(error = %error, "Failed to mark partial pair as closed");
+                        false
+                    }
                 }
-            }
+            } else {
+                false
+            };
 
             let action = if close_succeeded {
                 ReconciliationAction::ClosedSurvivingLeg
+            } else if pair_closed {
+                ReconciliationAction::MarkedPairClosed
             } else {
                 ReconciliationAction::LoggedOnly
             };
-            let resolved_at = if close_succeeded || ticker_shared_by_other_pair {
+            let resolved_at = if pair_closed || close_succeeded {
                 Some(closed_at)
             } else {
                 None
@@ -312,7 +328,9 @@ pub async fn reconcile(
             {
                 error!(error = %error, "Failed to persist partial_position_loss reconciliation event");
             }
-            report.partial_positions_closed += 1;
+            if close_succeeded || pair_closed {
+                report.partial_positions_closed += 1;
+            }
         }
     }
 
@@ -332,7 +350,6 @@ pub async fn reconcile(
         orphans_closed = report.orphans_closed,
         pairs_marked_closed = report.pairs_marked_closed,
         partial_positions_closed = report.partial_positions_closed,
-        quantity_mismatches = report.quantity_mismatches_logged,
         stale_orders_resolved = report.stale_orders_resolved,
         compensation_retries = report.compensation_retries,
         "Reconciliation pass completed"
@@ -418,7 +435,8 @@ async fn resolve_stale_order(
             match alpaca.cancel_order(order.alpaca_order_id()).await {
                 Ok(true) => {
                     if let Err(error) = database::mark_order_cancelled(pool, order.id()).await {
-                        error!(error = %error, "Failed to mark cancelled stale order in DB");
+                        error!(error = %error, "Failed to mark cancelled stale order in DB; will retry");
+                        return 0;
                     }
                     if let Err(error) = database::insert_reconciliation_event(
                         pool,
@@ -584,14 +602,12 @@ mod tests {
             orphans_closed: 0,
             pairs_marked_closed: 0,
             partial_positions_closed: 0,
-            quantity_mismatches_logged: 0,
             stale_orders_resolved: 0,
             compensation_retries: 0,
         };
         assert_eq!(report.orphans_closed, 0);
         assert_eq!(report.pairs_marked_closed, 0);
         assert_eq!(report.partial_positions_closed, 0);
-        assert_eq!(report.quantity_mismatches_logged, 0);
         assert_eq!(report.stale_orders_resolved, 0);
         assert_eq!(report.compensation_retries, 0);
     }

--- a/src/portfolio/reconciliation.rs
+++ b/src/portfolio/reconciliation.rs
@@ -1,0 +1,595 @@
+//! Periodic reconciliation between PostgreSQL pair state and Alpaca broker positions.
+//!
+//! The [`reconcile`] function is stateless and idempotent: it can run at any
+//! cadence — once per rebalance cycle (Phase 0) or every 30 seconds (Phase 2b) —
+//! without behavioral changes. All corrective actions check current state before
+//! acting, so repeated calls against the same discrepancy are safe.
+//!
+//! Discrepancy categories:
+//! - **Alpaca-only**: Alpaca holds a position the DB does not track → close orphan.
+//! - **DB-only**: DB has an open pair but Alpaca has no position → mark pair closed.
+//! - **Quantity mismatch**: Both agree the ticker is held, but quantities differ → log only.
+//! - **Stale submitted order**: An order exceeded the staleness threshold → query Alpaca
+//!   and either confirm fill or cancel.
+//! - **Compensation failure retry**: A prior compensation failure is retried.
+
+use std::collections::{HashMap, HashSet};
+
+use chrono::{Duration, Utc};
+use rust_decimal::Decimal;
+use sqlx::PgPool;
+use tracing::{error, info, warn};
+
+use crate::domain::trading::{CloseReason, ReconciliationAction, ReconciliationEventType};
+use crate::portfolio::alpaca::{Position, TradingClient};
+use crate::portfolio::database::{self, OpenPair, SubmittedOrder, UnresolvedReconciliationEvent};
+
+/// Default staleness threshold for submitted orders (seconds).
+const STALE_ORDER_THRESHOLD_SECONDS: i64 = 60;
+
+/// Summary of actions taken during a reconciliation pass.
+#[derive(Debug)]
+pub struct ReconciliationReport {
+    /// Number of orphaned Alpaca positions closed.
+    pub orphans_closed: usize,
+    /// Number of DB pairs marked closed because Alpaca no longer holds them.
+    pub pairs_marked_closed: usize,
+    /// Number of quantity mismatches logged.
+    pub quantity_mismatches_logged: usize,
+    /// Number of stale submitted orders resolved (confirmed or cancelled).
+    pub stale_orders_resolved: usize,
+    /// Number of compensation failures retried.
+    pub compensation_retries: usize,
+}
+
+/// Runs a full reconciliation pass comparing DB state against Alpaca positions.
+///
+/// This function is the single entry point for all reconciliation work. It:
+/// 1. Fetches positions from Alpaca and open pairs from the DB.
+/// 2. Compares ticker sets and classifies discrepancies.
+/// 3. Takes corrective action for clear-cut cases, logs ambiguous ones.
+/// 4. Resolves stale submitted orders by querying Alpaca.
+/// 5. Retries unresolved compensation failures.
+///
+/// Returns a [`ReconciliationReport`] summarizing actions taken.
+pub async fn reconcile(
+    pool: &PgPool,
+    alpaca: &TradingClient,
+) -> Result<ReconciliationReport, ReconciliationError> {
+    let alpaca_positions = alpaca
+        .fetch_positions()
+        .await
+        .map_err(ReconciliationError::AlpacaFetch)?;
+    let open_pairs = database::fetch_open_pairs(pool)
+        .await
+        .map_err(ReconciliationError::Database)?;
+    let stale_threshold = Utc::now() - Duration::seconds(STALE_ORDER_THRESHOLD_SECONDS);
+    let stale_orders = database::fetch_submitted_orders(pool, stale_threshold)
+        .await
+        .map_err(ReconciliationError::Database)?;
+    let unresolved_events = database::fetch_unresolved_reconciliation_events(pool)
+        .await
+        .map_err(ReconciliationError::Database)?;
+
+    // Build lookup structures.
+    let alpaca_by_symbol: HashMap<&str, &Position> = alpaca_positions
+        .iter()
+        .map(|position| (position.symbol.as_str(), position))
+        .collect();
+    let alpaca_symbols: HashSet<&str> = alpaca_by_symbol.keys().copied().collect();
+
+    // Collect all tickers from open pairs (both long and short legs).
+    let mut database_symbols: HashSet<String> = HashSet::new();
+    // Map from ticker to (pair_id, expected side) for pair-level tracking.
+    let mut ticker_to_pair: HashMap<String, Vec<&OpenPair>> = HashMap::new();
+    for pair in &open_pairs {
+        database_symbols.insert(pair.long_ticker().as_str().to_string());
+        database_symbols.insert(pair.short_ticker().as_str().to_string());
+        ticker_to_pair
+            .entry(pair.long_ticker().as_str().to_string())
+            .or_default()
+            .push(pair);
+        ticker_to_pair
+            .entry(pair.short_ticker().as_str().to_string())
+            .or_default()
+            .push(pair);
+    }
+
+    let mut report = ReconciliationReport {
+        orphans_closed: 0,
+        pairs_marked_closed: 0,
+        quantity_mismatches_logged: 0,
+        stale_orders_resolved: 0,
+        compensation_retries: 0,
+    };
+
+    // --- Alpaca-only positions: close orphans ---
+    for symbol in &alpaca_symbols {
+        if !database_symbols.contains(*symbol) {
+            let position = alpaca_by_symbol[symbol];
+            warn!(
+                ticker = *symbol,
+                quantity = position.quantity,
+                "Alpaca-only position detected; closing orphan"
+            );
+            let action = match alpaca.close_position(symbol).await {
+                Ok(_) => {
+                    report.orphans_closed += 1;
+                    ReconciliationAction::ClosedOrphan
+                }
+                Err(close_error) => {
+                    error!(
+                        ticker = *symbol,
+                        error = %close_error,
+                        "Failed to close orphaned position"
+                    );
+                    ReconciliationAction::LoggedOnly
+                }
+            };
+            let resolved_at = if action == ReconciliationAction::ClosedOrphan {
+                Some(Utc::now())
+            } else {
+                None
+            };
+            if let Err(error) = database::insert_reconciliation_event(
+                pool,
+                &ReconciliationEventType::AlpacaOnly,
+                symbol,
+                None,
+                Some(Decimal::try_from(position.quantity).unwrap_or(Decimal::ZERO)),
+                None,
+                None,
+                &action,
+                resolved_at,
+            )
+            .await
+            {
+                error!(error = %error, "Failed to persist alpaca_only reconciliation event");
+            }
+        }
+    }
+
+    // --- DB-only pairs: mark closed ---
+    // A pair is DB-only when BOTH its tickers are absent from Alpaca.
+    // If only one leg is missing, that's a quantity/position issue, not a full pair loss.
+    let mut closed_pair_ids: HashSet<uuid::Uuid> = HashSet::new();
+    for pair in &open_pairs {
+        let long_on_alpaca = alpaca_symbols.contains(pair.long_ticker().as_str());
+        let short_on_alpaca = alpaca_symbols.contains(pair.short_ticker().as_str());
+        if !long_on_alpaca && !short_on_alpaca && !closed_pair_ids.contains(&pair.id()) {
+            error!(
+                pair_id = pair.pair_id().as_str(),
+                long_ticker = pair.long_ticker().as_str(),
+                short_ticker = pair.short_ticker().as_str(),
+                "DB pair has no Alpaca positions; marking closed"
+            );
+            let closed_at = Utc::now();
+            if let Err(error) = database::close_equity_pair_with_reason(
+                pool,
+                pair.id(),
+                closed_at,
+                &CloseReason::ReconciliationAlpacaMissing,
+            )
+            .await
+            {
+                error!(error = %error, "Failed to mark DB pair as closed");
+            } else {
+                closed_pair_ids.insert(pair.id());
+                report.pairs_marked_closed += 1;
+            }
+            // Record event for both tickers.
+            for ticker in [pair.long_ticker().as_str(), pair.short_ticker().as_str()] {
+                if let Err(error) = database::insert_reconciliation_event(
+                    pool,
+                    &ReconciliationEventType::DatabaseOnly,
+                    ticker,
+                    None,
+                    None,
+                    Some(pair.id()),
+                    None,
+                    &ReconciliationAction::MarkedPairClosed,
+                    Some(closed_at),
+                )
+                .await
+                {
+                    error!(error = %error, "Failed to persist database_only reconciliation event");
+                }
+            }
+        }
+    }
+
+    // --- Partial position loss: close surviving leg and mark pair closed ---
+    // When only one leg of a pair remains on Alpaca, the hedge is broken and the
+    // portfolio carries naked directional risk. Close the surviving leg and mark
+    // the pair closed to restore a balanced state.
+    for pair in &open_pairs {
+        if closed_pair_ids.contains(&pair.id()) {
+            continue;
+        }
+        let long_on_alpaca = alpaca_symbols.contains(pair.long_ticker().as_str());
+        let short_on_alpaca = alpaca_symbols.contains(pair.short_ticker().as_str());
+        if long_on_alpaca != short_on_alpaca {
+            let missing_ticker = if !long_on_alpaca {
+                pair.long_ticker().as_str()
+            } else {
+                pair.short_ticker().as_str()
+            };
+            let present_ticker = if long_on_alpaca {
+                pair.long_ticker().as_str()
+            } else {
+                pair.short_ticker().as_str()
+            };
+            error!(
+                pair_id = pair.pair_id().as_str(),
+                missing_ticker = missing_ticker,
+                present_ticker = present_ticker,
+                "Partial position: one leg missing; closing surviving leg to eliminate directional risk"
+            );
+
+            // Close the surviving leg on Alpaca.
+            let close_succeeded = match alpaca.close_position(present_ticker).await {
+                Ok(_) => true,
+                Err(close_error) => {
+                    error!(
+                        ticker = present_ticker,
+                        error = %close_error,
+                        "Failed to close surviving leg of partial pair"
+                    );
+                    false
+                }
+            };
+
+            // Mark the pair closed in the DB regardless of whether the Alpaca
+            // close succeeded — the pair is already broken.
+            let closed_at = Utc::now();
+            if let Err(error) = database::close_equity_pair_with_reason(
+                pool,
+                pair.id(),
+                closed_at,
+                &CloseReason::ReconciliationAlpacaMissing,
+            )
+            .await
+            {
+                error!(error = %error, "Failed to mark partial pair as closed");
+            } else {
+                closed_pair_ids.insert(pair.id());
+                report.pairs_marked_closed += 1;
+            }
+
+            let action = if close_succeeded {
+                ReconciliationAction::ClosedOrphan
+            } else {
+                ReconciliationAction::LoggedOnly
+            };
+            let resolved_at = if close_succeeded {
+                Some(closed_at)
+            } else {
+                None
+            };
+
+            if let Err(error) = database::insert_reconciliation_event(
+                pool,
+                &ReconciliationEventType::QuantityMismatch,
+                missing_ticker,
+                None,
+                None,
+                Some(pair.id()),
+                None,
+                &action,
+                resolved_at,
+            )
+            .await
+            {
+                error!(error = %error, "Failed to persist quantity_mismatch reconciliation event");
+            }
+            report.quantity_mismatches_logged += 1;
+        }
+    }
+
+    // --- Stale submitted orders: query Alpaca and resolve ---
+    for order in &stale_orders {
+        report.stale_orders_resolved += resolve_stale_order(pool, alpaca, order).await;
+    }
+
+    // --- Compensation failure retries ---
+    for event in &unresolved_events {
+        if event.event_type() == ReconciliationEventType::CompensationFailure.as_str() {
+            report.compensation_retries += retry_compensation_failure(pool, alpaca, event).await;
+        }
+    }
+
+    info!(
+        orphans_closed = report.orphans_closed,
+        pairs_marked_closed = report.pairs_marked_closed,
+        quantity_mismatches = report.quantity_mismatches_logged,
+        stale_orders_resolved = report.stale_orders_resolved,
+        compensation_retries = report.compensation_retries,
+        "Reconciliation pass completed"
+    );
+
+    Ok(report)
+}
+
+/// Queries Alpaca for a stale submitted order and either confirms the fill
+/// or cancels it. Returns 1 if resolved, 0 otherwise.
+async fn resolve_stale_order(
+    pool: &PgPool,
+    alpaca: &TradingClient,
+    order: &SubmittedOrder,
+) -> usize {
+    let order_result = alpaca.get_order(order.alpaca_order_id()).await;
+    match order_result {
+        Ok(fill) if fill.status == "filled" => {
+            info!(
+                alpaca_order_id = order.alpaca_order_id(),
+                ticker = order.ticker(),
+                "Stale submitted order was actually filled; confirming"
+            );
+            // Mark order as filled in DB (allocation_id is unknown for stale orders,
+            // so we use the order's own ID as a placeholder — the allocation will be
+            // linked when the full persistence path runs).
+            if let Err(error) =
+                database::mark_order_filled(pool, order.id(), order.id(), Utc::now()).await
+            {
+                error!(error = %error, "Failed to mark stale order as filled");
+                return 0;
+            }
+            if let Err(error) = database::insert_reconciliation_event(
+                pool,
+                &ReconciliationEventType::StaleSubmittedOrder,
+                order.ticker(),
+                None,
+                None,
+                None,
+                Some(order.alpaca_order_id()),
+                &ReconciliationAction::ConfirmedFill,
+                Some(Utc::now()),
+            )
+            .await
+            {
+                error!(error = %error, "Failed to persist stale_submitted_order event");
+            }
+            1
+        }
+        Ok(fill) if is_terminal_non_filled(&fill.status) => {
+            info!(
+                alpaca_order_id = order.alpaca_order_id(),
+                status = fill.status.as_str(),
+                "Stale submitted order in terminal non-filled state; marking cancelled"
+            );
+            if let Err(error) = database::mark_order_cancelled(pool, order.id()).await {
+                error!(error = %error, "Failed to mark stale order as cancelled");
+                return 0;
+            }
+            if let Err(error) = database::insert_reconciliation_event(
+                pool,
+                &ReconciliationEventType::StaleSubmittedOrder,
+                order.ticker(),
+                None,
+                None,
+                None,
+                Some(order.alpaca_order_id()),
+                &ReconciliationAction::CancelledStaleOrder,
+                Some(Utc::now()),
+            )
+            .await
+            {
+                error!(error = %error, "Failed to persist stale_submitted_order event");
+            }
+            1
+        }
+        Ok(fill) => {
+            // Order is still open on Alpaca — attempt to cancel it.
+            warn!(
+                alpaca_order_id = order.alpaca_order_id(),
+                status = fill.status.as_str(),
+                "Stale submitted order still open; attempting cancel"
+            );
+            match alpaca.cancel_order(order.alpaca_order_id()).await {
+                Ok(true) => {
+                    if let Err(error) = database::mark_order_cancelled(pool, order.id()).await {
+                        error!(error = %error, "Failed to mark cancelled stale order in DB");
+                    }
+                    if let Err(error) = database::insert_reconciliation_event(
+                        pool,
+                        &ReconciliationEventType::StaleSubmittedOrder,
+                        order.ticker(),
+                        None,
+                        None,
+                        None,
+                        Some(order.alpaca_order_id()),
+                        &ReconciliationAction::CancelledStaleOrder,
+                        Some(Utc::now()),
+                    )
+                    .await
+                    {
+                        error!(error = %error, "Failed to persist stale_submitted_order event");
+                    }
+                    1
+                }
+                Ok(false) => {
+                    // Order is in terminal state now (race between get_order and cancel).
+                    // Re-check on next reconciliation pass.
+                    warn!(
+                        alpaca_order_id = order.alpaca_order_id(),
+                        "Cancel returned false; will retry on next reconciliation pass"
+                    );
+                    0
+                }
+                Err(error) => {
+                    error!(
+                        alpaca_order_id = order.alpaca_order_id(),
+                        error = %error,
+                        "Failed to cancel stale order"
+                    );
+                    0
+                }
+            }
+        }
+        Err(error) => {
+            error!(
+                alpaca_order_id = order.alpaca_order_id(),
+                error = %error,
+                "Failed to query Alpaca for stale order status"
+            );
+            0
+        }
+    }
+}
+
+/// Returns `true` for Alpaca order statuses that are terminal but not filled.
+fn is_terminal_non_filled(status: &str) -> bool {
+    matches!(
+        status,
+        "cancelled" | "expired" | "rejected" | "replaced" | "canceled"
+    )
+}
+
+/// Retries a prior compensation failure by attempting to close the position.
+/// Returns 1 if the retry succeeded and the event was resolved, 0 otherwise.
+async fn retry_compensation_failure(
+    pool: &PgPool,
+    alpaca: &TradingClient,
+    event: &UnresolvedReconciliationEvent,
+) -> usize {
+    info!(
+        event_id = event.id(),
+        ticker = event.ticker(),
+        "Retrying compensation failure"
+    );
+
+    // First try to cancel the order if we have an order ID.
+    if let Some(alpaca_order_id) = event.alpaca_order_id() {
+        match alpaca.cancel_order(alpaca_order_id).await {
+            Ok(true) => {
+                info!(
+                    alpaca_order_id = alpaca_order_id,
+                    "Orphaned order cancelled on retry"
+                );
+                if let Err(error) = database::resolve_reconciliation_event(pool, event.id()).await {
+                    error!(error = %error, "Failed to resolve compensation event");
+                }
+                return 1;
+            }
+            Ok(false) => {
+                // Terminal state — fall through to close position.
+            }
+            Err(error) => {
+                warn!(error = %error, "Cancel retry failed; trying close_position");
+            }
+        }
+    }
+
+    // Fall back to closing the position directly.
+    match alpaca.close_position(event.ticker()).await {
+        Ok(_) => {
+            info!(ticker = event.ticker(), "Orphaned position closed on retry");
+            if let Err(error) = database::resolve_reconciliation_event(pool, event.id()).await {
+                error!(error = %error, "Failed to resolve compensation event");
+            }
+            1
+        }
+        Err(error) => {
+            error!(
+                ticker = event.ticker(),
+                event_id = event.id(),
+                error = %error,
+                "Compensation retry failed again"
+            );
+            0
+        }
+    }
+}
+
+/// Error from the reconciliation process.
+#[derive(Debug)]
+pub enum ReconciliationError {
+    /// Failed to fetch positions from Alpaca.
+    AlpacaFetch(crate::portfolio::alpaca::ClientError),
+    /// Database query failed.
+    Database(sqlx::Error),
+}
+
+impl std::fmt::Display for ReconciliationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlpacaFetch(error) => {
+                write!(formatter, "Alpaca position fetch failed: {error}")
+            }
+            Self::Database(error) => {
+                write!(formatter, "Database error during reconciliation: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ReconciliationError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_terminal_non_filled_recognizes_all_terminal_states() {
+        assert!(is_terminal_non_filled("cancelled"));
+        assert!(is_terminal_non_filled("canceled"));
+        assert!(is_terminal_non_filled("expired"));
+        assert!(is_terminal_non_filled("rejected"));
+        assert!(is_terminal_non_filled("replaced"));
+    }
+
+    #[test]
+    fn test_is_terminal_non_filled_rejects_non_terminal() {
+        assert!(!is_terminal_non_filled("new"));
+        assert!(!is_terminal_non_filled("partially_filled"));
+        assert!(!is_terminal_non_filled("filled"));
+        assert!(!is_terminal_non_filled("accepted"));
+    }
+
+    #[test]
+    fn test_reconciliation_report_default_zeros() {
+        let report = ReconciliationReport {
+            orphans_closed: 0,
+            pairs_marked_closed: 0,
+            quantity_mismatches_logged: 0,
+            stale_orders_resolved: 0,
+            compensation_retries: 0,
+        };
+        assert_eq!(report.orphans_closed, 0);
+        assert_eq!(report.pairs_marked_closed, 0);
+        assert_eq!(report.quantity_mismatches_logged, 0);
+        assert_eq!(report.stale_orders_resolved, 0);
+        assert_eq!(report.compensation_retries, 0);
+    }
+
+    #[test]
+    fn test_reconciliation_error_display_alpaca_fetch() {
+        let error = ReconciliationError::AlpacaFetch(crate::portfolio::alpaca::ClientError::Parse(
+            "connection refused".to_string(),
+        ));
+        let message = format!("{error}");
+        assert!(message.contains("Alpaca position fetch failed"));
+        assert!(message.contains("connection refused"));
+    }
+
+    #[test]
+    fn test_reconciliation_error_display_database() {
+        let error = ReconciliationError::Database(sqlx::Error::RowNotFound);
+        let message = format!("{error}");
+        assert!(message.contains("Database error during reconciliation"));
+    }
+
+    #[test]
+    fn test_reconciliation_error_is_error_trait() {
+        let error = ReconciliationError::AlpacaFetch(crate::portfolio::alpaca::ClientError::Parse(
+            "test".to_string(),
+        ));
+        let _boxed: Box<dyn std::error::Error> = Box::new(error);
+    }
+
+    #[test]
+    fn test_stale_order_threshold_is_reasonable() {
+        const _: () = assert!(STALE_ORDER_THRESHOLD_SECONDS >= 30);
+        const _: () = assert!(STALE_ORDER_THRESHOLD_SECONDS <= 300);
+    }
+}

--- a/src/portfolio/reconciliation.rs
+++ b/src/portfolio/reconciliation.rs
@@ -8,6 +8,7 @@
 //! Discrepancy categories:
 //! - **Alpaca-only**: Alpaca holds a position the DB does not track → close orphan.
 //! - **DB-only**: DB has an open pair but Alpaca has no position → mark pair closed.
+//! - **Partial position loss**: One leg of a pair is missing → close surviving leg.
 //! - **Quantity mismatch**: Both agree the ticker is held, but quantities differ → log only.
 //! - **Stale submitted order**: An order exceeded the staleness threshold → query Alpaca
 //!   and either confirm fill or cancel.
@@ -22,7 +23,7 @@ use tracing::{error, info, warn};
 
 use crate::domain::trading::{CloseReason, ReconciliationAction, ReconciliationEventType};
 use crate::portfolio::alpaca::{Position, TradingClient};
-use crate::portfolio::database::{self, OpenPair, SubmittedOrder, UnresolvedReconciliationEvent};
+use crate::portfolio::database::{self, SubmittedOrder, UnresolvedReconciliationEvent};
 
 /// Default staleness threshold for submitted orders (seconds).
 const STALE_ORDER_THRESHOLD_SECONDS: i64 = 60;
@@ -34,6 +35,8 @@ pub struct ReconciliationReport {
     pub orphans_closed: usize,
     /// Number of DB pairs marked closed because Alpaca no longer holds them.
     pub pairs_marked_closed: usize,
+    /// Number of partial position losses handled (surviving leg closed).
+    pub partial_positions_closed: usize,
     /// Number of quantity mismatches logged.
     pub quantity_mismatches_logged: usize,
     /// Number of stale submitted orders resolved (confirmed or cancelled).
@@ -80,24 +83,15 @@ pub async fn reconcile(
 
     // Collect all tickers from open pairs (both long and short legs).
     let mut database_symbols: HashSet<String> = HashSet::new();
-    // Map from ticker to (pair_id, expected side) for pair-level tracking.
-    let mut ticker_to_pair: HashMap<String, Vec<&OpenPair>> = HashMap::new();
     for pair in &open_pairs {
         database_symbols.insert(pair.long_ticker().as_str().to_string());
         database_symbols.insert(pair.short_ticker().as_str().to_string());
-        ticker_to_pair
-            .entry(pair.long_ticker().as_str().to_string())
-            .or_default()
-            .push(pair);
-        ticker_to_pair
-            .entry(pair.short_ticker().as_str().to_string())
-            .or_default()
-            .push(pair);
     }
 
     let mut report = ReconciliationReport {
         orphans_closed: 0,
         pairs_marked_closed: 0,
+        partial_positions_closed: 0,
         quantity_mismatches_logged: 0,
         stale_orders_resolved: 0,
         compensation_retries: 0,
@@ -136,7 +130,17 @@ pub async fn reconcile(
                 &ReconciliationEventType::AlpacaOnly,
                 symbol,
                 None,
-                Some(Decimal::try_from(position.quantity).unwrap_or(Decimal::ZERO)),
+                Some(
+                    Decimal::try_from(position.quantity).unwrap_or_else(|error| {
+                        error!(
+                            ticker = *symbol,
+                            quantity = position.quantity,
+                            error = %error,
+                            "Failed to convert position quantity to Decimal"
+                        );
+                        Decimal::ZERO
+                    }),
+                ),
                 None,
                 None,
                 &action,
@@ -200,8 +204,8 @@ pub async fn reconcile(
 
     // --- Partial position loss: close surviving leg and mark pair closed ---
     // When only one leg of a pair remains on Alpaca, the hedge is broken and the
-    // portfolio carries naked directional risk. Close the surviving leg and mark
-    // the pair closed to restore a balanced state.
+    // portfolio carries naked directional risk. Close the surviving leg (if no
+    // other open pair also uses that ticker) and mark the pair closed.
     for pair in &open_pairs {
         if closed_pair_ids.contains(&pair.id()) {
             continue;
@@ -219,49 +223,75 @@ pub async fn reconcile(
             } else {
                 pair.short_ticker().as_str()
             };
-            error!(
-                pair_id = pair.pair_id().as_str(),
-                missing_ticker = missing_ticker,
-                present_ticker = present_ticker,
-                "Partial position: one leg missing; closing surviving leg to eliminate directional risk"
-            );
 
-            // Close the surviving leg on Alpaca.
-            let close_succeeded = match alpaca.close_position(present_ticker).await {
-                Ok(_) => true,
-                Err(close_error) => {
-                    error!(
-                        ticker = present_ticker,
-                        error = %close_error,
-                        "Failed to close surviving leg of partial pair"
-                    );
-                    false
+            // Check if any other open pair (not already closed) also uses the
+            // surviving ticker. If so, skip the close — the position is still
+            // needed by the other pair.
+            let ticker_shared_by_other_pair = open_pairs.iter().any(|other| {
+                other.id() != pair.id()
+                    && !closed_pair_ids.contains(&other.id())
+                    && (other.long_ticker().as_str() == present_ticker
+                        || other.short_ticker().as_str() == present_ticker)
+            });
+
+            if ticker_shared_by_other_pair {
+                warn!(
+                    pair_id = pair.pair_id().as_str(),
+                    present_ticker = present_ticker,
+                    "Surviving leg shared by another open pair; skipping close, marking pair closed only"
+                );
+            } else {
+                error!(
+                    pair_id = pair.pair_id().as_str(),
+                    missing_ticker = missing_ticker,
+                    present_ticker = present_ticker,
+                    "Partial position: one leg missing; closing surviving leg to eliminate directional risk"
+                );
+            }
+
+            // Close the surviving leg on Alpaca unless another pair needs it.
+            let close_succeeded = if ticker_shared_by_other_pair {
+                false
+            } else {
+                match alpaca.close_position(present_ticker).await {
+                    Ok(_) => true,
+                    Err(close_error) => {
+                        error!(
+                            ticker = present_ticker,
+                            error = %close_error,
+                            "Failed to close surviving leg of partial pair"
+                        );
+                        false
+                    }
                 }
             };
 
-            // Mark the pair closed in the DB regardless of whether the Alpaca
-            // close succeeded — the pair is already broken.
+            // Only mark pair closed in DB when the close succeeds or when the
+            // ticker is shared (the position belongs to another pair). If the
+            // close failed, leave the pair open so compensation retry picks it up.
             let closed_at = Utc::now();
-            if let Err(error) = database::close_equity_pair_with_reason(
-                pool,
-                pair.id(),
-                closed_at,
-                &CloseReason::ReconciliationAlpacaMissing,
-            )
-            .await
-            {
-                error!(error = %error, "Failed to mark partial pair as closed");
-            } else {
-                closed_pair_ids.insert(pair.id());
-                report.pairs_marked_closed += 1;
+            if close_succeeded || ticker_shared_by_other_pair {
+                if let Err(error) = database::close_equity_pair_with_reason(
+                    pool,
+                    pair.id(),
+                    closed_at,
+                    &CloseReason::ReconciliationAlpacaMissing,
+                )
+                .await
+                {
+                    error!(error = %error, "Failed to mark partial pair as closed");
+                } else {
+                    closed_pair_ids.insert(pair.id());
+                    report.pairs_marked_closed += 1;
+                }
             }
 
             let action = if close_succeeded {
-                ReconciliationAction::ClosedOrphan
+                ReconciliationAction::ClosedSurvivingLeg
             } else {
                 ReconciliationAction::LoggedOnly
             };
-            let resolved_at = if close_succeeded {
+            let resolved_at = if close_succeeded || ticker_shared_by_other_pair {
                 Some(closed_at)
             } else {
                 None
@@ -269,7 +299,7 @@ pub async fn reconcile(
 
             if let Err(error) = database::insert_reconciliation_event(
                 pool,
-                &ReconciliationEventType::QuantityMismatch,
+                &ReconciliationEventType::PartialPositionLoss,
                 missing_ticker,
                 None,
                 None,
@@ -280,9 +310,9 @@ pub async fn reconcile(
             )
             .await
             {
-                error!(error = %error, "Failed to persist quantity_mismatch reconciliation event");
+                error!(error = %error, "Failed to persist partial_position_loss reconciliation event");
             }
-            report.quantity_mismatches_logged += 1;
+            report.partial_positions_closed += 1;
         }
     }
 
@@ -301,6 +331,7 @@ pub async fn reconcile(
     info!(
         orphans_closed = report.orphans_closed,
         pairs_marked_closed = report.pairs_marked_closed,
+        partial_positions_closed = report.partial_positions_closed,
         quantity_mismatches = report.quantity_mismatches_logged,
         stale_orders_resolved = report.stale_orders_resolved,
         compensation_retries = report.compensation_retries,
@@ -325,11 +356,10 @@ async fn resolve_stale_order(
                 ticker = order.ticker(),
                 "Stale submitted order was actually filled; confirming"
             );
-            // Mark order as filled in DB (allocation_id is unknown for stale orders,
-            // so we use the order's own ID as a placeholder — the allocation will be
-            // linked when the full persistence path runs).
+            // Mark order as filled in DB. allocation_id is None because stale
+            // orders resolved by reconciliation have no associated allocation.
             if let Err(error) =
-                database::mark_order_filled(pool, order.id(), order.id(), Utc::now()).await
+                database::mark_order_filled(pool, order.id(), None, Utc::now()).await
             {
                 error!(error = %error, "Failed to mark stale order as filled");
                 return 0;
@@ -467,7 +497,8 @@ async fn retry_compensation_failure(
                     "Orphaned order cancelled on retry"
                 );
                 if let Err(error) = database::resolve_reconciliation_event(pool, event.id()).await {
-                    error!(error = %error, "Failed to resolve compensation event");
+                    error!(error = %error, "Failed to resolve compensation event after cancel; will retry");
+                    return 0;
                 }
                 return 1;
             }
@@ -485,7 +516,8 @@ async fn retry_compensation_failure(
         Ok(_) => {
             info!(ticker = event.ticker(), "Orphaned position closed on retry");
             if let Err(error) = database::resolve_reconciliation_event(pool, event.id()).await {
-                error!(error = %error, "Failed to resolve compensation event");
+                error!(error = %error, "Failed to resolve compensation event after close; will retry");
+                return 0;
             }
             1
         }
@@ -551,12 +583,14 @@ mod tests {
         let report = ReconciliationReport {
             orphans_closed: 0,
             pairs_marked_closed: 0,
+            partial_positions_closed: 0,
             quantity_mismatches_logged: 0,
             stale_orders_resolved: 0,
             compensation_retries: 0,
         };
         assert_eq!(report.orphans_closed, 0);
         assert_eq!(report.pairs_marked_closed, 0);
+        assert_eq!(report.partial_positions_closed, 0);
         assert_eq!(report.quantity_mismatches_logged, 0);
         assert_eq!(report.stale_orders_resolved, 0);
         assert_eq!(report.compensation_retries, 0);


### PR DESCRIPTION
# Overview

## Changes

- Add `equity_reconciliation_events` table to `schema.sql` with indexed unresolved event lookup, event types (`alpaca_only`, `database_only`, `quantity_mismatch`, `compensation_failure`, `stale_submitted_order`), and action types (`closed_orphan`, `marked_pair_closed`, `confirmed_fill`, `cancelled_stale_order`, `logged_only`)
- Create `src/portfolio/reconciliation.rs` with a stateless, idempotent `reconcile()` function that compares DB open pairs against Alpaca positions, resolves stale submitted orders, retries compensation failures, and closes surviving legs of broken hedges
- Add `ReconciliationEventType` and `ReconciliationAction` enums to `src/domain/trading.rs`
- Add `insert_reconciliation_event`, `fetch_unresolved_reconciliation_events`, and `resolve_reconciliation_event` to `src/portfolio/database.rs`
- Replace the inline symmetric mismatch detection in `rebalance.rs` with a `reconcile()` call that handles all discrepancy types before deciding the build/monitor path
- Add startup reconciliation in `consumer.rs` before event catch-up so drift accumulated while the service was down is resolved immediately
- Wire compensation failures in `execution.rs` to persist `compensation_failure` events when both `cancel_order` and `close_position` fail, enabling automatic retry on the next reconciliation pass
- Close surviving leg and mark pair closed when one leg of a pair is missing from Alpaca, eliminating naked directional risk from broken hedges
- Add `quantity` field to `Position` struct in `alpaca.rs` for reconciliation comparison support

## Context

This is the second and final PR for Phase 0 Project 2 (Database-Alpaca Sync Hardening). The first PR (#1012) added symmetric mismatch detection, durable order tracking, and fill polling improvements. This PR completes the project by adding the reconciliation module (plan PRs 3 and 4), which ties all the prior work together into a unified reconciliation system.

The `reconcile()` function is stateless and idempotent -- it can run at any cadence without behavioral changes. All corrective actions check current state before acting, so repeated calls against the same discrepancy are safe. The schema and event contract are designed for Phase 2b's continuous risk monitor to upgrade reconciliation from periodic to event-driven without migration.

Discrepancy handling:
- **Alpaca-only positions**: Close the orphan on Alpaca, record `closed_orphan` event
- **DB-only pairs** (both legs missing): Mark pair closed with `reconciliation_alpaca_missing`, record `marked_pair_closed` event
- **Partial position** (one leg missing): Close surviving leg to eliminate directional risk, mark pair closed
- **Stale submitted orders**: Query Alpaca for current status; confirm fill or cancel; record event
- **Compensation failures**: Retry cancel/close on each reconciliation pass until resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated reconciliation between portfolio records and broker positions.
  * Added startup checks to detect and resolve orphaned positions, missing pair legs, stale orders, and quantity mismatches.
  * Added persistent tracking and retry handling for unresolved reconciliation and compensation failures.
  * Position data now includes share quantities, including correct handling of short positions.
* **Reliability**
  * Failed order cancellation and position-closing attempts are recorded for later retry.
  * Reconciliation failures are logged while allowing normal processing to continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**Updated action/event types (added in review feedback commits):**
- Event type: `partial_position_loss` — one leg of a pair missing from Alpaca
- Action: `closed_surviving_leg` — closed the remaining leg to eliminate directional risk