### PR TITLE
Add graceful shutdown with `CancellationToken`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2885,6 +2885,7 @@ dependencies = [
  "testcontainers-modules",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-util",
  "tower",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ sqlx = { version = "0.8", default-features = false, features = [
   "json",
 ] }
 tokio = { version = "1.51.1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.23", features = [
   "env-filter",

--- a/devenv.nix
+++ b/devenv.nix
@@ -662,6 +662,8 @@ in {
         exec secretspec run -- cargo run --release --bin fund -- --module data
       '';
       process-compose.depends_on.schema.condition = "process_completed_successfully";
+      process-compose.shutdown.signal = 15;
+      process-compose.shutdown.timeout_seconds = 60;
     };
 
     processes.inference = {
@@ -671,6 +673,8 @@ in {
         exec secretspec run -- cargo run --release --bin fund -- --module inference
       '';
       process-compose.depends_on.schema.condition = "process_completed_successfully";
+      process-compose.shutdown.signal = 15;
+      process-compose.shutdown.timeout_seconds = 120;
     };
 
     processes.portfolio = {
@@ -680,6 +684,8 @@ in {
         exec secretspec run -- cargo run --release --bin fund -- --module portfolio
       '';
       process-compose.depends_on.schema.condition = "process_completed_successfully";
+      process-compose.shutdown.signal = 15;
+      process-compose.shutdown.timeout_seconds = 120;
     };
 
     processes.dashboard = {

--- a/src/bin/fund.rs
+++ b/src/bin/fund.rs
@@ -8,7 +8,7 @@
 
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 const USAGE: &str = "Usage: fund [--module <data|inference|portfolio>]";
 
@@ -88,12 +88,22 @@ async fn run(module: Option<Module>) -> Result<(), Box<dyn std::error::Error>> {
 
     let s3_client = fund::common::aws::s3_client().await;
 
-    let shutdown_token = CancellationToken::new();
-    let mut handles: Vec<JoinHandle<()>> = Vec::new();
-
     let run_data = module.is_none() || module == Some(Module::Data);
     let run_inference = module.is_none() || module == Some(Module::Inference);
     let run_portfolio = module.is_none() || module == Some(Module::Portfolio);
+
+    // Construct fallible state objects before spawning any tasks so that a
+    // configuration error (e.g. missing ALPACA_API_KEY_ID) aborts before any
+    // background work starts, rather than leaving already-spawned tasks to be
+    // killed without draining.
+    let portfolio_state = if run_portfolio {
+        Some(fund::portfolio::state::AppState::with_pool(pool.clone())?)
+    } else {
+        None
+    };
+
+    let shutdown_token = CancellationToken::new();
+    let mut handles: Vec<JoinHandle<()>> = Vec::new();
 
     if run_data {
         let state = fund::data::state::State::with_pool(pool.clone(), s3_client.clone());
@@ -119,8 +129,7 @@ async fn run(module: Option<Module>) -> Result<(), Box<dyn std::error::Error>> {
         info!("Inference service started");
     }
 
-    if run_portfolio {
-        let state = fund::portfolio::state::AppState::with_pool(pool)?;
+    if let Some(state) = portfolio_state {
         handles.push(fund::portfolio::consumer::spawn_event_consumer(
             state,
             shutdown_token.clone(),
@@ -134,7 +143,9 @@ async fn run(module: Option<Module>) -> Result<(), Box<dyn std::error::Error>> {
     shutdown_token.cancel();
 
     for handle in handles {
-        let _ = handle.await;
+        if let Err(error) = handle.await {
+            warn!(error = %error, "Task failed during shutdown");
+        }
     }
 
     info!("Shutdown complete");
@@ -146,11 +157,17 @@ async fn await_shutdown_signal() {
     #[cfg(unix)]
     {
         use tokio::signal::unix::{signal, SignalKind};
-        let mut sigterm =
-            signal(SignalKind::terminate()).expect("Failed to install SIGTERM handler");
-        tokio::select! {
-            _ = tokio::signal::ctrl_c() => {}
-            _ = sigterm.recv() => {}
+        match signal(SignalKind::terminate()) {
+            Ok(mut sigterm) => {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {}
+                    _ = sigterm.recv() => {}
+                }
+            }
+            Err(error) => {
+                warn!(error = %error, "Failed to install SIGTERM handler, falling back to Ctrl+C only");
+                let _ = tokio::signal::ctrl_c().await;
+            }
         }
     }
 
@@ -187,7 +204,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_shutdown_signal_cancels_token() {
+    async fn test_cancellation_token_propagates_to_child() {
         let token = CancellationToken::new();
         let child = token.child_token();
 
@@ -195,5 +212,29 @@ mod tests {
         token.cancel();
         child.cancelled().await;
         assert!(child.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_cancel_token_drains_spawned_tasks() {
+        let token = CancellationToken::new();
+        let completed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let completed_clone = completed.clone();
+
+        let handle = tokio::spawn({
+            let token = token.clone();
+            async move {
+                token.cancelled().await;
+                completed_clone.store(true, std::sync::atomic::Ordering::SeqCst);
+            }
+        });
+
+        // Task should be waiting on cancellation.
+        tokio::task::yield_now().await;
+        assert!(!completed.load(std::sync::atomic::Ordering::SeqCst));
+
+        // Cancel and await — task should complete.
+        token.cancel();
+        handle.await.unwrap();
+        assert!(completed.load(std::sync::atomic::Ordering::SeqCst));
     }
 }

--- a/src/bin/fund.rs
+++ b/src/bin/fund.rs
@@ -6,6 +6,8 @@
 //! own log stream and TUI panel while still sharing the same PostgreSQL
 //! event bus for inter-service coordination.
 
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 const USAGE: &str = "Usage: fund [--module <data|inference|portfolio>]";
@@ -86,36 +88,78 @@ async fn run(module: Option<Module>) -> Result<(), Box<dyn std::error::Error>> {
 
     let s3_client = fund::common::aws::s3_client().await;
 
+    let shutdown_token = CancellationToken::new();
+    let mut handles: Vec<JoinHandle<()>> = Vec::new();
+
     let run_data = module.is_none() || module == Some(Module::Data);
     let run_inference = module.is_none() || module == Some(Module::Inference);
     let run_portfolio = module.is_none() || module == Some(Module::Portfolio);
 
     if run_data {
         let state = fund::data::state::State::with_pool(pool.clone(), s3_client.clone());
-        fund::data::scheduler::spawn_sync_scheduler(state.clone());
+        let data_handles =
+            fund::data::scheduler::spawn_sync_scheduler(state.clone(), shutdown_token.clone());
+        handles.extend(data_handles);
         info!("Data service started");
     }
 
     if run_inference {
         let state = fund::inference::state::AppState::with_pool(pool.clone(), s3_client.clone());
         fund::inference::pipeline::poll_artifact_once(&state).await;
-        tokio::spawn(fund::inference::pipeline::start_artifact_polling(
-            state.clone(),
+        handles.push(tokio::spawn(
+            fund::inference::pipeline::start_artifact_polling(
+                state.clone(),
+                shutdown_token.clone(),
+            ),
         ));
-        fund::inference::consumer::spawn_event_consumer(state);
+        handles.extend(fund::inference::consumer::spawn_event_consumer(
+            state,
+            shutdown_token.clone(),
+        ));
         info!("Inference service started");
     }
 
     if run_portfolio {
         let state = fund::portfolio::state::AppState::with_pool(pool)?;
-        fund::portfolio::consumer::spawn_event_consumer(state);
+        handles.push(fund::portfolio::consumer::spawn_event_consumer(
+            state,
+            shutdown_token.clone(),
+        ));
         info!("Portfolio service started");
     }
 
     info!("Waiting for events");
-    tokio::signal::ctrl_c().await?;
-    info!("Shutting down");
+    await_shutdown_signal().await;
+    info!("Shutdown signal received, waiting for consumers to drain");
+    shutdown_token.cancel();
+
+    for handle in handles {
+        let _ = handle.await;
+    }
+
+    info!("Shutdown complete");
     Ok(())
+}
+
+/// Waits for either SIGTERM or Ctrl+C (SIGINT).
+async fn await_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigterm =
+            signal(SignalKind::terminate()).expect("Failed to install SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("Failed to listen for Ctrl+C");
+    }
 }
 
 #[cfg(test)]
@@ -140,5 +184,16 @@ mod tests {
         for module in [Module::Data, Module::Inference, Module::Portfolio] {
             assert_eq!(Module::parse(module.as_str()).unwrap(), module);
         }
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_signal_cancels_token() {
+        let token = CancellationToken::new();
+        let child = token.child_token();
+
+        // Cancelling the parent token should resolve the child.
+        token.cancel();
+        child.cancelled().await;
+        assert!(child.is_cancelled());
     }
 }

--- a/src/data/scheduler.rs
+++ b/src/data/scheduler.rs
@@ -78,6 +78,10 @@ fn export_date_from_payload(payload: &serde_json::Value) -> NaiveDate {
         .unwrap_or_else(|| Utc::now().date_naive())
 }
 
+/// Spawns the data sync scheduler loops as background tasks.
+///
+/// Returns join handles that callers must await after cancelling the
+/// `shutdown_token` to allow in-flight work to drain before exit.
 pub fn spawn_sync_scheduler(
     state: State,
     shutdown_token: CancellationToken,
@@ -186,6 +190,10 @@ async fn run_listener(
     let mut listener = PgListener::connect_with(pool).await?;
     listener.listen("events").await?;
     info!("Event consumer connected, listening on channel 'events'");
+
+    if shutdown_token.is_cancelled() {
+        return Ok(());
+    }
 
     // Catch up on any missed one-time actionable events (latest missed instance each).
     let sync_offset = get_consumer_offset(pool, CONSUMER_DATA_EQUITY_BARS_SYNC).await?;

--- a/src/data/scheduler.rs
+++ b/src/data/scheduler.rs
@@ -12,7 +12,9 @@ use chrono::{DateTime, Datelike, NaiveDate, NaiveTime, TimeZone, Utc, Weekday};
 use chrono_tz::US::Eastern;
 use sqlx::postgres::PgListener;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 const SYNC_HOUR: u32 = 1;
@@ -76,15 +78,20 @@ fn export_date_from_payload(payload: &serde_json::Value) -> NaiveDate {
         .unwrap_or_else(|| Utc::now().date_naive())
 }
 
-pub fn spawn_sync_scheduler(state: State) {
+pub fn spawn_sync_scheduler(
+    state: State,
+    shutdown_token: CancellationToken,
+) -> Vec<JoinHandle<()>> {
     let listen_state = state.clone();
+    let mut handles = Vec::new();
     // sync_loop is a fallback timer-based scheduler used only when PostgreSQL is
     // unavailable (e.g., local development without a database). In production the
     // pg_cron + LISTEN/NOTIFY path (listen_loop) is the sole trigger mechanism.
     if !state.database.is_configured() {
-        tokio::spawn(sync_loop(state));
+        handles.push(tokio::spawn(sync_loop(state, shutdown_token.clone())));
     }
-    tokio::spawn(listen_loop(listen_state));
+    handles.push(tokio::spawn(listen_loop(listen_state, shutdown_token)));
+    handles
 }
 
 async fn run_equity_bar_sync(state: &State) -> Result<Option<usize>, String> {
@@ -96,14 +103,24 @@ async fn run_equity_bar_sync(state: &State) -> Result<Option<usize>, String> {
     fetch_and_store_equity_bars(state, &trading_date).await
 }
 
-async fn sync_loop(state: State) {
+async fn sync_loop(state: State, shutdown_token: CancellationToken) {
     loop {
         let wait_duration = duration_until_next_sync(Utc::now());
         info!(
             seconds = wait_duration.as_secs(),
             "Waiting for next equity bar sync"
         );
-        sleep(wait_duration).await;
+        tokio::select! {
+            _ = sleep(wait_duration) => {}
+            _ = shutdown_token.cancelled() => {
+                info!("Sync loop stopped for shutdown");
+                break;
+            }
+        }
+
+        if shutdown_token.is_cancelled() {
+            break;
+        }
 
         if state.synced_recently(SYNC_DEDUP_TTL_SECS) {
             info!("Skipping sync loop run, synced recently");
@@ -125,7 +142,7 @@ async fn sync_loop(state: State) {
     }
 }
 
-async fn listen_loop(state: State) {
+async fn listen_loop(state: State, shutdown_token: CancellationToken) {
     let pool = match state.database.pool() {
         Some(pool) => pool.clone(),
         None => {
@@ -135,19 +152,37 @@ async fn listen_loop(state: State) {
     };
 
     loop {
-        match run_listener(&state, &pool).await {
+        match run_listener(&state, &pool, &shutdown_token).await {
             Ok(()) => {
+                if shutdown_token.is_cancelled() {
+                    info!("LISTEN handler stopped for shutdown");
+                    break;
+                }
                 info!("LISTEN handler exited, restarting");
             }
             Err(error) => {
+                if shutdown_token.is_cancelled() {
+                    info!("LISTEN handler stopped for shutdown");
+                    break;
+                }
                 warn!("LISTEN handler error: {}, restarting in 30s", error);
-                sleep(Duration::from_secs(30)).await;
+                tokio::select! {
+                    _ = sleep(Duration::from_secs(30)) => {}
+                    _ = shutdown_token.cancelled() => {
+                        info!("LISTEN handler stopped for shutdown");
+                        break;
+                    }
+                }
             }
         }
     }
 }
 
-async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
+async fn run_listener(
+    state: &State,
+    pool: &sqlx::PgPool,
+    shutdown_token: &CancellationToken,
+) -> Result<(), sqlx::Error> {
     let mut listener = PgListener::connect_with(pool).await?;
     listener.listen("events").await?;
     info!("Event consumer connected, listening on channel 'events'");
@@ -205,7 +240,13 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
 
     // Main event loop.
     loop {
-        let notification = listener.recv().await?;
+        let notification = tokio::select! {
+            result = listener.recv() => result?,
+            _ = shutdown_token.cancelled() => {
+                info!("Shutdown signal received, draining");
+                break;
+            }
+        };
         let parsed: serde_json::Value = match serde_json::from_str(notification.payload()) {
             Ok(value) => value,
             Err(_) => continue,
@@ -236,6 +277,8 @@ async fn run_listener(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Er
             handle_database_backup(state, pool, event_id).await;
         }
     }
+
+    Ok(())
 }
 
 async fn handle_equity_bars_sync(state: &State, pool: &sqlx::PgPool, event_id: i64) {
@@ -616,6 +659,7 @@ mod tests {
     use chrono::{NaiveDate, TimeZone, Utc};
     use chrono_tz::US::Eastern;
     use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
 
     /// RAII guard that removes an environment variable for the duration of a test
     /// and restores the original value (or absence) on drop.
@@ -1080,7 +1124,8 @@ mod tests {
             "test-bucket".to_string(),
         );
         // listen_loop must return immediately (no pool configured).
-        listen_loop(state).await;
+        let token = CancellationToken::new();
+        listen_loop(state, token).await;
     }
 
     #[tokio::test]
@@ -1116,9 +1161,13 @@ mod tests {
         // DatabaseState::NotConfigured so is_configured() == false, which
         // causes both the sync_loop and listen_loop tasks to be spawned.
         // listen_loop returns immediately without a pool.
-        spawn_sync_scheduler(state);
-        // Yield once so the spawned listen_loop task can run to completion.
-        tokio::task::yield_now().await;
+        let token = CancellationToken::new();
+        let handles = spawn_sync_scheduler(state, token.clone());
+        // Cancel so the sync_loop task exits its sleep and terminates.
+        token.cancel();
+        for handle in handles {
+            let _ = handle.await;
+        }
     }
 
     #[test]

--- a/src/inference/consumer.rs
+++ b/src/inference/consumer.rs
@@ -23,8 +23,9 @@ use crate::inference::state::AppState;
 
 /// Spawn the event consumer if a database pool is configured.
 ///
-/// Returns the join handle for the spawned task, or an empty vec if no pool
-/// is available.
+/// Returns join handles for the spawned tasks, or an empty vec if no pool
+/// is available. Callers must cancel the `shutdown_token` and then await the
+/// returned handles for graceful shutdown.
 pub fn spawn_event_consumer(
     state: AppState,
     shutdown_token: CancellationToken,
@@ -78,6 +79,10 @@ async fn run_consumer(
     let mut listener = PgListener::connect_with(pool).await?;
     listener.listen("events").await?;
     info!("Event consumer connected, listening on channel 'events'");
+
+    if shutdown_token.is_cancelled() {
+        return Ok(());
+    }
 
     // Catch up on an equity_predictions_requested that arrived while we were down.
     let offset = get_consumer_offset(pool, CONSUMER_INFERENCE).await?;

--- a/src/inference/consumer.rs
+++ b/src/inference/consumer.rs
@@ -9,7 +9,9 @@ use std::time::Duration;
 
 use sqlx::postgres::PgListener;
 use sqlx::PgPool;
+use tokio::task::JoinHandle;
 use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::common::events::{
@@ -20,33 +22,59 @@ use crate::inference::pipeline::run_predictions;
 use crate::inference::state::AppState;
 
 /// Spawn the event consumer if a database pool is configured.
-pub fn spawn_event_consumer(state: AppState) {
+///
+/// Returns the join handle for the spawned task, or an empty vec if no pool
+/// is available.
+pub fn spawn_event_consumer(
+    state: AppState,
+    shutdown_token: CancellationToken,
+) -> Vec<JoinHandle<()>> {
     if state.pool().is_none() {
         info!("PostgreSQL not available, event consumer disabled");
-        return;
+        return Vec::new();
     }
-    tokio::spawn(consumer_loop(state));
+    vec![tokio::spawn(consumer_loop(state, shutdown_token))]
 }
 
 /// Supervisor: restart the listener on error with a backoff.
-async fn consumer_loop(state: AppState) {
+async fn consumer_loop(state: AppState, shutdown_token: CancellationToken) {
     let pool = match state.pool() {
         Some(pool) => pool.clone(),
         None => return,
     };
 
     loop {
-        match run_consumer(&state, &pool).await {
-            Ok(()) => info!("Event consumer exited, restarting"),
+        match run_consumer(&state, &pool, &shutdown_token).await {
+            Ok(()) => {
+                if shutdown_token.is_cancelled() {
+                    info!("Event consumer stopped for shutdown");
+                    break;
+                }
+                info!("Event consumer exited, restarting");
+            }
             Err(error) => {
+                if shutdown_token.is_cancelled() {
+                    info!("Event consumer stopped for shutdown");
+                    break;
+                }
                 warn!("Event consumer error: {}, restarting in 30s", error);
-                sleep(Duration::from_secs(30)).await;
+                tokio::select! {
+                    _ = sleep(Duration::from_secs(30)) => {}
+                    _ = shutdown_token.cancelled() => {
+                        info!("Event consumer stopped for shutdown");
+                        break;
+                    }
+                }
             }
         }
     }
 }
 
-async fn run_consumer(state: &AppState, pool: &PgPool) -> Result<(), sqlx::Error> {
+async fn run_consumer(
+    state: &AppState,
+    pool: &PgPool,
+    shutdown_token: &CancellationToken,
+) -> Result<(), sqlx::Error> {
     let mut listener = PgListener::connect_with(pool).await?;
     listener.listen("events").await?;
     info!("Event consumer connected, listening on channel 'events'");
@@ -64,7 +92,13 @@ async fn run_consumer(state: &AppState, pool: &PgPool) -> Result<(), sqlx::Error
     }
 
     loop {
-        let notification = listener.recv().await?;
+        let notification = tokio::select! {
+            result = listener.recv() => result?,
+            _ = shutdown_token.cancelled() => {
+                info!("Shutdown signal received, draining");
+                break;
+            }
+        };
         let payload = notification.payload();
 
         if parse_event_type(payload).as_deref()
@@ -81,6 +115,8 @@ async fn run_consumer(state: &AppState, pool: &PgPool) -> Result<(), sqlx::Error
         info!(event_id, "Received equity_predictions_requested");
         handle_equity_predictions_requested(state, pool, event_id).await;
     }
+
+    Ok(())
 }
 
 /// Parse an event notification payload and return the event type string if
@@ -223,7 +259,9 @@ mod tests {
             "prefix/".to_string(),
             "latest".to_string(),
         );
+        let token = CancellationToken::new();
         // No pool configured; the function must log and return without spawning.
-        spawn_event_consumer(state);
+        let handles = spawn_event_consumer(state, token);
+        assert!(handles.is_empty());
     }
 }

--- a/src/inference/pipeline.rs
+++ b/src/inference/pipeline.rs
@@ -278,6 +278,9 @@ pub async fn start_artifact_polling(
                 break;
             }
         }
+        if shutdown_token.is_cancelled() {
+            break;
+        }
         poll_artifact_once(&state).await;
     }
 }

--- a/src/inference/pipeline.rs
+++ b/src/inference/pipeline.rs
@@ -264,11 +264,20 @@ pub async fn poll_artifact_once(state: &AppState) {
     }
 }
 
-pub async fn start_artifact_polling(state: AppState) {
+pub async fn start_artifact_polling(
+    state: AppState,
+    shutdown_token: tokio_util::sync::CancellationToken,
+) {
     let poll_interval = std::time::Duration::from_secs(60);
 
     loop {
-        tokio::time::sleep(poll_interval).await;
+        tokio::select! {
+            _ = tokio::time::sleep(poll_interval) => {}
+            _ = shutdown_token.cancelled() => {
+                info!("Artifact polling stopped for shutdown");
+                break;
+            }
+        }
         poll_artifact_once(&state).await;
     }
 }

--- a/src/portfolio/consumer.rs
+++ b/src/portfolio/consumer.rs
@@ -67,6 +67,10 @@ async fn run_consumer(
     listener.listen("events").await?;
     info!("Event consumer connected, listening on channel 'events'");
 
+    if shutdown_token.is_cancelled() {
+        return Ok(());
+    }
+
     // Run startup reconciliation to resolve any DB-Alpaca drift accumulated
     // while the service was down.
     match reconciliation::reconcile(pool, state.alpaca_client()).await {

--- a/src/portfolio/consumer.rs
+++ b/src/portfolio/consumer.rs
@@ -10,7 +10,9 @@ use std::time::Duration;
 use chrono::Utc;
 use sqlx::postgres::PgListener;
 use sqlx::PgPool;
+use tokio::task::JoinHandle;
 use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::common::events::{
@@ -23,24 +25,44 @@ use crate::portfolio::reconciliation;
 use crate::portfolio::state::AppState;
 
 /// Spawns the event consumer as a background task.
-pub fn spawn_event_consumer(state: AppState) {
-    tokio::spawn(consumer_loop(state));
+pub fn spawn_event_consumer(state: AppState, shutdown_token: CancellationToken) -> JoinHandle<()> {
+    tokio::spawn(consumer_loop(state, shutdown_token))
 }
 
-async fn consumer_loop(state: AppState) {
+async fn consumer_loop(state: AppState, shutdown_token: CancellationToken) {
     let pool = state.pool().clone();
     loop {
-        match run_consumer(&state, &pool).await {
-            Ok(()) => info!("Event consumer exited, restarting"),
+        match run_consumer(&state, &pool, &shutdown_token).await {
+            Ok(()) => {
+                if shutdown_token.is_cancelled() {
+                    info!("Event consumer stopped for shutdown");
+                    break;
+                }
+                info!("Event consumer exited, restarting");
+            }
             Err(error) => {
+                if shutdown_token.is_cancelled() {
+                    info!("Event consumer stopped for shutdown");
+                    break;
+                }
                 warn!("Event consumer error: {}, restarting in 30s", error);
-                sleep(Duration::from_secs(30)).await;
+                tokio::select! {
+                    _ = sleep(Duration::from_secs(30)) => {}
+                    _ = shutdown_token.cancelled() => {
+                        info!("Event consumer stopped for shutdown");
+                        break;
+                    }
+                }
             }
         }
     }
 }
 
-async fn run_consumer(state: &AppState, pool: &PgPool) -> Result<(), sqlx::Error> {
+async fn run_consumer(
+    state: &AppState,
+    pool: &PgPool,
+    shutdown_token: &CancellationToken,
+) -> Result<(), sqlx::Error> {
     let mut listener = PgListener::connect_with(pool).await?;
     listener.listen("events").await?;
     info!("Event consumer connected, listening on channel 'events'");
@@ -110,7 +132,13 @@ async fn run_consumer(state: &AppState, pool: &PgPool) -> Result<(), sqlx::Error
     }
 
     loop {
-        let notification = listener.recv().await?;
+        let notification = tokio::select! {
+            result = listener.recv() => result?,
+            _ = shutdown_token.cancelled() => {
+                info!("Shutdown signal received, draining");
+                break;
+            }
+        };
         let parsed: serde_json::Value = match serde_json::from_str(notification.payload()) {
             Ok(value) => value,
             Err(_) => continue,
@@ -141,6 +169,8 @@ async fn run_consumer(state: &AppState, pool: &PgPool) -> Result<(), sqlx::Error
             handle_portfolio_liquidation(state, pool, event_id).await;
         }
     }
+
+    Ok(())
 }
 
 /// Maximum duration (seconds) for a prediction-pipeline run before the in-progress


### PR DESCRIPTION
# Overview

## Changes

- Add `tokio-util` (with `rt` feature) as a new dependency for `CancellationToken`
- Create a shared `CancellationToken` in the main entrypoint (`src/bin/fund.rs`) and pass clones to all spawned consumer and polling loops
- Replace the bare `ctrl_c().await` exit with a `await_shutdown_signal()` helper that listens for both SIGTERM and SIGINT, then cancels the token and awaits all join handles for a clean exit
- Wrap the inner `listener.recv()` call in `tokio::select!` with `shutdown_token.cancelled()` in the inference consumer, portfolio consumer, and data scheduler so in-flight handlers complete before exiting
- Wrap backoff `sleep` calls in supervisor restart loops with `select!` so shutdown is not delayed by up to 30 seconds
- Wrap the artifact polling `sleep` in `select!` for the same reason
- Update `spawn_sync_scheduler`, `spawn_event_consumer` (inference and portfolio), and `start_artifact_polling` signatures to accept a `CancellationToken` and return `JoinHandle`s
- Configure `process-compose.shutdown` timeouts in `devenv.nix`: 60s for data, 120s for inference and portfolio

## Context

Phase 0, Project 3 from the roadmap (`.scratchpad/phase_0_project_3_graceful_shutdown.md`). Previously, SIGTERM caused immediate task cancellation without waiting for in-flight work. While the event system is already resilient to hard kills (consumer offsets and catch-up on startup prevent data loss), graceful shutdown avoids wasting partially completed work like a prediction run killed mid-computation or a rebalance cycle interrupted after order submission but before fill polling. This is also a prerequisite for the Data Stream project (Phase 1, Project 6), which introduces long-lived WebSocket connections requiring coordinated teardown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinated graceful shutdown for data synchronization, inference, and portfolio services.
  * Services now stop promptly when receiving termination or interrupt signals.
  * Background tasks are tracked and completed before the application exits.

* **Bug Fixes**
  * Improved shutdown behavior during listener errors, retries, and polling waits.
  * Added configurable shutdown signals and timeouts for managed services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->