### PR TITLE
Add data stream infrastructure with WebSocket manager and broadcast buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,6 +2867,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "flate2",
+ "futures-util",
  "http 1.4.2",
  "mockito",
  "ndarray 0.16.1",
@@ -2886,6 +2887,7 @@ dependencies = [
  "testcontainers-modules",
  "thiserror 2.0.19",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tower",
  "tracing",
@@ -8219,6 +8221,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8418,6 +8434,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.2",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.9.4",
+ "sha1 0.10.7",
+ "thiserror 2.0.19",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8563,6 +8597,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,14 @@ required-features = ["dashboard"]
 [[bin]]
 name = "fund"
 path = "src/bin/fund.rs"
-required-features = ["data", "inference", "portfolio"]
+required-features = ["data", "inference", "portfolio", "stream"]
 
 [features]
-default = ["data", "inference", "portfolio"]
+default = ["data", "inference", "portfolio", "stream"]
 data = ["dep:chrono-tz"]
 inference = ["dep:burn", "dep:ndarray", "dep:flate2", "dep:tar", "dep:tempfile"]
 portfolio = ["dep:chrono-tz"]
+stream = ["dep:tokio-tungstenite", "dep:futures-util"]
 dashboard = ["dep:axum"]
 
 # Rust-native TiDE training. Reuses the inference model/data/predict code
@@ -104,6 +105,12 @@ tempfile = { version = "3.27", optional = true }
 
 # train-only (optional; enabled by the `train` feature)
 rand = { version = "0.10", optional = true }
+
+# stream-only (optional; enabled by the `stream` feature)
+tokio-tungstenite = { version = "0.26", features = [
+  "native-tls",
+], optional = true }
+futures-util = { version = "0.3", optional = true }
 
 # dashboard-only (optional; enabled by the `dashboard` feature)
 axum = { version = "0.8", optional = true }

--- a/src/bin/fund.rs
+++ b/src/bin/fund.rs
@@ -6,9 +6,14 @@
 //! own log stream and TUI panel while still sharing the same PostgreSQL
 //! event bus for inter-service coordination.
 
+use std::sync::Arc;
+
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
+
+use fund::stream::buffer::MarketDataBuffer;
+use fund::stream::connection::MessagePayload;
 
 const USAGE: &str = "Usage: fund [--module <data|inference|portfolio>]";
 
@@ -101,6 +106,18 @@ async fn run(module: Option<Module>) -> Result<(), Box<dyn std::error::Error>> {
     } else {
         None
     };
+
+    // The market data buffer is the in-memory broadcast channel for live
+    // quotes and ticks. All data here is ephemeral (DataBoundary::Ephemeral)
+    // and is never written to PostgreSQL. Downstream consumers that detect
+    // durable signals are responsible for crossing the event boundary via
+    // emit_event().
+    let market_data_buffer: Arc<MarketDataBuffer<MessagePayload>> =
+        Arc::new(MarketDataBuffer::new());
+    info!(
+        capacity = market_data_buffer.capacity(),
+        "Market data buffer created"
+    );
 
     let shutdown_token = CancellationToken::new();
     let mut handles: Vec<JoinHandle<()>> = Vec::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,5 +21,8 @@ pub mod inference;
 #[cfg(feature = "portfolio")]
 pub mod portfolio;
 
+#[cfg(feature = "stream")]
+pub mod stream;
+
 #[cfg(feature = "dashboard")]
 pub mod dashboard;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,15 @@
+//! Live market data streaming infrastructure.
+//!
+//! Provides a generic WebSocket connection manager and an in-memory broadcast
+//! buffer for real-time market data. Raw data stays exclusively in the
+//! broadcast channel and is never written to PostgreSQL — this keeps the hot
+//! path decoupled from database I/O throughput.
+//!
+//! Data crosses the persistence boundary only when a downstream consumer
+//! produces a derived signal or trading decision. Those are written to the
+//! `events` table via [`crate::common::events::emit_event`] and become
+//! durable, replayable events visible to all consumers.
+
+pub mod buffer;
+pub mod connection;
+pub mod data_boundary;

--- a/src/stream/buffer.rs
+++ b/src/stream/buffer.rs
@@ -1,0 +1,287 @@
+//! In-memory hot buffer for live market data.
+//!
+//! [`MarketDataBuffer`] wraps a [`tokio::sync::broadcast`] channel where
+//! WebSocket readers publish raw market data and downstream consumers
+//! subscribe. All data in this buffer is [`DataBoundary::Ephemeral`] —
+//! it lives only during the current process lifetime and is never written
+//! to PostgreSQL.
+
+use std::fmt;
+
+use tokio::sync::broadcast;
+use tracing::{debug, warn};
+
+use super::data_boundary::DataBoundary;
+
+/// Default broadcast channel capacity.
+///
+/// Sized for sustained quote throughput during market hours. A lagging
+/// consumer that falls more than this many messages behind will receive
+/// a [`broadcast::error::RecvError::Lagged`] error and skip to the
+/// current position.
+const DEFAULT_BUFFER_CAPACITY: usize = 16_384;
+
+/// In-memory broadcast buffer for live market data.
+///
+/// Owns the [`broadcast::Sender`] and provides [`subscribe`](Self::subscribe)
+/// to create new receivers. Multiple consumers can subscribe independently
+/// and each receives every message published after their subscription.
+///
+/// The buffer enforces the [`DataBoundary::Ephemeral`] contract: data
+/// published here is never persisted. Downstream consumers that detect
+/// a durable signal are responsible for crossing the event boundary
+/// themselves via [`crate::common::events::emit_event`].
+pub struct MarketDataBuffer<T: Clone + Send + 'static> {
+    sender: broadcast::Sender<T>,
+    capacity: usize,
+}
+
+impl<T: Clone + Send + 'static> MarketDataBuffer<T> {
+    /// Creates a new buffer with the default capacity.
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_BUFFER_CAPACITY)
+    }
+
+    /// Creates a new buffer with the specified capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(capacity);
+        Self { sender, capacity }
+    }
+
+    /// Publishes a message to all active subscribers.
+    ///
+    /// Returns `Ok(receiver_count)` on success. Returns `Err` if there
+    /// are no active subscribers — this is not an error condition during
+    /// startup or shutdown when consumers may not yet be connected.
+    pub fn publish(&self, message: T) -> Result<usize, PublishError<T>> {
+        self.sender.send(message).map_err(|error| {
+            debug!("No active subscribers for published message");
+            PublishError(error.0)
+        })
+    }
+
+    /// Creates a new subscriber that receives all future messages.
+    ///
+    /// Each subscriber independently tracks its position in the buffer.
+    /// If a subscriber falls behind by more than the buffer capacity,
+    /// it will receive a lag error and skip to the current position.
+    pub fn subscribe(&self) -> BufferSubscriber<T> {
+        BufferSubscriber {
+            receiver: self.sender.subscribe(),
+        }
+    }
+
+    /// Returns the number of active subscribers.
+    pub fn subscriber_count(&self) -> usize {
+        self.sender.receiver_count()
+    }
+
+    /// Returns the configured buffer capacity.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Returns the data boundary classification for this buffer.
+    ///
+    /// Always returns [`DataBoundary::Ephemeral`] — data in the broadcast
+    /// channel is never persisted to PostgreSQL.
+    pub fn data_boundary(&self) -> DataBoundary {
+        DataBoundary::Ephemeral
+    }
+}
+
+impl<T: Clone + Send + 'static> Default for MarketDataBuffer<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Error returned when publishing to a buffer with no active subscribers.
+pub struct PublishError<T>(pub T);
+
+impl<T> fmt::Debug for PublishError<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("PublishError(no active subscribers)")
+    }
+}
+
+impl<T> fmt::Display for PublishError<T> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("no active subscribers")
+    }
+}
+
+/// A subscriber to a [`MarketDataBuffer`].
+///
+/// Wraps a [`broadcast::Receiver`] and handles lag errors transparently
+/// by logging a warning and skipping to the current buffer position.
+pub struct BufferSubscriber<T: Clone + Send + 'static> {
+    receiver: broadcast::Receiver<T>,
+}
+
+impl<T: Clone + Send + 'static> BufferSubscriber<T> {
+    /// Receives the next message from the buffer.
+    ///
+    /// If the subscriber has fallen behind, skipped messages are logged
+    /// and the subscriber advances to the current position. Returns
+    /// `None` when the buffer has been dropped (all senders closed),
+    /// indicating shutdown.
+    pub async fn receive(&mut self) -> Option<T> {
+        loop {
+            match self.receiver.recv().await {
+                Ok(message) => return Some(message),
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(
+                        skipped_messages = skipped,
+                        "Buffer subscriber lagged, skipping to current position"
+                    );
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_buffer_has_default_capacity() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::new();
+        assert_eq!(buffer.capacity(), DEFAULT_BUFFER_CAPACITY);
+    }
+
+    #[test]
+    fn test_with_capacity() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::with_capacity(256);
+        assert_eq!(buffer.capacity(), 256);
+    }
+
+    #[test]
+    fn test_default_matches_new() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::default();
+        assert_eq!(buffer.capacity(), DEFAULT_BUFFER_CAPACITY);
+    }
+
+    #[test]
+    fn test_subscriber_count_starts_at_zero() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::new();
+        assert_eq!(buffer.subscriber_count(), 0);
+    }
+
+    #[test]
+    fn test_subscribe_increments_count() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::new();
+        let _subscriber_a = buffer.subscribe();
+        assert_eq!(buffer.subscriber_count(), 1);
+        let _subscriber_b = buffer.subscribe();
+        assert_eq!(buffer.subscriber_count(), 2);
+    }
+
+    #[test]
+    fn test_dropped_subscriber_decrements_count() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::new();
+        let subscriber = buffer.subscribe();
+        assert_eq!(buffer.subscriber_count(), 1);
+        drop(subscriber);
+        assert_eq!(buffer.subscriber_count(), 0);
+    }
+
+    #[test]
+    fn test_publish_with_no_subscribers_returns_error() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::new();
+        let result = buffer.publish(42);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_publish_returns_subscriber_count() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::new();
+        let _subscriber = buffer.subscribe();
+        let result = buffer.publish(42);
+        assert_eq!(result.unwrap(), 1);
+    }
+
+    #[test]
+    fn test_data_boundary_is_ephemeral() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::new();
+        assert_eq!(buffer.data_boundary(), DataBoundary::Ephemeral);
+        assert!(buffer.data_boundary().is_ephemeral());
+        assert!(!buffer.data_boundary().is_durable());
+    }
+
+    #[tokio::test]
+    async fn test_subscriber_receives_published_message() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::new();
+        let mut subscriber = buffer.subscribe();
+        buffer.publish(42).unwrap();
+        let received = subscriber.receive().await;
+        assert_eq!(received, Some(42));
+    }
+
+    #[tokio::test]
+    async fn test_multiple_subscribers_receive_same_message() {
+        let buffer: MarketDataBuffer<String> = MarketDataBuffer::new();
+        let mut subscriber_a = buffer.subscribe();
+        let mut subscriber_b = buffer.subscribe();
+        buffer.publish("hello".to_string()).unwrap();
+        assert_eq!(subscriber_a.receive().await, Some("hello".to_string()));
+        assert_eq!(subscriber_b.receive().await, Some("hello".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_subscriber_receives_none_on_buffer_drop() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::new();
+        let mut subscriber = buffer.subscribe();
+        drop(buffer);
+        let received = subscriber.receive().await;
+        assert_eq!(received, None);
+    }
+
+    #[tokio::test]
+    async fn test_subscriber_handles_lag() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::with_capacity(4);
+        let mut subscriber = buffer.subscribe();
+
+        // Publish more messages than the buffer capacity to force lag.
+        for index in 0..10 {
+            let _ = buffer.publish(index);
+        }
+
+        // The subscriber should skip lagged messages and receive the
+        // most recent ones still in the buffer.
+        let received = subscriber.receive().await;
+        assert!(received.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_subscriber_receives_messages_in_order() {
+        let buffer: MarketDataBuffer<i32> = MarketDataBuffer::new();
+        let mut subscriber = buffer.subscribe();
+
+        buffer.publish(1).unwrap();
+        buffer.publish(2).unwrap();
+        buffer.publish(3).unwrap();
+
+        assert_eq!(subscriber.receive().await, Some(1));
+        assert_eq!(subscriber.receive().await, Some(2));
+        assert_eq!(subscriber.receive().await, Some(3));
+    }
+
+    #[test]
+    fn test_publish_error_debug_format() {
+        let error = PublishError(42);
+        assert_eq!(
+            format!("{:?}", error),
+            "PublishError(no active subscribers)"
+        );
+    }
+
+    #[test]
+    fn test_publish_error_display_format() {
+        let error = PublishError(42);
+        assert_eq!(format!("{}", error), "no active subscribers");
+    }
+}

--- a/src/stream/buffer.rs
+++ b/src/stream/buffer.rs
@@ -111,6 +111,8 @@ impl<T> fmt::Display for PublishError<T> {
     }
 }
 
+impl<T: fmt::Debug> std::error::Error for PublishError<T> {}
+
 /// A subscriber to a [`MarketDataBuffer`].
 ///
 /// Wraps a [`broadcast::Receiver`] and handles lag errors transparently

--- a/src/stream/connection.rs
+++ b/src/stream/connection.rs
@@ -33,7 +33,7 @@ const BACKOFF_MULTIPLIER: u32 = 2;
 
 /// Configuration for a WebSocket connection.
 #[derive(Debug, Clone)]
-pub struct ConnectionConfig {
+pub struct ConnectionConfiguration {
     /// WebSocket URL to connect to (e.g., `wss://stream.example.com/v1`).
     pub url: String,
 
@@ -42,7 +42,7 @@ pub struct ConnectionConfig {
     pub startup_messages: Vec<String>,
 }
 
-impl ConnectionConfig {
+impl ConnectionConfiguration {
     /// Creates a new connection configuration.
     pub fn new(url: impl Into<String>) -> Self {
         Self {
@@ -104,7 +104,7 @@ impl std::error::Error for ConnectionError {}
 /// to continue receiving or `false` to close the connection (e.g., if the
 /// server sends a terminal message).
 pub async fn run_connection<F>(
-    config: &ConnectionConfig,
+    config: &ConnectionConfiguration,
     shutdown_token: &CancellationToken,
     mut handler: F,
 ) where
@@ -165,7 +165,7 @@ pub enum MessagePayload {
 /// Returns [`SessionOutcome::Shutdown`] if the cancellation token fires,
 /// or [`SessionOutcome::Disconnected`] if the connection drops or errors.
 async fn connect_and_run<F>(
-    config: &ConnectionConfig,
+    config: &ConnectionConfiguration,
     shutdown_token: &CancellationToken,
     handler: &mut F,
 ) -> SessionOutcome
@@ -255,7 +255,7 @@ where
 
 /// Establishes the initial WebSocket connection.
 async fn connect(
-    config: &ConnectionConfig,
+    config: &ConnectionConfiguration,
 ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, ConnectionError> {
     match connect_async(&config.url).await {
         Ok((stream, response)) => {
@@ -281,14 +281,14 @@ mod tests {
 
     #[test]
     fn test_connection_config_new() {
-        let config = ConnectionConfig::new("wss://example.com/v1");
+        let config = ConnectionConfiguration::new("wss://example.com/v1");
         assert_eq!(config.url, "wss://example.com/v1");
         assert!(config.startup_messages.is_empty());
     }
 
     #[test]
     fn test_connection_config_with_startup_messages() {
-        let config = ConnectionConfig::new("wss://example.com/v1")
+        let config = ConnectionConfiguration::new("wss://example.com/v1")
             .with_startup_message(r#"{"action":"auth","key":"test"}"#)
             .with_startup_message(r#"{"action":"subscribe","quotes":["AAPL"]}"#);
 
@@ -347,7 +347,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_run_connection_exits_on_immediate_shutdown() {
-        let config = ConnectionConfig::new("wss://localhost:1/nonexistent");
+        let config = ConnectionConfiguration::new("wss://localhost:1/nonexistent");
         let token = CancellationToken::new();
         token.cancel();
 
@@ -368,14 +368,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_connect_to_invalid_url_returns_error() {
-        let config = ConnectionConfig::new("wss://localhost:1/nonexistent");
+        let config = ConnectionConfiguration::new("wss://localhost:1/nonexistent");
         let result = connect(&config).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_connect_and_run_with_cancelled_token() {
-        let config = ConnectionConfig::new("wss://localhost:1/nonexistent");
+        let config = ConnectionConfiguration::new("wss://localhost:1/nonexistent");
         let token = CancellationToken::new();
         token.cancel();
 

--- a/src/stream/connection.rs
+++ b/src/stream/connection.rs
@@ -1,0 +1,390 @@
+//! Generic WebSocket connection manager with automatic reconnection.
+//!
+//! [`WebSocketConnection`] manages a single WebSocket connection lifecycle:
+//! connect, subscribe to topics, receive messages in a loop, and reconnect
+//! with exponential backoff on failure. It accepts a [`CancellationToken`]
+//! for graceful shutdown — on cancellation, the connection drains in-flight
+//! messages and closes cleanly.
+//!
+//! This module is feed-agnostic: it handles raw WebSocket frames and
+//! delegates message parsing to a caller-provided handler. Specific feed
+//! integrations (Alpaca equities, Massive options, etc.) are built on top
+//! of this infrastructure in downstream projects.
+
+use std::fmt;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio::time::sleep;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
+
+/// Maximum reconnection backoff duration.
+const MAXIMUM_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Initial reconnection backoff duration.
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+
+/// Backoff multiplier applied after each failed reconnection attempt.
+const BACKOFF_MULTIPLIER: u32 = 2;
+
+/// Configuration for a WebSocket connection.
+#[derive(Debug, Clone)]
+pub struct ConnectionConfig {
+    /// WebSocket URL to connect to (e.g., `wss://stream.example.com/v1`).
+    pub url: String,
+
+    /// Messages to send immediately after connecting (e.g., authentication,
+    /// subscription requests). Sent in order before the receive loop begins.
+    pub startup_messages: Vec<String>,
+}
+
+impl ConnectionConfig {
+    /// Creates a new connection configuration.
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            startup_messages: Vec::new(),
+        }
+    }
+
+    /// Adds a message to send immediately after connecting.
+    pub fn with_startup_message(mut self, message: impl Into<String>) -> Self {
+        self.startup_messages.push(message.into());
+        self
+    }
+}
+
+/// Outcome of a single connection session.
+///
+/// Returned by [`run_connection`] to indicate why the session ended so the
+/// supervisor loop can decide whether to reconnect.
+#[derive(Debug)]
+pub enum SessionOutcome {
+    /// The connection was closed cleanly due to a shutdown signal.
+    Shutdown,
+
+    /// The connection was lost or encountered an error.
+    Disconnected(ConnectionError),
+}
+
+/// Errors that can occur during a WebSocket session.
+#[derive(Debug)]
+pub struct ConnectionError {
+    message: String,
+}
+
+impl ConnectionError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ConnectionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ConnectionError {}
+
+/// Runs a WebSocket connection with automatic reconnection.
+///
+/// This is the top-level supervisor loop. It connects to the configured
+/// URL, sends startup messages, and enters a receive loop that forwards
+/// messages to the provided handler. On disconnection, it reconnects
+/// with exponential backoff. On cancellation, it drains and exits.
+///
+/// The `handler` receives each text or binary message and returns `true`
+/// to continue receiving or `false` to close the connection (e.g., if the
+/// server sends a terminal message).
+pub async fn run_connection<F>(
+    config: &ConnectionConfig,
+    shutdown_token: &CancellationToken,
+    mut handler: F,
+) where
+    F: FnMut(MessagePayload) -> bool,
+{
+    let mut backoff = INITIAL_BACKOFF;
+
+    loop {
+        if shutdown_token.is_cancelled() {
+            info!("Shutdown before connect, exiting");
+            return;
+        }
+
+        info!(url = %config.url, "Connecting to WebSocket");
+
+        match connect_and_run(config, shutdown_token, &mut handler).await {
+            SessionOutcome::Shutdown => {
+                info!("WebSocket connection closed for shutdown");
+                return;
+            }
+            SessionOutcome::Disconnected(error) => {
+                if shutdown_token.is_cancelled() {
+                    info!("WebSocket connection closed for shutdown");
+                    return;
+                }
+
+                warn!(
+                    error = %error,
+                    backoff_seconds = backoff.as_secs(),
+                    "WebSocket disconnected, reconnecting after backoff"
+                );
+
+                tokio::select! {
+                    _ = sleep(backoff) => {}
+                    _ = shutdown_token.cancelled() => {
+                        info!("Shutdown during reconnect backoff, exiting");
+                        return;
+                    }
+                }
+
+                backoff = std::cmp::min(backoff * BACKOFF_MULTIPLIER, MAXIMUM_BACKOFF);
+            }
+        }
+    }
+}
+
+/// The payload extracted from a WebSocket message.
+#[derive(Debug, Clone)]
+pub enum MessagePayload {
+    /// UTF-8 text message.
+    Text(String),
+    /// Binary message.
+    Binary(Vec<u8>),
+}
+
+/// Connects, sends startup messages, and enters the receive loop.
+///
+/// Returns [`SessionOutcome::Shutdown`] if the cancellation token fires,
+/// or [`SessionOutcome::Disconnected`] if the connection drops or errors.
+async fn connect_and_run<F>(
+    config: &ConnectionConfig,
+    shutdown_token: &CancellationToken,
+    handler: &mut F,
+) -> SessionOutcome
+where
+    F: FnMut(MessagePayload) -> bool,
+{
+    let stream = match connect(config).await {
+        Ok(stream) => stream,
+        Err(error) => return SessionOutcome::Disconnected(error),
+    };
+
+    let (mut sink, mut source) = stream.split();
+
+    // Send startup messages (auth, subscriptions).
+    for message in &config.startup_messages {
+        if let Err(error) = sink.send(Message::Text(message.clone().into())).await {
+            return SessionOutcome::Disconnected(ConnectionError::new(format!(
+                "Failed to send startup message: {}",
+                error
+            )));
+        }
+    }
+
+    debug!("Startup messages sent, entering receive loop");
+
+    // Receive loop.
+    loop {
+        let frame = tokio::select! {
+            frame = source.next() => frame,
+            _ = shutdown_token.cancelled() => {
+                debug!("Shutdown signal received, closing WebSocket");
+                let _ = sink.close().await;
+                return SessionOutcome::Shutdown;
+            }
+        };
+
+        match frame {
+            Some(Ok(Message::Text(text))) => {
+                if !handler(MessagePayload::Text(text.to_string())) {
+                    debug!("Handler requested connection close");
+                    let _ = sink.close().await;
+                    return SessionOutcome::Shutdown;
+                }
+            }
+            Some(Ok(Message::Binary(data))) => {
+                if !handler(MessagePayload::Binary(data.to_vec())) {
+                    debug!("Handler requested connection close");
+                    let _ = sink.close().await;
+                    return SessionOutcome::Shutdown;
+                }
+            }
+            Some(Ok(Message::Ping(data))) => {
+                if let Err(error) = sink.send(Message::Pong(data)).await {
+                    return SessionOutcome::Disconnected(ConnectionError::new(format!(
+                        "Failed to send pong: {}",
+                        error
+                    )));
+                }
+            }
+            Some(Ok(Message::Pong(_))) => {
+                // Pong responses are expected and ignored.
+            }
+            Some(Ok(Message::Close(_))) => {
+                debug!("Server sent close frame");
+                let _ = sink.close().await;
+                return SessionOutcome::Disconnected(ConnectionError::new(
+                    "Server closed connection",
+                ));
+            }
+            Some(Ok(Message::Frame(_))) => {
+                // Raw frames are not expected in normal operation.
+            }
+            Some(Err(error)) => {
+                return SessionOutcome::Disconnected(ConnectionError::new(format!(
+                    "WebSocket error: {}",
+                    error
+                )));
+            }
+            None => {
+                return SessionOutcome::Disconnected(ConnectionError::new(
+                    "WebSocket stream ended",
+                ));
+            }
+        }
+    }
+}
+
+/// Establishes the initial WebSocket connection.
+async fn connect(
+    config: &ConnectionConfig,
+) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, ConnectionError> {
+    match connect_async(&config.url).await {
+        Ok((stream, response)) => {
+            info!(
+                status = %response.status(),
+                "WebSocket connected"
+            );
+            Ok(stream)
+        }
+        Err(error) => {
+            error!(error = %error, "WebSocket connection failed");
+            Err(ConnectionError::new(format!(
+                "Connection failed: {}",
+                error
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_connection_config_new() {
+        let config = ConnectionConfig::new("wss://example.com/v1");
+        assert_eq!(config.url, "wss://example.com/v1");
+        assert!(config.startup_messages.is_empty());
+    }
+
+    #[test]
+    fn test_connection_config_with_startup_messages() {
+        let config = ConnectionConfig::new("wss://example.com/v1")
+            .with_startup_message(r#"{"action":"auth","key":"test"}"#)
+            .with_startup_message(r#"{"action":"subscribe","quotes":["AAPL"]}"#);
+
+        assert_eq!(config.startup_messages.len(), 2);
+        assert!(config.startup_messages[0].contains("auth"));
+        assert!(config.startup_messages[1].contains("subscribe"));
+    }
+
+    #[test]
+    fn test_connection_error_display() {
+        let error = ConnectionError::new("something went wrong");
+        assert_eq!(format!("{}", error), "something went wrong");
+    }
+
+    #[test]
+    fn test_connection_error_debug() {
+        let error = ConnectionError::new("test error");
+        let debug_output = format!("{:?}", error);
+        assert!(debug_output.contains("test error"));
+    }
+
+    #[test]
+    fn test_backoff_constants() {
+        assert!(INITIAL_BACKOFF < MAXIMUM_BACKOFF);
+        assert!(BACKOFF_MULTIPLIER > 1);
+    }
+
+    #[test]
+    fn test_backoff_growth_is_bounded() {
+        let mut backoff = INITIAL_BACKOFF;
+        for _ in 0..20 {
+            backoff = std::cmp::min(backoff * BACKOFF_MULTIPLIER, MAXIMUM_BACKOFF);
+        }
+        assert_eq!(backoff, MAXIMUM_BACKOFF);
+    }
+
+    #[test]
+    fn test_message_payload_text_clone() {
+        let payload = MessagePayload::Text("hello".to_string());
+        let cloned = payload.clone();
+        match cloned {
+            MessagePayload::Text(text) => assert_eq!(text, "hello"),
+            _ => panic!("Expected Text variant"),
+        }
+    }
+
+    #[test]
+    fn test_message_payload_binary_clone() {
+        let payload = MessagePayload::Binary(vec![1, 2, 3]);
+        let cloned = payload.clone();
+        match cloned {
+            MessagePayload::Binary(data) => assert_eq!(data, vec![1, 2, 3]),
+            _ => panic!("Expected Binary variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_run_connection_exits_on_immediate_shutdown() {
+        let config = ConnectionConfig::new("wss://localhost:1/nonexistent");
+        let token = CancellationToken::new();
+        token.cancel();
+
+        let messages_received = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = messages_received.clone();
+
+        run_connection(&config, &token, move |_| {
+            counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            true
+        })
+        .await;
+
+        assert_eq!(
+            messages_received.load(std::sync::atomic::Ordering::SeqCst),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_connect_to_invalid_url_returns_error() {
+        let config = ConnectionConfig::new("wss://localhost:1/nonexistent");
+        let result = connect(&config).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_connect_and_run_with_cancelled_token() {
+        let config = ConnectionConfig::new("wss://localhost:1/nonexistent");
+        let token = CancellationToken::new();
+        token.cancel();
+
+        let outcome = connect_and_run(&config, &token, &mut |_| true).await;
+        // With a cancelled token, connect may fail or shutdown may fire first.
+        // Either outcome is acceptable — we just verify it doesn't hang.
+        match outcome {
+            SessionOutcome::Shutdown => {}
+            SessionOutcome::Disconnected(_) => {}
+        }
+    }
+}

--- a/src/stream/connection.rs
+++ b/src/stream/connection.rs
@@ -1,15 +1,14 @@
 //! Generic WebSocket connection manager with automatic reconnection.
 //!
-//! [`WebSocketConnection`] manages a single WebSocket connection lifecycle:
-//! connect, subscribe to topics, receive messages in a loop, and reconnect
-//! with exponential backoff on failure. It accepts a [`CancellationToken`]
-//! for graceful shutdown — on cancellation, the connection drains in-flight
-//! messages and closes cleanly.
+//! [`run_connection`] manages a WebSocket connection lifecycle: connect,
+//! send startup messages, receive messages in a loop, and reconnect with
+//! exponential backoff on failure. It accepts a [`CancellationToken`] for
+//! graceful shutdown — on cancellation, the connection closes cleanly.
 //!
 //! This module is feed-agnostic: it handles raw WebSocket frames and
 //! delegates message parsing to a caller-provided handler. Specific feed
 //! integrations (Alpaca equities, Massive options, etc.) are built on top
-//! of this infrastructure in downstream projects.
+//! of this infrastructure.
 
 use std::fmt;
 use std::time::Duration;
@@ -31,18 +30,31 @@ const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
 /// Backoff multiplier applied after each failed reconnection attempt.
 const BACKOFF_MULTIPLIER: u32 = 2;
 
+/// Timeout for the initial WebSocket connection handshake.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Configuration for a WebSocket connection.
 #[derive(Debug, Clone)]
 pub struct ConnectionConfiguration {
     /// WebSocket URL to connect to (e.g., `wss://stream.example.com/v1`).
-    pub url: String,
+    url: String,
 
     /// Messages to send immediately after connecting (e.g., authentication,
     /// subscription requests). Sent in order before the receive loop begins.
-    pub startup_messages: Vec<String>,
+    startup_messages: Vec<String>,
 }
 
 impl ConnectionConfiguration {
+    /// Returns the WebSocket URL.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Returns the startup messages sent after connecting.
+    pub fn startup_messages(&self) -> &[String] {
+        &self.startup_messages
+    }
+
     /// Creates a new connection configuration.
     pub fn new(url: impl Into<String>) -> Self {
         Self {
@@ -75,12 +87,23 @@ pub enum SessionOutcome {
 #[derive(Debug)]
 pub struct ConnectionError {
     message: String,
+    /// Whether the connection was established before the error occurred.
+    /// Used by the supervisor to decide whether to reset backoff.
+    was_connected: bool,
 }
 
 impl ConnectionError {
     fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
+            was_connected: false,
+        }
+    }
+
+    fn after_connected(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            was_connected: true,
         }
     }
 }
@@ -98,7 +121,7 @@ impl std::error::Error for ConnectionError {}
 /// This is the top-level supervisor loop. It connects to the configured
 /// URL, sends startup messages, and enters a receive loop that forwards
 /// messages to the provided handler. On disconnection, it reconnects
-/// with exponential backoff. On cancellation, it drains and exits.
+/// with exponential backoff. On cancellation, it closes cleanly and exits.
 ///
 /// The `handler` receives each text or binary message and returns `true`
 /// to continue receiving or `false` to close the connection (e.g., if the
@@ -145,7 +168,11 @@ pub async fn run_connection<F>(
                     }
                 }
 
-                backoff = std::cmp::min(backoff * BACKOFF_MULTIPLIER, MAXIMUM_BACKOFF);
+                if error.was_connected {
+                    backoff = INITIAL_BACKOFF;
+                } else {
+                    backoff = std::cmp::min(backoff * BACKOFF_MULTIPLIER, MAXIMUM_BACKOFF);
+                }
             }
         }
     }
@@ -182,7 +209,7 @@ where
     // Send startup messages (auth, subscriptions).
     for message in &config.startup_messages {
         if let Err(error) = sink.send(Message::Text(message.clone().into())).await {
-            return SessionOutcome::Disconnected(ConnectionError::new(format!(
+            return SessionOutcome::Disconnected(ConnectionError::after_connected(format!(
                 "Failed to send startup message: {}",
                 error
             )));
@@ -219,10 +246,9 @@ where
             }
             Some(Ok(Message::Ping(data))) => {
                 if let Err(error) = sink.send(Message::Pong(data)).await {
-                    return SessionOutcome::Disconnected(ConnectionError::new(format!(
-                        "Failed to send pong: {}",
-                        error
-                    )));
+                    return SessionOutcome::Disconnected(ConnectionError::after_connected(
+                        format!("Failed to send pong: {}", error),
+                    ));
                 }
             }
             Some(Ok(Message::Pong(_))) => {
@@ -231,7 +257,7 @@ where
             Some(Ok(Message::Close(_))) => {
                 debug!("Server sent close frame");
                 let _ = sink.close().await;
-                return SessionOutcome::Disconnected(ConnectionError::new(
+                return SessionOutcome::Disconnected(ConnectionError::after_connected(
                     "Server closed connection",
                 ));
             }
@@ -239,13 +265,13 @@ where
                 // Raw frames are not expected in normal operation.
             }
             Some(Err(error)) => {
-                return SessionOutcome::Disconnected(ConnectionError::new(format!(
+                return SessionOutcome::Disconnected(ConnectionError::after_connected(format!(
                     "WebSocket error: {}",
                     error
                 )));
             }
             None => {
-                return SessionOutcome::Disconnected(ConnectionError::new(
+                return SessionOutcome::Disconnected(ConnectionError::after_connected(
                     "WebSocket stream ended",
                 ));
             }
@@ -253,19 +279,25 @@ where
     }
 }
 
-/// Establishes the initial WebSocket connection.
+/// Establishes the initial WebSocket connection with a timeout.
 async fn connect(
     config: &ConnectionConfiguration,
 ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, ConnectionError> {
-    match connect_async(&config.url).await {
-        Ok((stream, response)) => {
+    let result = tokio::time::timeout(CONNECT_TIMEOUT, connect_async(&config.url)).await;
+
+    match result {
+        Err(_elapsed) => {
+            error!("WebSocket connection timed out");
+            Err(ConnectionError::new("Connection timed out"))
+        }
+        Ok(Ok((stream, response))) => {
             info!(
                 status = %response.status(),
                 "WebSocket connected"
             );
             Ok(stream)
         }
-        Err(error) => {
+        Ok(Err(error)) => {
             error!(error = %error, "WebSocket connection failed");
             Err(ConnectionError::new(format!(
                 "Connection failed: {}",

--- a/src/stream/data_boundary.rs
+++ b/src/stream/data_boundary.rs
@@ -1,0 +1,73 @@
+//! Event boundary contract classifying live market data by persistence
+//! requirements.
+//!
+//! The two-tier [`DataBoundary`] enum enforces the architectural separation
+//! between ephemeral in-memory data and durable persisted events. Code at
+//! the boundary uses this enum to route data: [`DataBoundary::Ephemeral`]
+//! values stay in the broadcast channel, while [`DataBoundary::Durable`]
+//! values cross the event boundary and are written to PostgreSQL.
+
+/// Classifies live market data by persistence requirements.
+///
+/// This enum encodes the architectural boundary between the in-memory
+/// broadcast channel and the PostgreSQL events table. Routing decisions
+/// at the boundary are driven by this classification — ephemeral data
+/// is never written to the database, and durable data is always persisted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DataBoundary {
+    /// Tick-level quotes, bid/ask updates, and raw price data.
+    ///
+    /// Lives only in the broadcast channel during market hours. Lost on
+    /// process restart and repopulated from the WebSocket stream. Never
+    /// written to PostgreSQL.
+    Ephemeral,
+
+    /// Derived signals and trading decisions that must survive process
+    /// restarts.
+    ///
+    /// Persisted to the `events` table via [`crate::common::events::emit_event`]
+    /// for durability and consumer replay. Examples include z-score threshold
+    /// breaches, IV surface dislocations, and order submissions.
+    Durable,
+}
+
+impl DataBoundary {
+    /// Returns `true` if this data should be persisted to PostgreSQL.
+    pub fn is_durable(self) -> bool {
+        matches!(self, Self::Durable)
+    }
+
+    /// Returns `true` if this data lives only in the broadcast channel.
+    pub fn is_ephemeral(self) -> bool {
+        matches!(self, Self::Ephemeral)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ephemeral_is_not_durable() {
+        assert!(DataBoundary::Ephemeral.is_ephemeral());
+        assert!(!DataBoundary::Ephemeral.is_durable());
+    }
+
+    #[test]
+    fn test_durable_is_not_ephemeral() {
+        assert!(DataBoundary::Durable.is_durable());
+        assert!(!DataBoundary::Durable.is_ephemeral());
+    }
+
+    #[test]
+    fn test_variants_are_distinct() {
+        assert_ne!(DataBoundary::Ephemeral, DataBoundary::Durable);
+    }
+
+    #[test]
+    fn test_copy_semantics() {
+        let original = DataBoundary::Ephemeral;
+        let copied = original;
+        assert_eq!(original, copied);
+    }
+}


### PR DESCRIPTION
# Overview

## Changes

- Add `src/stream/` module with generic, feed-agnostic live market data infrastructure
- Add `DataBoundary` enum (`Ephemeral`/`Durable`) encoding the architectural boundary between in-memory broadcast data and persisted PostgreSQL events
- Add `MarketDataBuffer` wrapping a `tokio::sync::broadcast` channel for publishing raw market data to multiple downstream consumers with transparent lag handling
- Add `WebSocketConnection` manager with automatic reconnection (exponential backoff), startup message sequencing, ping/pong handling, and graceful drain on `CancellationToken` cancellation
- Wire the broadcast buffer into `src/bin/fund.rs` as shared infrastructure created at startup
- Add `stream` feature gate with `tokio-tungstenite` and `futures-util` dependencies

## Context

Phase 1, Project 6 (Data Stream) establishes the infrastructure layer for live intraday market data streaming. This is the first of two consolidated PRs.

Raw market data (quotes, ticks) is classified as `DataBoundary::Ephemeral` and stays exclusively in the in-memory broadcast channel -- never written to PostgreSQL. This keeps the hot path decoupled from database I/O throughput. Data crosses the persistence boundary only when a downstream consumer produces a derived signal or trading decision (`DataBoundary::Durable`), at which point it is written to the events table via `emit_event`.

The module is feed-agnostic: no specific data feed integrations (Alpaca, Massive) are included. Downstream projects plug their feeds into this infrastructure by configuring `ConnectionConfig` with the appropriate URLs, auth messages, and subscription payloads.

31 new tests with 77.8% line coverage on the stream module. All 920 existing tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live market data streaming over WebSocket connections.
  * Added automatic reconnection and graceful shutdown support.
  * Added in-memory broadcasting so multiple consumers can receive market updates.
  * Added configurable connection startup messages and stream capacity.
  * Added clear classification of market data as ephemeral or durable.
  * Enabled streaming functionality by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->