### PR TITLE
Add DuckDB lab tooling for querying S3 data lake

### DIFF
--- a/.sqlfluffignore
+++ b/.sqlfluffignore
@@ -2,3 +2,4 @@
 target/
 .venv/
 models/tide/.devenv/
+tools/lab_initialization.sql

--- a/.sqlfluffignore
+++ b/.sqlfluffignore
@@ -2,4 +2,4 @@
 target/
 .venv/
 models/tide/.devenv/
-tools/lab_initialization.sql
+tools/duckdb_initialization.sql

--- a/README.md
+++ b/README.md
@@ -50,10 +50,9 @@ ssh oscm-fund-production-trainer.vm.exe.dev
 start-trainer
 
 # Launch DuckDB for a local query interface against S3 with all data lake views
-# pre-loaded, list available commands, and list available views.
+# pre-loaded. Once in the DuckDB shell, run .help for commands and SHOW TABLES
+# to list loaded views.
 start-duckdb oscm-fund-production
-.help
-SHOW TABLES;
 ```
 
 > For development VMs, run the equivalent `development` scripts.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ ssh exe.dev publish oscm-fund-production-application 8084:8084
 provision-production-trainer-vm
 ssh oscm-fund-production-trainer.vm.exe.dev
 start-trainer
+
+# Launch DuckDB for a local query interface against S3 with all data lake views
+# pre-loaded, list available commands, and list available views.
+start-duckdb oscm-fund-production
+.help
+SHOW TABLES;
 ```
 
 > For development VMs, run the equivalent `development` scripts.
@@ -59,6 +65,7 @@ start-trainer
 - Dashboard is available at `http://<vm-name>.vm.exe.dev:8084`
 - Git sync checks for updates every minute; view logs at `/var/log/fund/sync-application.log`
 - Training runs weekdays at 06:00 UTC; view logs at `/var/log/fund/train-tide-model.log`
+- The local `~/lab.duckdb` file is scratch space. It can be deleted and rebuilt from S3 at any time.
 
 ### Principles
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -382,7 +382,7 @@ in {
     export AWS_S3_BUCKET_NAME="$1"
     echo "Opening DuckDB lab (bucket: $AWS_S3_BUCKET_NAME)"
 
-    exec duckdb ~/lab.duckdb -init tools/lab_initialization.sql
+    exec duckdb ~/lab.duckdb -init "$DEVENV_ROOT/tools/duckdb_initialization.sql"
   '';
 
   scripts.trigger-rebalance.exec = ''
@@ -767,6 +767,8 @@ in {
       echo "    list-aws-secrets            List fund secrets in AWS"
       echo "    trigger-rebalance           Emit an intraday_check event"
       echo "                                manually"
+      echo "    start-duckdb                Open DuckDB with S3 data lake"
+      echo "                                views pre-loaded (pass bucket name)"
       echo "    bump-rust-dependencies      Update all dependency lockfiles"
       echo ""
       echo "  Tasks (devenv tasks run <name>):"
@@ -786,8 +788,6 @@ in {
       echo "                                arguments for usage)"
       echo "    data:equity-details         Seed equity details (run without"
       echo "                                arguments for usage)"
-      echo "    start-duckdb                Open DuckDB with S3 data lake"
-      echo "                                views pre-loaded (pass bucket name)"
       echo "    models:tide:train           Train TiDE model and upload"
       echo "                                artifacts"
     } >&2

--- a/devenv.nix
+++ b/devenv.nix
@@ -367,6 +367,24 @@ in {
     echo "  git diff Cargo.lock"
   '';
 
+  scripts.start-duckdb.exec = ''
+    set -euo pipefail
+
+    if [ -z "''${1:-}" ]; then
+      echo "Usage: start-duckdb <bucket-name>" >&2
+      echo "" >&2
+      echo "Examples:" >&2
+      echo "  start-duckdb oscm-fund-production" >&2
+      echo "  start-duckdb oscm-fund-development-john-forstmeier" >&2
+      exit 1
+    fi
+
+    export AWS_S3_BUCKET_NAME="$1"
+    echo "Opening DuckDB lab (bucket: $AWS_S3_BUCKET_NAME)"
+
+    exec duckdb ~/lab.duckdb -init tools/lab_initialization.sql
+  '';
+
   scripts.trigger-rebalance.exec = ''
     psql -h localhost -p 5432 -d fund -c "SELECT emit_event('intraday_check',
     '{}')"
@@ -598,6 +616,8 @@ in {
       ${applySchema}
     '';
 
+    # --- Lab tasks ---
+
     "checks:base" = {
       exec = ''
         echo "All base checks passed"
@@ -766,6 +786,8 @@ in {
       echo "                                arguments for usage)"
       echo "    data:equity-details         Seed equity details (run without"
       echo "                                arguments for usage)"
+      echo "    start-duckdb                Open DuckDB with S3 data lake"
+      echo "                                views pre-loaded (pass bucket name)"
       echo "    models:tide:train           Train TiDE model and upload"
       echo "                                artifacts"
     } >&2

--- a/tools/duckdb_initialization.sql
+++ b/tools/duckdb_initialization.sql
@@ -1,11 +1,12 @@
--- DuckDB lab initialization script
+-- DuckDB initialization script
 --
--- Loaded automatically by the lab-duckdb devenv script. Creates read-only views
--- over the S3 data lake so production and export data is queryable immediately.
+-- Loaded automatically by the start-duckdb devenv script. Creates read-only
+-- views over the S3 data lake so production and export data is queryable
+-- immediately.
 --
 -- Requirements:
 --   - AWS credentials configured in the environment (e.g. ~/.aws/credentials)
---   - AWS_S3_BUCKET_NAME set (lab-duckdb passes the bucket argument)
+--   - AWS_S3_BUCKET_NAME set (start-duckdb passes the bucket argument)
 
 INSTALL aws;
 LOAD aws;
@@ -22,6 +23,7 @@ SET VARIABLE bucket = getenv('AWS_S3_BUCKET_NAME');
 -- ---------------------------------------------------------------------------
 
 .print 'Loading equity_bars...'
+DROP VIEW IF EXISTS equity_bars;
 CREATE OR REPLACE VIEW equity_bars AS
 SELECT *
 FROM read_parquet(
@@ -30,6 +32,7 @@ FROM read_parquet(
 );
 
 .print 'Loading equity_quotes...'
+DROP VIEW IF EXISTS equity_quotes;
 CREATE OR REPLACE VIEW equity_quotes AS
 SELECT *
 FROM read_parquet(
@@ -38,6 +41,7 @@ FROM read_parquet(
 );
 
 .print 'Loading equity_details...'
+DROP VIEW IF EXISTS equity_details;
 CREATE OR REPLACE VIEW equity_details AS
 SELECT *
 FROM read_csv(
@@ -50,6 +54,7 @@ FROM read_csv(
 -- ---------------------------------------------------------------------------
 
 .print 'Loading equity_predictions...'
+DROP VIEW IF EXISTS equity_predictions;
 CREATE OR REPLACE VIEW equity_predictions AS
 SELECT *
 FROM read_parquet(
@@ -58,6 +63,7 @@ FROM read_parquet(
 );
 
 .print 'Loading equity_rebalance_sessions...'
+DROP VIEW IF EXISTS equity_rebalance_sessions;
 CREATE OR REPLACE VIEW equity_rebalance_sessions AS
 SELECT *
 FROM read_parquet(
@@ -66,6 +72,7 @@ FROM read_parquet(
 );
 
 .print 'Loading equity_pairs...'
+DROP VIEW IF EXISTS equity_pairs;
 CREATE OR REPLACE VIEW equity_pairs AS
 SELECT *
 FROM read_parquet(
@@ -74,6 +81,7 @@ FROM read_parquet(
 );
 
 .print 'Loading equity_allocations...'
+DROP VIEW IF EXISTS equity_allocations;
 CREATE OR REPLACE VIEW equity_allocations AS
 SELECT *
 FROM read_parquet(
@@ -82,6 +90,7 @@ FROM read_parquet(
 );
 
 .print 'Loading equity_orders...'
+DROP VIEW IF EXISTS equity_orders;
 CREATE OR REPLACE VIEW equity_orders AS
 SELECT *
 FROM read_parquet(
@@ -90,6 +99,7 @@ FROM read_parquet(
 );
 
 .print 'Loading equity_portfolio_snapshots...'
+DROP VIEW IF EXISTS equity_portfolio_snapshots;
 CREATE OR REPLACE VIEW equity_portfolio_snapshots AS
 SELECT *
 FROM read_parquet(
@@ -98,6 +108,7 @@ FROM read_parquet(
 );
 
 .print 'Loading model_runs...'
+DROP VIEW IF EXISTS model_runs;
 CREATE OR REPLACE VIEW model_runs AS
 SELECT *
 FROM read_parquet(
@@ -106,6 +117,7 @@ FROM read_parquet(
 );
 
 .print 'Loading equity_reconciliation_events...'
+DROP VIEW IF EXISTS equity_reconciliation_events;
 CREATE OR REPLACE VIEW equity_reconciliation_events AS
 SELECT *
 FROM read_parquet(
@@ -114,5 +126,5 @@ FROM read_parquet(
 );
 
 .print ''
-.print 'Lab initialized. Views with errors above were skipped (no data in S3).'
+.print 'DuckDB initialized. Views with errors above were skipped (no data in S3).'
 .print 'Run .help for DuckDB commands, SHOW TABLES to list loaded views.'

--- a/tools/lab_initialization.sql
+++ b/tools/lab_initialization.sql
@@ -1,0 +1,118 @@
+-- DuckDB lab initialization script
+--
+-- Loaded automatically by the lab-duckdb devenv script. Creates read-only views
+-- over the S3 data lake so production and export data is queryable immediately.
+--
+-- Requirements:
+--   - AWS credentials configured in the environment (e.g. ~/.aws/credentials)
+--   - AWS_S3_BUCKET_NAME set (lab-duckdb passes the bucket argument)
+
+INSTALL aws;
+LOAD aws;
+INSTALL httpfs;
+LOAD httpfs;
+CALL load_aws_credentials();
+
+SET VARIABLE bucket = getenv('AWS_S3_BUCKET_NAME');
+
+.bail off
+
+-- ---------------------------------------------------------------------------
+-- Data lake views (raw ingested data)
+-- ---------------------------------------------------------------------------
+
+.print 'Loading equity_bars...'
+CREATE OR REPLACE VIEW equity_bars AS
+SELECT *
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/data/equity/bars/**/*.parquet',
+    hive_partitioning = true
+);
+
+.print 'Loading equity_quotes...'
+CREATE OR REPLACE VIEW equity_quotes AS
+SELECT *
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/data/equity/quotes/**/*.parquet',
+    hive_partitioning = true
+);
+
+.print 'Loading equity_details...'
+CREATE OR REPLACE VIEW equity_details AS
+SELECT *
+FROM read_csv(
+    's3://' || getvariable('bucket') || '/data/equity/details/details.csv',
+    auto_detect = true
+);
+
+-- ---------------------------------------------------------------------------
+-- Export views (daily operational snapshots)
+-- ---------------------------------------------------------------------------
+
+.print 'Loading equity_predictions...'
+CREATE OR REPLACE VIEW equity_predictions AS
+SELECT *
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/exports/equity/predictions/**/*.parquet',
+    hive_partitioning = true
+);
+
+.print 'Loading equity_rebalance_sessions...'
+CREATE OR REPLACE VIEW equity_rebalance_sessions AS
+SELECT *
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/exports/equity/rebalance-sessions/**/*.parquet',
+    hive_partitioning = true
+);
+
+.print 'Loading equity_pairs...'
+CREATE OR REPLACE VIEW equity_pairs AS
+SELECT *
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/exports/equity/pairs/**/*.parquet',
+    hive_partitioning = true
+);
+
+.print 'Loading equity_allocations...'
+CREATE OR REPLACE VIEW equity_allocations AS
+SELECT *
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/exports/equity/allocations/**/*.parquet',
+    hive_partitioning = true
+);
+
+.print 'Loading equity_orders...'
+CREATE OR REPLACE VIEW equity_orders AS
+SELECT *
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/exports/equity/orders/**/*.parquet',
+    hive_partitioning = true
+);
+
+.print 'Loading equity_portfolio_snapshots...'
+CREATE OR REPLACE VIEW equity_portfolio_snapshots AS
+SELECT *
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/exports/equity/portfolio-snapshots/**/*.parquet',
+    hive_partitioning = true
+);
+
+.print 'Loading model_runs...'
+CREATE OR REPLACE VIEW model_runs AS
+SELECT *
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/exports/model-runs/**/*.parquet',
+    hive_partitioning = true
+);
+
+.print 'Loading equity_reconciliation_events...'
+CREATE OR REPLACE VIEW equity_reconciliation_events AS
+SELECT *
+FROM read_parquet(
+    's3://' || getvariable('bucket') || '/exports/equity/reconciliation-events/**/*.parquet',
+    hive_partitioning = true
+);
+
+.print ''
+.print 'Lab initialized. Views with errors above were skipped (no data in S3).'
+.print 'Run .help for DuckDB commands, SHOW TABLES to list loaded views.'


### PR DESCRIPTION
# Overview

## Changes

- Add `start-duckdb` devenv script replacing the `lab:duckdb` task to support interactive DuckDB sessions (devenv tasks swallow stdin/stdout)
- Require bucket name as a positional argument for explicit environment targeting (e.g. `start-duckdb oscm-fund-production`)
- Add `tools/lab_initialization.sql` with `.bail off` to skip views with no backing S3 data instead of aborting the session
- Add per-view loading status messages for clear feedback on which views succeed or fail
- Update README with `start-duckdb` usage, `.help` reference, and scratch space note
- Exclude `tools/lab_initialization.sql` from sqlfluff linting (DuckDB-specific syntax)

## Context

The previous `lab:duckdb` devenv task had two issues: devenv's task runner captures stdin/stdout making interactive sessions unusable, and DuckDB's `-init` flag aborts on the first error when any S3 path has no data (e.g. `equity_quotes` due to 1-day retention). The new script runs DuckDB directly and uses `.bail off` so missing data skips the view rather than killing the session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a local DuckDB lab workflow for querying S3-backed data.
  - Added ready-to-use views for equity data, predictions, allocations, orders, portfolios, model runs, and reconciliation events.
  - Added guidance for launching the lab session and viewing available tables.

- **Documentation**
  - Documented the required bucket argument and DuckDB commands.
  - Clarified that the local lab database is temporary scratch space and can be regenerated.

- **Chores**
  - Excluded the lab initialization script from SQLFluff checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->