### PR TITLE
Refactor rebalance pipeline from batch to incremental operation

### DIFF
--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -186,7 +186,7 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
     }
 
     // Phase 2: re-fetch state after reconciliation.
-    let alpaca_positions = alpaca.fetch_positions().await.map_err(|error| {
+    let mut alpaca_positions = alpaca.fetch_positions().await.map_err(|error| {
         RebalanceError::Execution(ExecutionError::PositionFetch { source: error })
     })?;
     let open_pairs = fetch_open_pairs(pool).await?;
@@ -219,6 +219,13 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
         );
     }
     let pairs_remaining = open_pairs.len() - pairs_closed;
+
+    // Re-fetch positions after exits so the risk gate sees post-exit exposure.
+    if pairs_closed > 0 {
+        alpaca_positions = alpaca.fetch_positions().await.map_err(|error| {
+            RebalanceError::Execution(ExecutionError::PositionFetch { source: error })
+        })?;
+    }
 
     // Phase 5: drawdown check. Required for both snapshot persistence and entry gating.
     let (current_equity, buying_power) = check_drawdown(
@@ -468,7 +475,7 @@ async fn try_evaluate_entries(
         available_capital,
         exposure_scale,
         state.candidate_pool_count(),
-        required_pairs,
+        vacant_slots,
     )
     .await;
 
@@ -808,8 +815,8 @@ async fn persist_submitted_order(pool: &sqlx::PgPool, leg: &Order<Pending>) {
     }
 }
 
-/// Selects candidate pairs, sizes them, applies the risk gate, filters to
-/// shortable tickers, and executes orders.
+/// Selects candidate pairs, sizes them, filters to tradable and shortable
+/// tickers, applies the pre-trade risk gate, and executes approved orders.
 ///
 /// Submitted orders are persisted to the database before polling for fills,
 /// ensuring that a crash between submission and fill confirmation leaves a
@@ -832,12 +839,12 @@ async fn select_size_execute(
     capital: f64,
     exposure_scale: f64,
     candidate_pool: usize,
-    required_pairs: usize,
+    minimum_pairs: usize,
 ) -> Result<Vec<(FilledPair, crate::portfolio::sizing::SizedPair)>, RebalanceError> {
     let candidate_pairs = select_pairs(signals, historical_prices, candidate_pool);
     info!(
         candidates = candidate_pairs.len(),
-        required = required_pairs,
+        minimum = minimum_pairs,
         "Candidate pairs selected"
     );
 
@@ -882,7 +889,7 @@ async fn select_size_execute(
         &market_betas,
         &entry_prices,
         exposure_scale,
-        required_pairs,
+        minimum_pairs,
     )?;
 
     // Resolve the tradable asset universe from the session cache, populating it
@@ -934,45 +941,96 @@ async fn select_size_execute(
         })
         .collect();
 
-    // Build the portfolio snapshot for risk gate evaluation.
-    let snapshot = build_portfolio_snapshot(current_equity, buying_power, alpaca_positions);
+    // Build the portfolio snapshot for risk gate evaluation. The snapshot is
+    // mutated after each approved pair so later candidates see the cumulative
+    // exposure of earlier approvals.
+    let mut snapshot = build_portfolio_snapshot(current_equity, buying_power, alpaca_positions);
     let now_utc = Utc::now();
 
-    // Apply the risk gate to each candidate pair.
-    let eligible_pairs: Vec<_> = tradable_pairs
-        .into_iter()
-        .filter(|pair| {
-            let combined_notional = pair.long_dollar_amount() + pair.short_dollar_amount();
-            // Use the long ticker as the representative for concentration and
-            // exit feasibility. Both legs are evaluated via combined notional.
-            let request = PositionRequest {
-                ticker: pair.long_ticker().to_string(),
-                asset_type: AssetType::Equity,
-                notional: combined_notional,
-                strategy: StrategyId::StatisticalArbitrage,
-            };
-            // Use a conservative ADV estimate: entry price × 1M shares as a
-            // placeholder. A proper ADV data source can be added later.
-            let liquidity = LiquidityMetrics {
-                average_daily_volume_dollars: pair.long_entry_price() * 1_000_000.0,
-            };
-            let decision =
-                risk_gate::evaluate(risk_gate_config, &snapshot, &request, &liquidity, now_utc);
-            match decision {
-                RiskGateDecision::Approved => true,
-                RiskGateDecision::Rejected { reasons } => {
-                    for reason in &reasons {
-                        info!(
-                            pair_id = pair.pair_id().as_str(),
-                            reason = %reason,
-                            "Risk gate rejected pair"
-                        );
-                    }
-                    false
-                }
+    // Apply the risk gate to each candidate pair, evaluating both legs
+    // independently and accumulating approved exposure into the snapshot.
+    let mut eligible_pairs = Vec::new();
+    for pair in tradable_pairs {
+        // Evaluate the long leg.
+        let long_request = PositionRequest {
+            ticker: pair.long_ticker().to_string(),
+            asset_type: AssetType::Equity,
+            notional: pair.long_dollar_amount(),
+            strategy: StrategyId::StatisticalArbitrage,
+        };
+        // ADV placeholder: entry price × 1M shares. A proper ADV data source
+        // can be added later.
+        let long_liquidity = LiquidityMetrics {
+            average_daily_volume_dollars: pair.long_entry_price() * 1_000_000.0,
+        };
+        let long_decision = risk_gate::evaluate(
+            risk_gate_config,
+            &snapshot,
+            &long_request,
+            &long_liquidity,
+            now_utc,
+        );
+        if let RiskGateDecision::Rejected { reasons } = long_decision {
+            for reason in &reasons {
+                info!(
+                    pair_id = pair.pair_id().as_str(),
+                    leg = "long",
+                    reason = %reason,
+                    "Risk gate rejected pair"
+                );
             }
-        })
-        .collect();
+            continue;
+        }
+
+        // Temporarily add the approved long leg so the short leg evaluation
+        // sees cumulative exposure.
+        snapshot.positions.push(PositionSnapshot {
+            ticker: pair.long_ticker().to_string(),
+            market_value_absolute: pair.long_dollar_amount(),
+            strategy: StrategyId::StatisticalArbitrage,
+        });
+
+        // Evaluate the short leg against the updated snapshot.
+        let short_request = PositionRequest {
+            ticker: pair.short_ticker().to_string(),
+            asset_type: AssetType::Equity,
+            notional: pair.short_dollar_amount(),
+            strategy: StrategyId::StatisticalArbitrage,
+        };
+        let short_liquidity = LiquidityMetrics {
+            average_daily_volume_dollars: pair.short_entry_price() * 1_000_000.0,
+        };
+        let short_decision = risk_gate::evaluate(
+            risk_gate_config,
+            &snapshot,
+            &short_request,
+            &short_liquidity,
+            now_utc,
+        );
+        if let RiskGateDecision::Rejected { reasons } = short_decision {
+            // Roll back the tentatively added long leg.
+            snapshot.positions.pop();
+            for reason in &reasons {
+                info!(
+                    pair_id = pair.pair_id().as_str(),
+                    leg = "short",
+                    reason = %reason,
+                    "Risk gate rejected pair"
+                );
+            }
+            continue;
+        }
+
+        // Both legs approved — add the short leg to the snapshot so
+        // subsequent candidates see the full cumulative exposure.
+        snapshot.positions.push(PositionSnapshot {
+            ticker: pair.short_ticker().to_string(),
+            market_value_absolute: pair.short_dollar_amount(),
+            strategy: StrategyId::StatisticalArbitrage,
+        });
+
+        eligible_pairs.push(pair);
+    }
 
     let pending = execute_open_pairs(alpaca, pool, &eligible_pairs).await;
 
@@ -991,7 +1049,7 @@ async fn select_size_execute(
         return Err(RebalanceError::InsufficientPairs(
             SizingError::InsufficientPairs {
                 found: 0,
-                required: required_pairs,
+                required: minimum_pairs,
             },
         ));
     }

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -1,16 +1,18 @@
 //! Main rebalance orchestration pipeline.
 //!
-//! `run_rebalance` follows a build-then-monitor model:
-//! - **Build** (no open pairs): full portfolio construction with invariant validation
-//! - **Monitor** (open pairs exist): evaluate each pair for close signals, close triggered
-//!   ones, leave vacant slots unfilled
+//! `run_rebalance` runs a unified evaluation pass on every cycle:
+//! 1. **Exit evaluation**: check each open pair for close signals (convergence, stop-loss),
+//!    close triggered pairs on Alpaca and in the database.
+//! 2. **Entry evaluation**: if vacant pair slots exist and market conditions allow (fresh
+//!    predictions, non-trending regime), select, size, risk-gate, and execute new pairs
+//!    using available capital proportional to the number of vacant slots.
 //!
 //! Key functions:
-//! 1. `fetch_market_data` — load predictions and price history from the database
-//! 2. `evaluate_open_pairs` — check each open pair for close signals (convergence, stop-loss)
-//! 3. `close_triggered_pairs` — close only pairs that hit a signal on Alpaca and in the DB
-//! 4. `check_drawdown` — gate on account equity vs previous NAV
-//! 5. `select_size_execute` — select, size, and execute new pairs (build path only)
+//! 1. `evaluate_open_pairs` — check each open pair for close signals
+//! 2. `close_triggered_pairs` — close only pairs that hit a signal
+//! 3. `check_drawdown` — gate on account equity vs previous NAV
+//! 4. `try_evaluate_entries` — load predictions, check regime, run entry pipeline
+//! 5. `select_size_execute` — select, size, risk-gate, and execute new pairs
 //! 6. `persist_filled_pairs` — write session, pairs, allocations, orders, and snapshot
 
 use std::collections::HashMap;
@@ -34,7 +36,6 @@ use crate::common::events::{emit_event, EventType};
 use crate::domain::market::Ticker;
 use crate::domain::orders::{FilledPair, Order, Pending};
 use crate::domain::portfolio::{Portfolio, PortfolioError};
-use crate::domain::predictions::EquityPrediction;
 use crate::domain::trading::{
     AllocationAction, AllocationSide, CloseReason, EquityAllocation, EquityOrder, EquityPair,
     EquityPairStatus, EquityRebalanceSession, RebalanceSessionStatus,
@@ -55,6 +56,10 @@ use crate::portfolio::execution::{
 use crate::portfolio::math::z_score_last;
 use crate::portfolio::reconciliation;
 use crate::portfolio::regime::classify_regime;
+use crate::portfolio::risk_gate::{
+    self, AssetType, LiquidityMetrics, PortfolioSnapshot, PositionRequest, PositionSnapshot,
+    RiskGateDecision, StrategyId,
+};
 use crate::portfolio::sizing::{size_pairs_with_volatility_parity, SizingError};
 use crate::portfolio::state::AppState;
 use crate::portfolio::statistical_arbitrage::select_pairs;
@@ -138,14 +143,16 @@ impl From<PortfolioError> for RebalanceError {
     }
 }
 
-/// Runs one rebalance cycle using a cold-start / warm-start model.
+/// Runs one rebalance cycle with unified exit monitoring and incremental entry.
 ///
-/// Alpaca positions are the source of truth for deciding the path:
-/// - **Cold start** (no Alpaca positions): build a fresh portfolio using account
-///   equity as the capital base. Entry prices come from the Alpaca REST snapshot API
-///   with daily close prices as fallback.
-/// - **Warm start** (Alpaca has positions): evaluate existing pairs for close signals
-///   (convergence, stop-loss). New pairs are never opened while any positions remain.
+/// Every cycle performs both phases:
+/// 1. **Exit evaluation**: if open pairs exist, evaluate each for close signals
+///    (convergence, stop-loss) and close triggered pairs.
+/// 2. **Entry evaluation**: if vacant pair slots exist and market conditions allow,
+///    select, size, risk-gate, and execute new pairs using available capital.
+///
+/// Entry is gated on fresh predictions, a non-trending regime, and passing the
+/// pre-trade risk gate. Exit evaluation runs unconditionally.
 ///
 /// Returns `RebalanceOutcome` on success or a `RebalanceError` describing
 /// why the cycle was skipped or failed.
@@ -153,7 +160,7 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
     let pool = state.pool();
     let alpaca = state.alpaca_client();
 
-    // Phase 1: reconcile DB state against Alpaca positions, then decide path.
+    // Phase 1: reconcile DB state against Alpaca positions.
     let reconciliation_report = match reconciliation::reconcile(pool, alpaca).await {
         Ok(report) => report,
         Err(reconciliation::ReconciliationError::AlpacaFetch(error)) => {
@@ -178,89 +185,118 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
         );
     }
 
-    // Re-fetch state after reconciliation to get the corrected view.
+    // Phase 2: re-fetch state after reconciliation.
     let alpaca_positions = alpaca.fetch_positions().await.map_err(|error| {
         RebalanceError::Execution(ExecutionError::PositionFetch { source: error })
     })?;
     let open_pairs = fetch_open_pairs(pool).await?;
 
-    if !alpaca_positions.is_empty() {
-        // Alpaca has live positions — enter monitor mode.
-        if open_pairs.is_empty() {
-            // Reconciliation should have resolved this, but if it persists, halt.
-            warn!(
-                alpaca_positions = alpaca_positions.len(),
-                "Alpaca has positions but database has no open pairs after reconciliation"
-            );
-            return Err(RebalanceError::Execution(ExecutionError::StateMismatch {
-                message: "Alpaca has positions but database has no open pairs after reconciliation"
-                    .to_string(),
-            }));
-        }
-
-        // Load historical prices for monitor evaluation.
-        let historical_prices = fetch_historical_equity_prices(pool).await?;
-        return run_monitor_cycle(state, pool, alpaca, &open_pairs, &historical_prices).await;
-    }
-
-    // Cold start: no Alpaca positions, no open DB pairs. Build a fresh portfolio.
-    info!("No Alpaca positions; building fresh portfolio");
-
-    // Phase 2: load predictions and market data.
-    let (predictions, historical_prices, spy_prices, equity_details) =
-        fetch_market_data(pool).await?;
-
-    // Phase 3: classify regime; skip if trending.
-    let regime_result = classify_regime(&spy_prices);
-    let exposure_scale = regime_result.state.exposure_factor();
-    if exposure_scale < 0.6 {
-        info!(
-            regime = ?regime_result.state,
-            confidence = ?regime_result.confidence.value(),
-            "Trending regime detected; skipping rebalance"
+    // Sanity check: Alpaca has positions but DB has none after reconciliation.
+    if !alpaca_positions.is_empty() && open_pairs.is_empty() {
+        warn!(
+            alpaca_positions = alpaca_positions.len(),
+            "Alpaca has positions but database has no open pairs after reconciliation"
         );
-        return Err(RebalanceError::TrendingRegime);
+        return Err(RebalanceError::Execution(ExecutionError::StateMismatch {
+            message: "Alpaca has positions but database has no open pairs after reconciliation"
+                .to_string(),
+        }));
     }
 
-    // Phase 4: consolidate signals.
-    let signals = consolidate_predictions(&predictions, &historical_prices, &equity_details);
-    info!(tickers = signals.len(), "Signals consolidated");
+    // Phase 3: load market data (needed for both exit evaluation and entry selection).
+    let historical_prices = fetch_historical_equity_prices(pool).await?;
 
-    // Phase 5: check drawdown. Use current_equity as the capital base for sizing.
-    let (current_equity, _buying_power) = check_drawdown(
+    // Phase 4: exit evaluation — always runs when open pairs exist.
+    let mut pairs_closed: usize = 0;
+    if !open_pairs.is_empty() {
+        let close_signals = evaluate_open_pairs(&open_pairs, &historical_prices);
+        pairs_closed = close_triggered_pairs(alpaca, pool, &close_signals).await?;
+        let pairs_kept_after_exits = open_pairs.len() - pairs_closed;
+        info!(
+            pairs_closed = pairs_closed,
+            pairs_kept = pairs_kept_after_exits,
+            "Exit evaluation completed"
+        );
+    }
+    let pairs_remaining = open_pairs.len() - pairs_closed;
+
+    // Phase 5: drawdown check. Required for both snapshot persistence and entry gating.
+    let (current_equity, buying_power) = check_drawdown(
         alpaca,
         pool,
         state.constraints().drawdown_threshold().0.value(),
     )
     .await?;
 
-    // Phase 6: select, size, and execute new pairs using current_equity.
+    // Phase 6: entry evaluation — gated on predictions, regime, and vacant slots.
     let required_pairs = state.constraints().minimum_pairs().0.get() as usize;
-    let filled = select_size_execute(
-        pool,
-        alpaca,
-        state.tradable_assets(),
-        &signals,
-        &historical_prices,
-        &spy_prices,
-        current_equity,
-        exposure_scale,
-        state.candidate_pool_count(),
-        required_pairs,
-    )
-    .await?;
+    let vacant_slots = required_pairs.saturating_sub(pairs_remaining);
+
+    let mut filled: Vec<(FilledPair, crate::portfolio::sizing::SizedPair)> = Vec::new();
+
+    if vacant_slots > 0 {
+        // Load entry-specific data: predictions, SPY prices, equity details.
+        let entry_result = try_evaluate_entries(
+            state,
+            pool,
+            alpaca,
+            &historical_prices,
+            &alpaca_positions,
+            current_equity,
+            buying_power,
+            vacant_slots,
+            required_pairs,
+        )
+        .await;
+
+        match entry_result {
+            Ok(new_fills) => {
+                filled = new_fills;
+            }
+            Err(EntrySkipReason::StalePredictions) => {
+                if pairs_remaining == 0 && pairs_closed == 0 {
+                    return Err(RebalanceError::StalePredictions);
+                }
+                warn!("Skipping new entries: stale or absent predictions");
+            }
+            Err(EntrySkipReason::TrendingRegime) => {
+                if pairs_remaining == 0 && pairs_closed == 0 {
+                    return Err(RebalanceError::TrendingRegime);
+                }
+                info!("Skipping new entries: trending regime detected");
+            }
+            Err(EntrySkipReason::InsufficientPairs(error)) => {
+                if pairs_remaining == 0 && pairs_closed == 0 {
+                    return Err(RebalanceError::InsufficientPairs(error));
+                }
+                info!("No new pairs found; continuing with exits only");
+            }
+            Err(EntrySkipReason::Other(error)) => {
+                return Err(error);
+            }
+        }
+    } else {
+        info!(
+            pairs_remaining = pairs_remaining,
+            "No vacant pair slots; skipping entry evaluation"
+        );
+    }
 
     let pairs_opened = filled.len();
+    let pairs_kept = pairs_remaining;
 
-    // Phase 7: validate portfolio invariants on the fresh set.
-    let filled_pairs_only: Vec<FilledPair> = filled
-        .iter()
-        .map(|(filled_pair, _)| filled_pair.clone())
-        .collect();
-    Portfolio::new(filled_pairs_only, state.constraints())?;
+    // Phase 7: validate portfolio invariants when new pairs were opened on a
+    // fresh (cold-start) portfolio. When adding to an existing portfolio, the
+    // risk gate has already validated each individual entry.
+    if pairs_opened > 0 && pairs_remaining == 0 {
+        let filled_pairs_only: Vec<FilledPair> = filled
+            .iter()
+            .map(|(filled_pair, _)| filled_pair.clone())
+            .collect();
+        Portfolio::new(filled_pairs_only, state.constraints())?;
+    }
 
-    // Phase 8: persist session, pairs, allocations, orders, and snapshot
-    // inside a single transaction so a mid-cycle failure rolls back all writes.
+    // Phase 8: persist session, pairs, allocations, orders, and snapshot.
     let session_id = Uuid::new_v4();
     let now = Utc::now();
 
@@ -285,8 +321,11 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
     );
     insert_rebalance_session(&mut *transaction, &session).await?;
 
-    let total_slippage_cost =
-        persist_filled_pairs(&mut transaction, session_id, now, &filled).await?;
+    let total_slippage_cost = if filled.is_empty() {
+        Decimal::ZERO
+    } else {
+        persist_filled_pairs(&mut transaction, session_id, now, &filled).await?
+    };
 
     insert_portfolio_snapshot(
         &mut *transaction,
@@ -309,8 +348,8 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
         &serde_json::json!({
             "session_id": session_id.to_string(),
             "pairs_opened": pairs_opened,
-            "pairs_closed": 0,
-            "pairs_kept": 0,
+            "pairs_closed": pairs_closed,
+            "pairs_kept": pairs_kept,
             "net_asset_value": net_asset_value,
         }),
     )
@@ -321,108 +360,125 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
     info!(
         session_id = %session_id,
         pairs_opened = pairs_opened,
+        pairs_closed = pairs_closed,
+        pairs_kept = pairs_kept,
         net_asset_value = net_asset_value,
-        "Fresh portfolio built"
+        "Rebalance cycle completed"
     );
 
     Ok(RebalanceOutcome {
         session_id,
         pairs_opened,
-        pairs_closed: 0,
-        pairs_kept: 0,
-        net_asset_value,
-    })
-}
-
-/// Monitor path: evaluate existing open pairs for close signals and persist a snapshot.
-///
-/// Closed pair slots are intentionally left vacant. If all pairs close during
-/// evaluation, the next rebalance tick will trigger a fresh portfolio build.
-async fn run_monitor_cycle(
-    state: &AppState,
-    pool: &sqlx::PgPool,
-    alpaca: &dyn Trading,
-    open_pairs: &[OpenPair],
-    historical_prices: &HashMap<Ticker, Vec<f64>>,
-) -> Result<RebalanceOutcome, RebalanceError> {
-    let close_signals = evaluate_open_pairs(open_pairs, historical_prices);
-    let pairs_closed = close_triggered_pairs(alpaca, pool, &close_signals).await?;
-    let pairs_kept = open_pairs.len() - pairs_closed;
-
-    info!(
-        pairs_kept = pairs_kept,
-        pairs_closed = pairs_closed,
-        "Monitor cycle: evaluated open pairs"
-    );
-
-    // Persist a snapshot even when no pairs were opened.
-    let (current_equity, _buying_power) = check_drawdown(
-        alpaca,
-        pool,
-        state.constraints().drawdown_threshold().0.value(),
-    )
-    .await?;
-
-    let session_id = Uuid::new_v4();
-    let now = Utc::now();
-
-    let net_asset_value_decimal = Decimal::try_from(current_equity).map_err(|_| {
-        RebalanceError::Conversion("current equity cannot be represented as Decimal".to_string())
-    })?;
-    let net_asset_value = net_asset_value_decimal.to_f64().ok_or_else(|| {
-        RebalanceError::Conversion(
-            "net_asset_value_decimal cannot be represented as f64".to_string(),
-        )
-    })?;
-
-    let mut transaction = pool.begin().await?;
-
-    let session = EquityRebalanceSession::new(
-        session_id,
-        now,
-        "market_session_check".to_string(),
-        None,
-        None,
-        RebalanceSessionStatus::Completed,
-    );
-    insert_rebalance_session(&mut *transaction, &session).await?;
-    insert_portfolio_snapshot(
-        &mut *transaction,
-        now,
-        net_asset_value_decimal,
-        Decimal::ZERO,
-    )
-    .await?;
-    update_rebalance_session_status(
-        &mut *transaction,
-        session_id,
-        &RebalanceSessionStatus::Completed,
-        now,
-    )
-    .await?;
-
-    emit_event(
-        &mut *transaction,
-        EventType::PortfolioRebalanceCompleted,
-        &serde_json::json!({
-            "session_id": session_id.to_string(),
-            "pairs_opened": 0,
-            "pairs_closed": pairs_closed,
-            "pairs_kept": pairs_kept,
-            "net_asset_value": net_asset_value,
-        }),
-    )
-    .await?;
-
-    transaction.commit().await?;
-
-    Ok(RebalanceOutcome {
-        session_id,
-        pairs_opened: 0,
         pairs_closed,
         pairs_kept,
         net_asset_value,
     })
+}
+
+/// Reasons entry evaluation can be skipped without aborting the full cycle.
+enum EntrySkipReason {
+    StalePredictions,
+    TrendingRegime,
+    InsufficientPairs(SizingError),
+    /// A non-recoverable error that should propagate.
+    Other(RebalanceError),
+}
+
+/// Attempts to evaluate and execute new pair entries.
+///
+/// Loads predictions, checks regime, consolidates signals, sizes candidates,
+/// applies the risk gate to each, and executes approved entries.
+///
+/// Returns filled pairs on success, or an `EntrySkipReason` explaining why
+/// entry was skipped (which the caller may treat as non-fatal if exits
+/// already occurred).
+#[allow(clippy::too_many_arguments)]
+async fn try_evaluate_entries(
+    state: &AppState,
+    pool: &sqlx::PgPool,
+    alpaca: &dyn Trading,
+    historical_prices: &HashMap<Ticker, Vec<f64>>,
+    alpaca_positions: &[crate::portfolio::alpaca::Position],
+    current_equity: f64,
+    buying_power: f64,
+    vacant_slots: usize,
+    required_pairs: usize,
+) -> Result<Vec<(FilledPair, crate::portfolio::sizing::SizedPair)>, EntrySkipReason> {
+    // Load predictions.
+    let fresh_predictions = fetch_equity_predictions(pool)
+        .await
+        .map_err(|error| EntrySkipReason::Other(RebalanceError::Database(error)))?;
+    let predictions = fresh_predictions
+        .get()
+        .ok_or(EntrySkipReason::StalePredictions)?;
+    if predictions.is_empty() {
+        return Err(EntrySkipReason::StalePredictions);
+    }
+    let predictions = predictions.to_vec();
+
+    // Load remaining market data for entry selection.
+    let (spy_prices, equity_details) =
+        tokio::join!(fetch_spy_equity_prices(pool), fetch_equity_details(pool),);
+    let spy_prices = spy_prices.map_err(|error| EntrySkipReason::Other(error.into()))?;
+    let equity_details = equity_details.map_err(|error| EntrySkipReason::Other(error.into()))?;
+
+    // Regime check: skip entries if trending.
+    let regime_result = classify_regime(&spy_prices);
+    let exposure_scale = regime_result.state.exposure_factor();
+    if exposure_scale < 0.6 {
+        info!(
+            regime = ?regime_result.state,
+            confidence = ?regime_result.confidence.value(),
+            "Trending regime detected; skipping new entries"
+        );
+        return Err(EntrySkipReason::TrendingRegime);
+    }
+
+    // Consolidate signals.
+    let signals = consolidate_predictions(&predictions, historical_prices, &equity_details);
+    info!(
+        tickers = signals.len(),
+        "Signals consolidated for entry evaluation"
+    );
+
+    // Compute available capital: capped at per-slot allocation to prevent
+    // over-concentration when fewer candidates survive than vacant slots.
+    let per_slot_capital = current_equity / required_pairs as f64;
+    let slot_capped_capital = per_slot_capital * vacant_slots as f64;
+    let available_capital = slot_capped_capital.min(current_equity);
+
+    info!(
+        vacant_slots = vacant_slots,
+        available_capital = format!("{:.2}", available_capital),
+        "Entry capital computed"
+    );
+
+    // Select, size, and execute.
+    let result = select_size_execute(
+        pool,
+        alpaca,
+        state.tradable_assets(),
+        state.risk_gate_configuration(),
+        alpaca_positions,
+        current_equity,
+        buying_power,
+        &signals,
+        historical_prices,
+        &spy_prices,
+        available_capital,
+        exposure_scale,
+        state.candidate_pool_count(),
+        required_pairs,
+    )
+    .await;
+
+    match result {
+        Ok(filled) => Ok(filled),
+        Err(RebalanceError::InsufficientPairs(error)) => {
+            Err(EntrySkipReason::InsufficientPairs(error))
+        }
+        Err(error) => Err(EntrySkipReason::Other(error)),
+    }
 }
 
 /// Closes all open positions at end of day and emits `portfolio_liquidation_completed`.
@@ -511,45 +567,27 @@ pub async fn run_end_of_day_liquidation(state: &AppState) -> Result<usize, Rebal
 // Private pipeline phases
 // ---------------------------------------------------------------------------
 
-/// Fetches and staleness-checks today's predictions, then loads market data.
-///
-/// Returns `(predictions, historical_prices, spy_prices, equity_details)`.
-/// Errors with `StalePredictions` when no valid predictions exist for today.
-async fn fetch_market_data(
-    pool: &sqlx::PgPool,
-) -> Result<
-    (
-        Vec<EquityPrediction>,
-        HashMap<Ticker, Vec<f64>>,
-        Vec<f64>,
-        HashMap<Ticker, String>,
-    ),
-    RebalanceError,
-> {
-    let fresh_predictions = fetch_equity_predictions(pool).await?;
-    let predictions = fresh_predictions
-        .get()
-        .ok_or(RebalanceError::StalePredictions)?;
+/// Builds a `PortfolioSnapshot` from Alpaca account data and current positions
+/// for use by the risk gate.
+fn build_portfolio_snapshot(
+    account_equity: f64,
+    buying_power: f64,
+    positions: &[crate::portfolio::alpaca::Position],
+) -> PortfolioSnapshot {
+    let position_snapshots = positions
+        .iter()
+        .map(|position| PositionSnapshot {
+            ticker: position.symbol.clone(),
+            market_value_absolute: position.market_value.abs(),
+            strategy: StrategyId::StatisticalArbitrage,
+        })
+        .collect();
 
-    if predictions.is_empty() {
-        warn!("No predictions available for today; skipping rebalance");
-        return Err(RebalanceError::StalePredictions);
+    PortfolioSnapshot {
+        account_equity,
+        buying_power,
+        positions: position_snapshots,
     }
-
-    let predictions = predictions.to_vec();
-
-    let (historical_prices_result, spy_prices_result, equity_details_result) = tokio::join!(
-        fetch_historical_equity_prices(pool),
-        fetch_spy_equity_prices(pool),
-        fetch_equity_details(pool),
-    );
-
-    Ok((
-        predictions,
-        historical_prices_result?,
-        spy_prices_result?,
-        equity_details_result?,
-    ))
 }
 
 /// A close signal produced by per-pair evaluation.
@@ -770,7 +808,8 @@ async fn persist_submitted_order(pool: &sqlx::PgPool, leg: &Order<Pending>) {
     }
 }
 
-/// Selects candidate pairs, sizes them, filters to shortable tickers, and executes orders.
+/// Selects candidate pairs, sizes them, applies the risk gate, filters to
+/// shortable tickers, and executes orders.
 ///
 /// Submitted orders are persisted to the database before polling for fills,
 /// ensuring that a crash between submission and fill confirmation leaves a
@@ -783,6 +822,10 @@ async fn select_size_execute(
     pool: &sqlx::PgPool,
     alpaca: &dyn Trading,
     tradable_assets_cache: &Arc<RwLock<Option<Arc<TradableAssets>>>>,
+    risk_gate_config: &risk_gate::RiskGateConfiguration,
+    alpaca_positions: &[crate::portfolio::alpaca::Position],
+    current_equity: f64,
+    buying_power: f64,
     signals: &[ConsolidatedSignal],
     historical_prices: &HashMap<Ticker, Vec<f64>>,
     spy_prices: &[f64],
@@ -870,7 +913,7 @@ async fn select_size_execute(
 
     // Filter pairs to those where the long leg is tradable on Alpaca and the
     // short leg is both tradable and shortable (easy to borrow).
-    let eligible_pairs: Vec<_> = sized_pairs
+    let tradable_pairs: Vec<_> = sized_pairs
         .into_iter()
         .filter(|pair| {
             let long_ok = tradable_assets.is_tradable(pair.long_ticker().as_str());
@@ -888,6 +931,46 @@ async fn select_size_execute(
                 );
             }
             long_ok && short_ok
+        })
+        .collect();
+
+    // Build the portfolio snapshot for risk gate evaluation.
+    let snapshot = build_portfolio_snapshot(current_equity, buying_power, alpaca_positions);
+    let now_utc = Utc::now();
+
+    // Apply the risk gate to each candidate pair.
+    let eligible_pairs: Vec<_> = tradable_pairs
+        .into_iter()
+        .filter(|pair| {
+            let combined_notional = pair.long_dollar_amount() + pair.short_dollar_amount();
+            // Use the long ticker as the representative for concentration and
+            // exit feasibility. Both legs are evaluated via combined notional.
+            let request = PositionRequest {
+                ticker: pair.long_ticker().to_string(),
+                asset_type: AssetType::Equity,
+                notional: combined_notional,
+                strategy: StrategyId::StatisticalArbitrage,
+            };
+            // Use a conservative ADV estimate: entry price × 1M shares as a
+            // placeholder. A proper ADV data source can be added later.
+            let liquidity = LiquidityMetrics {
+                average_daily_volume_dollars: pair.long_entry_price() * 1_000_000.0,
+            };
+            let decision =
+                risk_gate::evaluate(risk_gate_config, &snapshot, &request, &liquidity, now_utc);
+            match decision {
+                RiskGateDecision::Approved => true,
+                RiskGateDecision::Rejected { reasons } => {
+                    for reason in &reasons {
+                        info!(
+                            pair_id = pair.pair_id().as_str(),
+                            reason = %reason,
+                            "Risk gate rejected pair"
+                        );
+                    }
+                    false
+                }
+            }
         })
         .collect();
 
@@ -1419,5 +1502,53 @@ mod tests {
         let message = format!("{error}");
         assert!(message.contains("Numeric conversion"));
         assert!(message.contains("z_score"));
+    }
+
+    // --- build_portfolio_snapshot tests ---
+
+    #[test]
+    fn test_build_portfolio_snapshot_empty_positions() {
+        let snapshot = build_portfolio_snapshot(100_000.0, 400_000.0, &[]);
+        assert!((snapshot.account_equity - 100_000.0).abs() < f64::EPSILON);
+        assert!((snapshot.buying_power - 400_000.0).abs() < f64::EPSILON);
+        assert!(snapshot.positions.is_empty());
+    }
+
+    #[test]
+    fn test_build_portfolio_snapshot_with_positions() {
+        let positions = vec![
+            crate::portfolio::alpaca::Position {
+                symbol: "AAPL".to_string(),
+                side: "long".to_string(),
+                quantity: 100.0,
+                market_value: 15_000.0,
+                unrealized_profit_and_loss: 500.0,
+            },
+            crate::portfolio::alpaca::Position {
+                symbol: "MSFT".to_string(),
+                side: "short".to_string(),
+                quantity: 50.0,
+                market_value: -10_000.0,
+                unrealized_profit_and_loss: -200.0,
+            },
+        ];
+        let snapshot = build_portfolio_snapshot(100_000.0, 350_000.0, &positions);
+        assert_eq!(snapshot.positions.len(), 2);
+        assert_eq!(snapshot.positions[0].ticker, "AAPL");
+        assert!((snapshot.positions[0].market_value_absolute - 15_000.0).abs() < f64::EPSILON);
+        assert_eq!(snapshot.positions[1].ticker, "MSFT");
+        // Short market_value is negative; absolute value should be positive.
+        assert!((snapshot.positions[1].market_value_absolute - 10_000.0).abs() < f64::EPSILON);
+        assert!(matches!(
+            snapshot.positions[0].strategy,
+            StrategyId::StatisticalArbitrage
+        ));
+    }
+
+    #[test]
+    fn test_build_portfolio_snapshot_preserves_equity_and_buying_power() {
+        let snapshot = build_portfolio_snapshot(250_000.0, 800_000.0, &[]);
+        assert!((snapshot.account_equity - 250_000.0).abs() < f64::EPSILON);
+        assert!((snapshot.buying_power - 800_000.0).abs() < f64::EPSILON);
     }
 }

--- a/src/portfolio/state.rs
+++ b/src/portfolio/state.rs
@@ -16,6 +16,9 @@ use crate::domain::portfolio::{
 use crate::domain::primitives::Percent;
 use crate::domain::signals::ConfidenceFloor;
 use crate::portfolio::alpaca::{TradableAssets, Trading, TradingClient};
+use crate::portfolio::risk_gate::{
+    MarginUtilizationLimit, MaximumParticipationRate, RiskGateConfiguration, StrategyId,
+};
 use crate::portfolio::statistical_arbitrage::DEFAULT_CANDIDATE_POOL;
 
 /// Default drawdown threshold: halt trading when portfolio value drops 10% from peak.
@@ -32,6 +35,15 @@ const DEFAULT_BETA_TOLERANCE: f64 = 0.10;
 
 /// Default confidence floor: signals below 50% confidence are excluded.
 const DEFAULT_CONFIDENCE_FLOOR: f64 = 0.50;
+
+/// Default margin utilization limit: halt new entries when 80% of buying power is consumed.
+const DEFAULT_MARGIN_UTILIZATION_LIMIT: f64 = 0.80;
+
+/// Default strategy budget for statistical arbitrage: 100% (only strategy currently).
+const DEFAULT_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE: f64 = 1.0;
+
+/// Default maximum participation rate: 5% of remaining session volume for exit feasibility.
+const DEFAULT_MAXIMUM_PARTICIPATION_RATE: f64 = 0.05;
 
 /// Error returned when `AppState::from_env()` cannot read required configuration.
 #[derive(Debug)]
@@ -90,6 +102,48 @@ fn env_usize(key: &str, default: usize) -> Result<usize, ConfigError> {
     }
 }
 
+/// Builds a `RiskGateConfiguration` from environment variables with safe defaults.
+fn build_risk_gate_configuration(
+    concentration_cap: ConcentrationCap,
+) -> Result<RiskGateConfiguration, ConfigError> {
+    let margin_utilization_limit = Percent::new(env_f64(
+        "PORTFOLIO_MARGIN_UTILIZATION_LIMIT",
+        DEFAULT_MARGIN_UTILIZATION_LIMIT,
+    )?)
+    .map(MarginUtilizationLimit::new)
+    .map_err(|_| ConfigError {
+        message: "PORTFOLIO_MARGIN_UTILIZATION_LIMIT must be a fraction in [0, 1]".to_string(),
+    })?;
+
+    let strategy_budget_stat_arb = Percent::new(env_f64(
+        "PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE",
+        DEFAULT_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE,
+    )?)
+    .map_err(|_| ConfigError {
+        message: "PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE must be a fraction in [0, 1]"
+            .to_string(),
+    })?;
+
+    let maximum_participation_rate = Percent::new(env_f64(
+        "PORTFOLIO_MAXIMUM_PARTICIPATION_RATE",
+        DEFAULT_MAXIMUM_PARTICIPATION_RATE,
+    )?)
+    .map(MaximumParticipationRate::new)
+    .map_err(|_| ConfigError {
+        message: "PORTFOLIO_MAXIMUM_PARTICIPATION_RATE must be a fraction in [0, 1]".to_string(),
+    })?;
+
+    let mut strategy_budgets = std::collections::HashMap::new();
+    strategy_budgets.insert(StrategyId::StatisticalArbitrage, strategy_budget_stat_arb);
+
+    Ok(RiskGateConfiguration {
+        margin_utilization_limit,
+        concentration_cap,
+        strategy_budgets,
+        maximum_participation_rate,
+    })
+}
+
 /// Shared application state for the portfolio module.
 ///
 /// Constructed once at startup via `from_env()`. A value of this type proves
@@ -116,6 +170,8 @@ pub struct AppState {
     /// an upstream crash that never emits `equity_predictions_completed` or
     /// `equity_predictions_errored`.
     rebalance_cycle_started_at: Arc<AtomicI64>,
+    /// Pre-trade risk gate configuration for position request validation.
+    risk_gate_configuration: RiskGateConfiguration,
     /// Number of statistical-arbitrage candidate pairs to consider per rebalance.
     /// Decoupled from the required minimum (`constraints.minimum_pairs`) so a
     /// larger pool can absorb sizing attrition. Override per environment with
@@ -147,6 +203,11 @@ impl AppState {
     /// Returns a reference to the portfolio constraints.
     pub fn constraints(&self) -> &Constraints {
         &self.constraints
+    }
+
+    /// Returns the pre-trade risk gate configuration.
+    pub fn risk_gate_configuration(&self) -> &RiskGateConfiguration {
+        &self.risk_gate_configuration
     }
 
     /// Returns the shared tradable asset cache.
@@ -249,6 +310,8 @@ impl AppState {
         let candidate_pool_count = env_usize("PORTFOLIO_CANDIDATE_POOL", DEFAULT_CANDIDATE_POOL)?
             .max(minimum_pairs.0.get() as usize);
 
+        let risk_gate_configuration = build_risk_gate_configuration(concentration_cap)?;
+
         Ok(Self {
             pool,
             alpaca_client,
@@ -259,6 +322,7 @@ impl AppState {
                 minimum_pairs,
                 beta_tolerance,
             ),
+            risk_gate_configuration,
             tradable_assets: Arc::new(RwLock::new(None)),
             rebalance_cycle_in_progress: Arc::new(AtomicBool::new(false)),
             rebalance_cycle_started_at: Arc::new(AtomicI64::new(0)),
@@ -352,6 +416,8 @@ impl AppState {
         let candidate_pool_count = env_usize("PORTFOLIO_CANDIDATE_POOL", DEFAULT_CANDIDATE_POOL)?
             .max(minimum_pairs.0.get() as usize);
 
+        let risk_gate_configuration = build_risk_gate_configuration(concentration_cap)?;
+
         Ok(Self {
             pool,
             alpaca_client,
@@ -362,6 +428,7 @@ impl AppState {
                 minimum_pairs,
                 beta_tolerance,
             ),
+            risk_gate_configuration,
             tradable_assets: Arc::new(RwLock::new(None)),
             rebalance_cycle_in_progress: Arc::new(AtomicBool::new(false)),
             rebalance_cycle_started_at: Arc::new(AtomicI64::new(0)),
@@ -385,6 +452,22 @@ impl AppState {
         let confidence_floor = ConfidenceFloor(Percent::new(DEFAULT_CONFIDENCE_FLOOR).unwrap());
         let candidate_pool_count = DEFAULT_CANDIDATE_POOL.max(DEFAULT_MINIMUM_PAIRS as usize);
 
+        let mut strategy_budgets = std::collections::HashMap::new();
+        strategy_budgets.insert(
+            StrategyId::StatisticalArbitrage,
+            Percent::new(DEFAULT_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE).unwrap(),
+        );
+        let risk_gate_configuration = RiskGateConfiguration {
+            margin_utilization_limit: MarginUtilizationLimit::new(
+                Percent::new(DEFAULT_MARGIN_UTILIZATION_LIMIT).unwrap(),
+            ),
+            concentration_cap,
+            strategy_budgets,
+            maximum_participation_rate: MaximumParticipationRate::new(
+                Percent::new(DEFAULT_MAXIMUM_PARTICIPATION_RATE).unwrap(),
+            ),
+        };
+
         Self {
             pool,
             alpaca_client: client,
@@ -395,6 +478,7 @@ impl AppState {
                 minimum_pairs,
                 beta_tolerance,
             ),
+            risk_gate_configuration,
             tradable_assets: Arc::new(RwLock::new(None)),
             rebalance_cycle_in_progress: Arc::new(AtomicBool::new(false)),
             rebalance_cycle_started_at: Arc::new(AtomicI64::new(0)),
@@ -419,6 +503,10 @@ mod tests {
         let original_confidence = env::var("PORTFOLIO_CONFIDENCE_FLOOR").ok();
         let original_beta = env::var("PORTFOLIO_BETA_TOLERANCE").ok();
         let original_candidate_pool = env::var("PORTFOLIO_CANDIDATE_POOL").ok();
+        let original_margin_limit = env::var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT").ok();
+        let original_stat_arb_budget =
+            env::var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE").ok();
+        let original_max_participation = env::var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE").ok();
 
         unsafe {
             env::set_var("ALPACA_API_KEY_ID", "test-key");
@@ -430,6 +518,9 @@ mod tests {
             env::remove_var("PORTFOLIO_CONFIDENCE_FLOOR");
             env::remove_var("PORTFOLIO_BETA_TOLERANCE");
             env::remove_var("PORTFOLIO_CANDIDATE_POOL");
+            env::remove_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT");
+            env::remove_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE");
+            env::remove_var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE");
         }
 
         let pool = sqlx::PgPool::connect_lazy("postgresql://user:pass@127.0.0.1:1/test").unwrap();
@@ -477,6 +568,20 @@ mod tests {
             match original_candidate_pool {
                 Some(value) => env::set_var("PORTFOLIO_CANDIDATE_POOL", value),
                 None => env::remove_var("PORTFOLIO_CANDIDATE_POOL"),
+            }
+            match original_margin_limit {
+                Some(value) => env::set_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT", value),
+                None => env::remove_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT"),
+            }
+            match original_stat_arb_budget {
+                Some(value) => {
+                    env::set_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE", value)
+                }
+                None => env::remove_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE"),
+            }
+            match original_max_participation {
+                Some(value) => env::set_var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE", value),
+                None => env::remove_var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE"),
             }
         }
     }
@@ -685,5 +790,129 @@ mod tests {
         let result = env_usize("PORTFOLIO_TEST_WHITESPACE_USIZE", 0).unwrap();
         unsafe { env::remove_var("PORTFOLIO_TEST_WHITESPACE_USIZE") };
         assert_eq!(result, 42);
+    }
+
+    // --- Risk gate configuration tests ---
+
+    #[test]
+    #[serial_test::serial]
+    fn test_build_risk_gate_configuration_defaults() {
+        unsafe {
+            env::remove_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT");
+            env::remove_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE");
+            env::remove_var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE");
+        }
+
+        let concentration_cap = ConcentrationCap(Percent::new(0.20).unwrap());
+        let config = build_risk_gate_configuration(concentration_cap).unwrap();
+
+        assert!(
+            (config.margin_utilization_limit.value() - DEFAULT_MARGIN_UTILIZATION_LIMIT).abs()
+                < f64::EPSILON
+        );
+        assert!(
+            (config.maximum_participation_rate.value() - DEFAULT_MAXIMUM_PARTICIPATION_RATE).abs()
+                < f64::EPSILON
+        );
+        assert!((config.concentration_cap.0.value() - 0.20).abs() < f64::EPSILON);
+
+        let stat_arb_budget = config
+            .strategy_budgets
+            .get(&StrategyId::StatisticalArbitrage)
+            .unwrap();
+        assert!(
+            (stat_arb_budget.value() - DEFAULT_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE).abs()
+                < f64::EPSILON
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_build_risk_gate_configuration_overrides() {
+        unsafe {
+            env::set_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT", "0.60");
+            env::set_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE", "0.75");
+            env::set_var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE", "0.10");
+        }
+
+        let concentration_cap = ConcentrationCap(Percent::new(0.25).unwrap());
+        let config = build_risk_gate_configuration(concentration_cap).unwrap();
+
+        assert!((config.margin_utilization_limit.value() - 0.60).abs() < f64::EPSILON);
+        assert!((config.maximum_participation_rate.value() - 0.10).abs() < f64::EPSILON);
+        assert!((config.concentration_cap.0.value() - 0.25).abs() < f64::EPSILON);
+
+        let stat_arb_budget = config
+            .strategy_budgets
+            .get(&StrategyId::StatisticalArbitrage)
+            .unwrap();
+        assert!((stat_arb_budget.value() - 0.75).abs() < f64::EPSILON);
+
+        unsafe {
+            env::remove_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT");
+            env::remove_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE");
+            env::remove_var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE");
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_build_risk_gate_configuration_invalid_margin_limit_rejects() {
+        unsafe { env::set_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT", "1.5") };
+
+        let concentration_cap = ConcentrationCap(Percent::new(0.20).unwrap());
+        let result = build_risk_gate_configuration(concentration_cap);
+        assert!(result.is_err());
+        assert!(result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("PORTFOLIO_MARGIN_UTILIZATION_LIMIT"));
+
+        unsafe { env::remove_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT") };
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_build_risk_gate_configuration_invalid_participation_rate_rejects() {
+        unsafe { env::set_var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE", "-0.1") };
+
+        let concentration_cap = ConcentrationCap(Percent::new(0.20).unwrap());
+        let result = build_risk_gate_configuration(concentration_cap);
+        assert!(result.is_err());
+
+        unsafe { env::remove_var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE") };
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_build_risk_gate_configuration_invalid_strategy_budget_rejects() {
+        unsafe { env::set_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE", "2.0") };
+
+        let concentration_cap = ConcentrationCap(Percent::new(0.20).unwrap());
+        let result = build_risk_gate_configuration(concentration_cap);
+        assert!(result.is_err());
+
+        unsafe { env::remove_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE") };
+    }
+
+    #[tokio::test]
+    async fn test_with_mock_includes_risk_gate_configuration() {
+        let pool = sqlx::PgPool::connect_lazy("postgresql://user:pass@127.0.0.1:1/test").unwrap();
+        let mock = Arc::new(crate::portfolio::alpaca::MockTrading::default());
+        let state = AppState::with_mock(pool, mock);
+
+        let config = state.risk_gate_configuration();
+        assert!(
+            (config.margin_utilization_limit.value() - DEFAULT_MARGIN_UTILIZATION_LIMIT).abs()
+                < f64::EPSILON
+        );
+        assert!(
+            (config.maximum_participation_rate.value() - DEFAULT_MAXIMUM_PARTICIPATION_RATE).abs()
+                < f64::EPSILON
+        );
+        assert!(config
+            .strategy_budgets
+            .contains_key(&StrategyId::StatisticalArbitrage));
     }
 }

--- a/src/portfolio/state.rs
+++ b/src/portfolio/state.rs
@@ -115,7 +115,7 @@ fn build_risk_gate_configuration(
         message: "PORTFOLIO_MARGIN_UTILIZATION_LIMIT must be a fraction in [0, 1]".to_string(),
     })?;
 
-    let strategy_budget_stat_arb = Percent::new(env_f64(
+    let strategy_budget_statistical_arbitrage = Percent::new(env_f64(
         "PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE",
         DEFAULT_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE,
     )?)
@@ -134,7 +134,10 @@ fn build_risk_gate_configuration(
     })?;
 
     let mut strategy_budgets = std::collections::HashMap::new();
-    strategy_budgets.insert(StrategyId::StatisticalArbitrage, strategy_budget_stat_arb);
+    strategy_budgets.insert(
+        StrategyId::StatisticalArbitrage,
+        strategy_budget_statistical_arbitrage,
+    );
 
     Ok(RiskGateConfiguration {
         margin_utilization_limit,
@@ -142,6 +145,29 @@ fn build_risk_gate_configuration(
         strategy_budgets,
         maximum_participation_rate,
     })
+}
+
+/// Builds a `RiskGateConfiguration` from compile-time defaults.
+///
+/// Used by test helpers (`with_mock`) that need valid configuration without
+/// reading environment variables.
+#[cfg(test)]
+fn default_risk_gate_configuration(concentration_cap: ConcentrationCap) -> RiskGateConfiguration {
+    let mut strategy_budgets = std::collections::HashMap::new();
+    strategy_budgets.insert(
+        StrategyId::StatisticalArbitrage,
+        Percent::new(DEFAULT_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE).unwrap(),
+    );
+    RiskGateConfiguration {
+        margin_utilization_limit: MarginUtilizationLimit::new(
+            Percent::new(DEFAULT_MARGIN_UTILIZATION_LIMIT).unwrap(),
+        ),
+        concentration_cap,
+        strategy_budgets,
+        maximum_participation_rate: MaximumParticipationRate::new(
+            Percent::new(DEFAULT_MAXIMUM_PARTICIPATION_RATE).unwrap(),
+        ),
+    }
 }
 
 /// Shared application state for the portfolio module.
@@ -452,21 +478,7 @@ impl AppState {
         let confidence_floor = ConfidenceFloor(Percent::new(DEFAULT_CONFIDENCE_FLOOR).unwrap());
         let candidate_pool_count = DEFAULT_CANDIDATE_POOL.max(DEFAULT_MINIMUM_PAIRS as usize);
 
-        let mut strategy_budgets = std::collections::HashMap::new();
-        strategy_budgets.insert(
-            StrategyId::StatisticalArbitrage,
-            Percent::new(DEFAULT_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE).unwrap(),
-        );
-        let risk_gate_configuration = RiskGateConfiguration {
-            margin_utilization_limit: MarginUtilizationLimit::new(
-                Percent::new(DEFAULT_MARGIN_UTILIZATION_LIMIT).unwrap(),
-            ),
-            concentration_cap,
-            strategy_budgets,
-            maximum_participation_rate: MaximumParticipationRate::new(
-                Percent::new(DEFAULT_MAXIMUM_PARTICIPATION_RATE).unwrap(),
-            ),
-        };
+        let risk_gate_configuration = default_risk_gate_configuration(concentration_cap);
 
         Self {
             pool,
@@ -794,9 +806,36 @@ mod tests {
 
     // --- Risk gate configuration tests ---
 
+    /// Saves the three risk-gate env vars, returning their previous values.
+    fn save_risk_gate_env_vars() -> [Option<String>; 3] {
+        [
+            env::var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT").ok(),
+            env::var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE").ok(),
+            env::var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE").ok(),
+        ]
+    }
+
+    /// Restores the three risk-gate env vars from saved values.
+    fn restore_risk_gate_env_vars(saved: [Option<String>; 3]) {
+        let keys = [
+            "PORTFOLIO_MARGIN_UTILIZATION_LIMIT",
+            "PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE",
+            "PORTFOLIO_MAXIMUM_PARTICIPATION_RATE",
+        ];
+        unsafe {
+            for (key, value) in keys.into_iter().zip(saved) {
+                match value {
+                    Some(v) => env::set_var(key, v),
+                    None => env::remove_var(key),
+                }
+            }
+        }
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_build_risk_gate_configuration_defaults() {
+        let saved = save_risk_gate_env_vars();
         unsafe {
             env::remove_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT");
             env::remove_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE");
@@ -824,11 +863,14 @@ mod tests {
             (stat_arb_budget.value() - DEFAULT_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE).abs()
                 < f64::EPSILON
         );
+
+        restore_risk_gate_env_vars(saved);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_build_risk_gate_configuration_overrides() {
+        let saved = save_risk_gate_env_vars();
         unsafe {
             env::set_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT", "0.60");
             env::set_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE", "0.75");
@@ -848,16 +890,13 @@ mod tests {
             .unwrap();
         assert!((stat_arb_budget.value() - 0.75).abs() < f64::EPSILON);
 
-        unsafe {
-            env::remove_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT");
-            env::remove_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE");
-            env::remove_var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE");
-        }
+        restore_risk_gate_env_vars(saved);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_build_risk_gate_configuration_invalid_margin_limit_rejects() {
+        let saved = save_risk_gate_env_vars();
         unsafe { env::set_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT", "1.5") };
 
         let concentration_cap = ConcentrationCap(Percent::new(0.20).unwrap());
@@ -869,31 +908,33 @@ mod tests {
             .to_string()
             .contains("PORTFOLIO_MARGIN_UTILIZATION_LIMIT"));
 
-        unsafe { env::remove_var("PORTFOLIO_MARGIN_UTILIZATION_LIMIT") };
+        restore_risk_gate_env_vars(saved);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_build_risk_gate_configuration_invalid_participation_rate_rejects() {
+        let saved = save_risk_gate_env_vars();
         unsafe { env::set_var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE", "-0.1") };
 
         let concentration_cap = ConcentrationCap(Percent::new(0.20).unwrap());
         let result = build_risk_gate_configuration(concentration_cap);
         assert!(result.is_err());
 
-        unsafe { env::remove_var("PORTFOLIO_MAXIMUM_PARTICIPATION_RATE") };
+        restore_risk_gate_env_vars(saved);
     }
 
     #[test]
     #[serial_test::serial]
     fn test_build_risk_gate_configuration_invalid_strategy_budget_rejects() {
+        let saved = save_risk_gate_env_vars();
         unsafe { env::set_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE", "2.0") };
 
         let concentration_cap = ConcentrationCap(Percent::new(0.20).unwrap());
         let result = build_risk_gate_configuration(concentration_cap);
         assert!(result.is_err());
 
-        unsafe { env::remove_var("PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE") };
+        restore_risk_gate_env_vars(saved);
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Overview

## Changes

- Refactors `run_rebalance` from a binary cold-start/warm-start split into a unified evaluation pass that runs both exit monitoring and entry evaluation on every cycle
- Eliminates `run_monitor_cycle`; its exit evaluation logic merges into the unified flow
- Extracts `try_evaluate_entries` to encapsulate entry-specific logic (predictions, regime check, signal consolidation, sizing, risk gate, execution)
- Integrates the pre-trade risk gate (from #1023) into the entry pipeline: every candidate pair passes through `risk_gate::evaluate` before execution
- Adds per-slot capital cap (`equity / minimum_pairs * vacant_slots`) to prevent over-concentration or over-distribution when replacing closed pairs
- Wires `RiskGateConfiguration` into `AppState` with three new environment variables:
  - `PORTFOLIO_MARGIN_UTILIZATION_LIMIT` (default 0.80)
  - `PORTFOLIO_STRATEGY_BUDGET_STATISTICAL_ARBITRAGE` (default 1.0)
  - `PORTFOLIO_MAXIMUM_PARTICIPATION_RATE` (default 0.05)
- Softens error handling: `StalePredictions`, `TrendingRegime`, and `InsufficientPairs` are non-fatal when open pairs exist or exits occurred in the same cycle
- Adds `build_portfolio_snapshot` helper to convert Alpaca positions into risk gate input format

## Context

PR 2 of 4 for continuous capital deployment (Phase 3, Project 8). The batch rebalance model created idle cash periods: capital sat uninvested while the system waited for all pairs to close before building a new portfolio. With incremental operation, individual positions enter and exit independently, and freed capital is immediately available for redeployment.

The risk gate integration ensures that each new entry is validated against current portfolio state (margin utilization, concentration, strategy budget, exit feasibility) before execution. The per-slot capital cap prevents freed capital from being over-allocated to a single replacement pair or spread too thinly across too many candidates.

Exit evaluation runs unconditionally. Entry evaluation is gated on vacant pair slots, fresh predictions, and a non-trending regime. When entry conditions are not met but exits already occurred, the cycle completes successfully with `pairs_opened: 0` rather than returning an error that would mask the successful exits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rebalancing now evaluates exits and new entries in a unified cycle.
  * Added configurable pre-trade risk controls for margin usage, strategy budgets, and market participation.
  * Portfolio snapshots now support risk-aware trade sizing and execution.

* **Bug Fixes**
  * Improved reconciliation between broker positions and portfolio records.
  * Prevented trades that exceed available capital, liquidity limits, or asset trading restrictions.
  * Reduced unnecessary processing when no new positions are opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->