### PR TITLE
Rework position pricing and session lifecycle; enable the integration suite

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -54,25 +54,31 @@ jobs:
         run: >-
           devenv --secretspec-provider env --secretspec-profile development
           tasks run checks:base
-      # The integration test targets run against a real Postgres. Only the
-      # database is started, not the fund services: those would connect to
-      # Alpaca and are not what is under test here.
-      - name: Start PostgreSQL
+      # The integration test targets need a database and an S3-compatible
+      # object store. Only those two are started, not the fund services: those
+      # would connect to Alpaca and are not what is under test here.
+      - name: Start test services
         if: steps.changes.outputs.rust == 'true'
         run: >-
           devenv --secretspec-provider env --secretspec-profile development
-          up postgres --detach
-      - name: Wait for PostgreSQL
+          --profile test up postgres object-store --detach
+      - name: Wait for test services
         if: steps.changes.outputs.rust == 'true'
         run: |
-          for attempt in $(seq 1 60); do
-            if pg_isready -h localhost -p 5432 -q; then
-              echo "PostgreSQL accepting connections after ${attempt}s"
+          for attempt in $(seq 1 90); do
+            postgres_ready=false
+            object_store_ready=false
+            pg_isready -h localhost -p 5432 -q && postgres_ready=true
+            curl -sf -o /dev/null http://127.0.0.1:8333 && object_store_ready=true
+            if [ "$postgres_ready" = true ] && [ "$object_store_ready" = true ]; then
+              echo "Test services ready after ${attempt}s"
               exit 0
             fi
             sleep 1
           done
-          echo "PostgreSQL did not accept connections within 60s"
+          echo "Test services not ready within 90s"
+          echo "  postgres:     $postgres_ready"
+          echo "  object-store: $object_store_ready"
           exit 1
       - name: Run Rust checks
         if: steps.changes.outputs.rust == 'true'

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -65,11 +65,18 @@ jobs:
       - name: Wait for test services
         if: steps.changes.outputs.rust == 'true'
         run: |
+          # Any HTTP response means the object store is listening. `curl -f`
+          # would treat a 403 as down, and an unsigned GET / returns 403 on
+          # MinIO and on real S3, so the probe must not assume a 200 there.
+          object_store_up() {
+            status=$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 http://127.0.0.1:8333 || true)
+            [ -n "${status}" ] && [ "${status}" != "000" ]
+          }
           for attempt in $(seq 1 90); do
             postgres_ready=false
             object_store_ready=false
             pg_isready -h localhost -p 5432 -q && postgres_ready=true
-            curl -sf -o /dev/null http://127.0.0.1:8333 && object_store_ready=true
+            object_store_up && object_store_ready=true
             if [ "$postgres_ready" = true ] && [ "$object_store_ready" = true ]; then
               echo "Test services ready after ${attempt}s"
               exit 0

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -54,6 +54,26 @@ jobs:
         run: >-
           devenv --secretspec-provider env --secretspec-profile development
           tasks run checks:base
+      # The integration test targets run against a real Postgres. Only the
+      # database is started, not the fund services: those would connect to
+      # Alpaca and are not what is under test here.
+      - name: Start PostgreSQL
+        if: steps.changes.outputs.rust == 'true'
+        run: >-
+          devenv --secretspec-provider env --secretspec-profile development
+          up postgres --detach
+      - name: Wait for PostgreSQL
+        if: steps.changes.outputs.rust == 'true'
+        run: |
+          for attempt in $(seq 1 60); do
+            if pg_isready -h localhost -p 5432 -q; then
+              echo "PostgreSQL accepting connections after ${attempt}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "PostgreSQL did not accept connections within 60s"
+          exit 1
       - name: Run Rust checks
         if: steps.changes.outputs.rust == 'true'
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,56 +1010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bollard"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
-dependencies = [
- "base64",
- "bollard-stubs",
- "bytes",
- "futures-core",
- "futures-util",
- "hex",
- "home",
- "http 1.4.2",
- "http-body-util",
- "hyper 1.10.1",
- "hyper-named-pipe",
- "hyper-rustls 0.27.9",
- "hyper-util",
- "hyperlocal",
- "log",
- "pin-project-lite",
- "rustls 0.23.42",
- "rustls-native-certs",
- "rustls-pemfile",
- "rustls-pki-types",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_repr",
- "serde_urlencoded",
- "thiserror 2.0.19",
- "tokio",
- "tokio-util",
- "tower-service",
- "url",
- "winapi",
-]
-
-[[package]]
-name = "bollard-stubs"
-version = "1.47.1-rc.27.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
-dependencies = [
- "serde",
- "serde_repr",
- "serde_with",
-]
-
-[[package]]
 name = "borsh"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,15 +1058,6 @@ checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
-]
-
-[[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "tinyvec",
 ]
 
 [[package]]
@@ -2323,9 +2264,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "derive-new"
@@ -2435,17 +2373,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "docker_credential"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
-dependencies = [
- "base64",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2616,17 +2543,6 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "etcetera"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2883,8 +2799,6 @@ dependencies = [
  "sqlx",
  "tar",
  "tempfile",
- "testcontainers",
- "testcontainers-modules",
  "thiserror 2.0.19",
  "tokio",
  "tokio-tungstenite",
@@ -3496,7 +3410,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -3515,7 +3429,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.2",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -3803,21 +3717,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-named-pipe"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
-dependencies = [
- "hex",
- "hyper 1.10.1",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
- "winapi",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3887,21 +3786,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
-]
-
-[[package]]
-name = "hyperlocal"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
-dependencies = [
- "hex",
- "http-body-util",
- "hyper 1.10.1",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -4076,17 +3960,6 @@ name = "imgref"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
 
 [[package]]
 name = "indexmap"
@@ -4630,7 +4503,7 @@ dependencies = [
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "rustc-hash 1.1.0",
  "spirv",
@@ -5088,31 +4961,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-display"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
-dependencies = [
- "parse-display-derive",
- "regex",
- "regex-syntax",
-]
-
-[[package]]
-name = "parse-display-derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "regex-syntax",
- "structmeta",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "password-hash"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5351,7 +5199,7 @@ dependencies = [
  "comfy-table",
  "either",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "num-traits",
  "polars-arrow",
@@ -5528,7 +5376,7 @@ dependencies = [
  "either",
  "hashbrown 0.15.5",
  "hex",
- "indexmap 2.14.0",
+ "indexmap",
  "libm",
  "memchr",
  "num-traits",
@@ -5640,7 +5488,7 @@ version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6c1ab13e04d5167661a9854ed1ea0482b2ed9b8a0f1118dabed7cd994a85e3"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "polars-error",
  "polars-utils",
  "serde",
@@ -5743,7 +5591,7 @@ dependencies = [
  "flate2",
  "foldhash 0.1.5",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "libc",
  "memmap2",
  "num-traits",
@@ -6340,15 +6188,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
@@ -6374,26 +6213,6 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -6785,15 +6604,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6928,30 +6738,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot",
-]
-
-[[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -7090,17 +6876,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "serde_rusqlite"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7131,38 +6906,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
-dependencies = [
- "base64",
- "bs58",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.14.0",
- "schemars 0.9.0",
- "schemars 1.2.1",
- "serde_core",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -7469,7 +7212,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink 0.10.0",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -7585,7 +7328,7 @@ dependencies = [
  "chrono",
  "crc",
  "dotenvy",
- "etcetera 0.8.0",
+ "etcetera",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -7700,29 +7443,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "structmeta"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta-derive",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "structmeta-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
 
 [[package]]
 name = "strum"
@@ -7959,44 +7679,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "testcontainers"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bb7577dca13ad86a78e8271ef5d322f37229ec83b8d98da6d996c588a1ddb1"
-dependencies = [
- "async-trait",
- "bollard",
- "bollard-stubs",
- "bytes",
- "docker_credential",
- "either",
- "etcetera 0.10.0",
- "futures",
- "log",
- "memchr",
- "parse-display",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.19",
- "tokio",
- "tokio-stream",
- "tokio-tar",
- "tokio-util",
- "url",
-]
-
-[[package]]
-name = "testcontainers-modules"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac95cde96549fc19c6bf19ef34cc42bd56e264c1cb97e700e21555be0ecf9e2"
-dependencies = [
- "testcontainers",
-]
-
-[[package]]
 name = "text_placeholder"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8206,21 +7888,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tar"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "redox_syscall 0.3.5",
- "tokio",
- "tokio-stream",
- "xattr",
-]
-
-[[package]]
 name = "tokio-tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8264,7 +7931,7 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -8590,7 +8257,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -8863,7 +8529,7 @@ dependencies = [
  "bitflags 2.13.0",
  "cfg_aliases 0.1.1",
  "document-features",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "naga",
  "once_cell",
@@ -9551,7 +9217,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
- "indexmap 2.14.0",
+ "indexmap",
  "num_enum",
  "thiserror 1.0.69",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,8 +127,3 @@ http = "1"
 mockito = "1.7"
 serial_test = "4.0"
 tower = { version = "0.5", features = ["util"] }
-testcontainers = "0.24"
-testcontainers-modules = { version = "0.12", features = [
-  "localstack",
-  "postgres",
-] }

--- a/devenv.nix
+++ b/devenv.nix
@@ -56,6 +56,20 @@ in {
   };
 
   git-hooks.hooks = {
+    # Ordered before check-rust deliberately. The sqlx check takes about four
+    # seconds against a warm build; check-rust runs fmt, clippy over all targets,
+    # and the test suite with coverage. Schema drift is the failure most likely
+    # to be caught here, so surfacing it in seconds rather than after minutes of
+    # unrelated work is worth the ordering.
+    check-sqlx = {
+      enable = true;
+      name = "Check sqlx query metadata cache";
+      entry = "check-sqlx";
+      files = "\\.rs$|schema\\.sql$";
+      pass_filenames = false;
+      language = "system";
+      fail_fast = true;
+    };
     check-rust = {
       enable = true;
       name = "Check all Rust code";
@@ -106,15 +120,6 @@ in {
       name = "Check all Nix code";
       entry = "check-nix";
       files = "\\.nix$";
-      pass_filenames = false;
-      language = "system";
-      fail_fast = true;
-    };
-    check-sqlx = {
-      enable = true;
-      name = "Check sqlx query metadata cache";
-      entry = "check-sqlx";
-      files = "\\.rs$|schema\\.sql$";
       pass_filenames = false;
       language = "system";
       fail_fast = true;
@@ -317,10 +322,25 @@ in {
 
   scripts.check-sqlx.exec = ''
     set -euo pipefail
+    # The committed .sqlx/ cache can disagree with schema.sql, and every offline
+    # build believes the cache. Only a live connection catches that, so a
+    # missing database is a failure rather than a pass: exiting 0 here reported
+    # success for a check that had not run, which is worse than not having it.
     if ! pg_isready -q 2>/dev/null; then
-      echo "sqlx prepare check skipped: database not available"
-      echo "Run 'devenv --profile application up' then 'cargo sqlx prepare -- --all-features' to verify the cache"
-      exit 0
+      echo "Starting PostgreSQL to verify the sqlx query metadata cache"
+      devenv up postgres --detach >/dev/null 2>&1 || true
+      for attempt in $(seq 1 30); do
+        if pg_isready -q 2>/dev/null; then
+          break
+        fi
+        sleep 1
+      done
+    fi
+    if ! pg_isready -q 2>/dev/null; then
+      echo "sqlx prepare check FAILED: no database after 30s"
+      echo "Start it with 'devenv up postgres --detach', then re-run the commit."
+      echo "The .sqlx/ cache cannot be validated against schema.sql without one."
+      exit 1
     fi
     echo "Checking sqlx query metadata cache is up to date"
     cargo sqlx prepare --check -- --all-features

--- a/devenv.nix
+++ b/devenv.nix
@@ -312,9 +312,17 @@ in {
   # developer remembering to start two processes before every commit.
   scripts.ensure-test-services.exec = ''
     set -euo pipefail
+    # Any HTTP response means the object store is listening. `curl -f` would
+    # treat a 403 as down, and an unsigned GET / returns 403 on MinIO and on
+    # real S3 — TEST_S3_ENDPOINT is overridable, so the probe must not depend
+    # on one server answering 200 there.
+    object_store_up() {
+      [ -n "$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "${objectStoreEndpoint}" 2>/dev/null | grep -v '^000$')" ]
+    }
+
     needed=""
     pg_isready -q 2>/dev/null || needed="postgres"
-    curl -sf -o /dev/null "${objectStoreEndpoint}" 2>/dev/null || needed="$needed object-store"
+    object_store_up || needed="$needed object-store"
 
     if [ -z "$needed" ]; then
       exit 0
@@ -327,7 +335,7 @@ in {
       pg_ok=false
       store_ok=false
       pg_isready -q 2>/dev/null && pg_ok=true
-      curl -sf -o /dev/null "${objectStoreEndpoint}" 2>/dev/null && store_ok=true
+      object_store_up && store_ok=true
       if [ "$pg_ok" = true ] && [ "$store_ok" = true ]; then
         exit 0
       fi

--- a/devenv.nix
+++ b/devenv.nix
@@ -47,6 +47,24 @@
   # The runtimeEnv block above detects when that path is not writable (e.g.
   # local laptop without bootstrap) and falls back to an XDG state path.
   fundLogDir = "/var/log/fund";
+
+  # S3-compatible object store for the integration test suite. Defined here so
+  # the process definition and the environment handed to the tests cannot drift
+  # apart; `tests/common` reads these values from the environment.
+  #
+  # SeaweedFS rather than MinIO: MinIO is marked insecure in this nixpkgs
+  # (CVE-2026-40344 and CVE-2026-41145 are unauthenticated object-write
+  # bypasses), and using it would mean adding it to permittedInsecurePackages —
+  # a project-wide statement that a known-vulnerable package is acceptable, to
+  # gain nothing SeaweedFS does not already provide here.
+  #
+  # The credentials are arbitrary. SeaweedFS with no S3 configuration file
+  # accepts any signature, but the AWS SDK still requires non-empty values to
+  # sign a request, so the tests must send something.
+  objectStorePort = 8333;
+  objectStoreAccessKey = "fundtest";
+  objectStoreSecretKey = "fundtestsecret";
+  objectStoreEndpoint = "http://127.0.0.1:${toString objectStorePort}";
 in {
   dotenv.enable = true;
 
@@ -153,6 +171,14 @@ in {
 
     # Disable AWS CLI pager so secrets output is not paged
     AWS_PAGER = "";
+
+    # S3-compatible endpoint and credentials for the integration test suite.
+    # Set unconditionally rather than inside the test profile so `cargo test`
+    # works from a plain devenv shell; only the MinIO process itself is
+    # profile-scoped.
+    TEST_S3_ENDPOINT = objectStoreEndpoint;
+    TEST_S3_ACCESS_KEY = objectStoreAccessKey;
+    TEST_S3_SECRET_KEY = objectStoreSecretKey;
   };
 
   services.postgres = {
@@ -196,6 +222,7 @@ in {
     markdownlint-cli
     postgresql_16
     rustup
+    seaweedfs
     (sqlfluff.overridePythonAttrs (_: {
       # The aarch64-darwin binary is not cached on cache.nixos.org for this
       # nixpkgs revision; building from source runs the full pytest suite which
@@ -279,23 +306,59 @@ in {
     echo "No unused dependencies found"
   '';
 
+  # Brings up the services the integration targets need, if they are not
+  # already listening. Mirrors what check-sqlx does for the database: a check
+  # that cannot run is worse than no check, and the alternative is every
+  # developer remembering to start two processes before every commit.
+  scripts.ensure-test-services.exec = ''
+    set -euo pipefail
+    needed=""
+    pg_isready -q 2>/dev/null || needed="postgres"
+    curl -sf -o /dev/null "${objectStoreEndpoint}" 2>/dev/null || needed="$needed object-store"
+
+    if [ -z "$needed" ]; then
+      exit 0
+    fi
+
+    echo "Starting test services:$needed"
+    devenv --profile test up $needed --detach >/dev/null 2>&1 || true
+
+    for _ in $(seq 1 60); do
+      pg_ok=false
+      store_ok=false
+      pg_isready -q 2>/dev/null && pg_ok=true
+      curl -sf -o /dev/null "${objectStoreEndpoint}" 2>/dev/null && store_ok=true
+      if [ "$pg_ok" = true ] && [ "$store_ok" = true ]; then
+        exit 0
+      fi
+      sleep 1
+    done
+
+    echo "Test services did not start within 60s"
+    echo "  postgres:     $(pg_isready -q 2>/dev/null && echo ready || echo down)"
+    echo "  object-store: ${objectStoreEndpoint}"
+    echo "Start them with 'devenv --profile test up postgres object-store --detach'."
+    exit 1
+  '';
+
   scripts.test-rust.exec = ''
     set -euo pipefail
+    ensure-test-services
     echo "Running Rust tests"
 
     # Integration test targets are named individually rather than passing
-    # --tests. Every target listed here runs against the devenv-managed
-    # Postgres and needs no container runtime. test_backfill is deliberately
-    # absent: it still starts LocalStack through testcontainers and so requires
-    # a Docker daemon, which neither this shell nor CI provides.
+    # --tests, so adding a target is a deliberate act and a new file cannot
+    # join the gate unnoticed. Every target here runs against the devenv-managed
+    # PostgreSQL and MinIO; none needs a container runtime.
     #
     # Before this, target selection was --lib --bins, which silently excluded
     # every file under tests/ — around 1,300 lines that compiled under clippy
     # but whose assertions had never been executed.
     TEST_ARGS="--lib --bins --all-features"
-    TEST_ARGS="$TEST_ARGS --test test_data --test test_database"
-    TEST_ARGS="$TEST_ARGS --test test_ensemble_events --test test_errors"
-    TEST_ARGS="$TEST_ARGS --test test_handlers --test test_stream"
+    TEST_ARGS="$TEST_ARGS --test test_backfill --test test_data"
+    TEST_ARGS="$TEST_ARGS --test test_database --test test_ensemble_events"
+    TEST_ARGS="$TEST_ARGS --test test_errors --test test_handlers"
+    TEST_ARGS="$TEST_ARGS --test test_stream"
 
     mkdir -p .coverage_output
     export LLVM_COV=$(which llvm-cov)
@@ -757,6 +820,31 @@ in {
       MLFLOW_TRACKING_URI = "";
       PREFECT_API_URL = "";
     };
+  };
+
+  # Test profile: an S3-compatible object store for the integration suite.
+  #
+  # Scoped to its own profile rather than declared top level, because profile
+  # modules merge with the top level and a top-level process would therefore
+  # start in production, which has no use for it. PostgreSQL is top level by
+  # contrast because production genuinely needs it.
+  #
+  # This replaces the LocalStack container the suite used to start through
+  # testcontainers. The tests never needed Docker as such — they needed an HTTP
+  # endpoint speaking S3, and `create_test_s3_client` already builds its client
+  # with an explicit endpoint and path-style addressing, which is exactly the
+  # configuration an S3-compatible server wants.
+  profiles.test.module = {
+    processes.object-store.exec = ''
+      set -euo pipefail
+      OBJECT_STORE_DIR="''${DEVENV_STATE:-.devenv/state}/object-store"
+      mkdir -p "$OBJECT_STORE_DIR"
+      exec weed server \
+        -dir="$OBJECT_STORE_DIR" \
+        -ip=127.0.0.1 \
+        -s3 \
+        -s3.port=${toString objectStorePort}
+    '';
   };
 
   enterShell = ''

--- a/devenv.nix
+++ b/devenv.nix
@@ -278,7 +278,19 @@ in {
     set -euo pipefail
     echo "Running Rust tests"
 
+    # Integration test targets are named individually rather than passing
+    # --tests. Every target listed here runs against the devenv-managed
+    # Postgres and needs no container runtime. test_backfill is deliberately
+    # absent: it still starts LocalStack through testcontainers and so requires
+    # a Docker daemon, which neither this shell nor CI provides.
+    #
+    # Before this, target selection was --lib --bins, which silently excluded
+    # every file under tests/ — around 1,300 lines that compiled under clippy
+    # but whose assertions had never been executed.
     TEST_ARGS="--lib --bins --all-features"
+    TEST_ARGS="$TEST_ARGS --test test_data --test test_database"
+    TEST_ARGS="$TEST_ARGS --test test_ensemble_events --test test_errors"
+    TEST_ARGS="$TEST_ARGS --test test_handlers --test test_stream"
 
     mkdir -p .coverage_output
     export LLVM_COV=$(which llvm-cov)

--- a/schema.sql
+++ b/schema.sql
@@ -329,10 +329,10 @@ CREATE TABLE IF NOT EXISTS equity_predictions (
 SELECT create_hypertable('equity_predictions', by_range('timestamp'), if_not_exists => TRUE);
 SELECT remove_retention_policy('equity_predictions', if_exists => TRUE);
 
--- Session cron jobs: one pre-market prediction request plus a portfolio
--- evaluation heartbeat. Consumers listen on the 'events' channel; live quotes
--- reach the portfolio service over the in-memory broadcast channel and are
--- never persisted, so no table mediates this path.
+-- Session cron jobs: one pre-market prediction request plus a session-start
+-- trigger. Consumers listen on the 'events' channel; live quotes reach the
+-- portfolio service over the in-memory broadcast channel and are never
+-- persisted, so no table mediates this path.
 DO $do$
 BEGIN
     -- Remove superseded tick jobs. market-session-check emitted a prediction
@@ -362,20 +362,32 @@ BEGIN
             AND (now() AT TIME ZONE 'America/New_York')::time < TIME '09:05'$$
     );
 
-    -- Portfolio evaluation heartbeat: every five minutes through the session.
-    -- The portfolio consumer checks the real session before acting, so this
-    -- window may safely span a regular close even on early-close days. Live
-    -- quote threshold crossings emit the same event, making this a recovery
-    -- path rather than the sole driver.
+    -- Retire the five-minute evaluation heartbeat. It ran a full rebalance pass
+    -- every five minutes whether or not anything had changed: up to 78 passes a
+    -- session, each re-ranking the candidate reservoir and re-pricing every open
+    -- leg to usually conclude that nothing should happen. Intraday work is now
+    -- driven by the live-quote evaluator, which emits
+    -- portfolio_evaluation_requested only when a spread actually crosses a close
+    -- threshold, and the session is opened and closed by the two jobs below.
     IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'portfolio-evaluation-requested') THEN
         PERFORM cron.unschedule('portfolio-evaluation-requested');
     END IF;
+
+    -- Session start: weekdays at 09:25 Eastern, five minutes ahead of a regular
+    -- open. The portfolio consumer confirms against Alpaca's clock that the
+    -- market actually trades today, so a holiday costs one no-op event; the
+    -- schedule itself only needs to exclude weekends. Fires in UTC hours 13-14
+    -- to cover both EDT and EST, gated on the actual Eastern time so DST needs
+    -- no schema re-apply.
+    IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'trading-session-started') THEN
+        PERFORM cron.unschedule('trading-session-started');
+    END IF;
     PERFORM cron.schedule(
-        'portfolio-evaluation-requested',
-        '*/5 13-20 * * 1-5',
-        $$SELECT emit_event('portfolio_evaluation_requested', '{"reason": "heartbeat"}'::jsonb)
-          WHERE (now() AT TIME ZONE 'America/New_York')::time >= TIME '09:30'
-            AND (now() AT TIME ZONE 'America/New_York')::time < TIME '16:00'$$
+        'trading-session-started',
+        '25 13,14 * * 1-5',
+        $$SELECT emit_event('trading_session_started', '{"reason": "scheduled_open"}'::jsonb)
+          WHERE (now() AT TIME ZONE 'America/New_York')::time >= TIME '09:25'
+            AND (now() AT TIME ZONE 'America/New_York')::time < TIME '09:30'$$
     );
 END;
 $do$;
@@ -421,8 +433,8 @@ $$;
 -- Fires in the UTC range 19-20 (covering 15:45 EDT and 15:45 EST) with an inline WHERE clause
 -- that gates on the actual Eastern time, so DST is handled correctly year-round without needing
 -- to re-apply the schema after a DST transition.
--- This is the fail-safe path only. The portfolio consumer derives the real close from Alpaca on every
--- evaluation pass and requests liquidation once it is within the lead time, which pulls liquidation
+-- This is the fail-safe path only. On trading_session_started the portfolio consumer reads the real
+-- close from Alpaca and arms a one-shot timer for 15 minutes before it, which pulls liquidation
 -- forward on early-close days when this fixed 15:45 schedule would fire hours after the market shut.
 -- This job still fires unconditionally so an unreachable Alpaca clock cannot leave positions open
 -- overnight; liquidation is idempotent, so both paths firing is harmless.

--- a/src/bin/fund.rs
+++ b/src/bin/fund.rs
@@ -176,6 +176,7 @@ async fn run(module: Option<Module>) -> Result<(), Box<dyn std::error::Error>> {
                 fund::stream::alpaca_equities::run_quote_stream(
                     configuration,
                     credentials,
+                    state.alpaca_client_handle(),
                     pool.clone(),
                     Arc::clone(&market_data_buffer),
                     shutdown_token.clone(),

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -69,13 +69,27 @@ pub enum EventType {
     /// inference: equity prediction run encountered an error.
     EquityPredictionsErrored,
 
-    // --- Portfolio rebalance ---
-    /// pg_cron periodic trigger: evaluate open positions for exits and idle
-    /// capital for entries.
+    // --- Trading session ---
+    /// pg_cron trigger: the trading session is about to begin.
     ///
-    /// Also emitted by the live-quote evaluator when a spread crosses a close
-    /// threshold, so the cron acts as a heartbeat and recovery path rather than
-    /// the sole driver.
+    /// Emitted once, shortly before the regular open. Starts the session: the
+    /// portfolio consumer reconciles against the broker, confirms the market
+    /// actually trades today, builds the initial portfolio, and arms the
+    /// liquidation timer from the real session close.
+    ///
+    /// This replaced a five-minute evaluation heartbeat that ran a full
+    /// rebalance whether or not anything had changed. Intraday work is driven by
+    /// the live-quote evaluator instead, which emits
+    /// [`EventType::PortfolioEvaluationRequested`] only when a spread actually
+    /// crosses a close threshold.
+    TradingSessionStarted,
+
+    // --- Portfolio rebalance ---
+    /// Evaluate open positions for exits and idle capital for entries.
+    ///
+    /// Emitted by the live-quote evaluator on a threshold crossing. No longer
+    /// emitted on a timer: a pass that finds nothing changed is pure cost, and
+    /// the events that genuinely need one now emit it directly.
     PortfolioEvaluationRequested,
     /// portfolio: rebalance has started.
     PortfolioRebalanceStarted,
@@ -123,6 +137,7 @@ impl EventType {
             Self::EquityPredictionsStarted => "equity_predictions_started",
             Self::EquityPredictionsCompleted => "equity_predictions_completed",
             Self::EquityPredictionsErrored => "equity_predictions_errored",
+            Self::TradingSessionStarted => "trading_session_started",
             Self::PortfolioEvaluationRequested => "portfolio_evaluation_requested",
             Self::PortfolioRebalanceStarted => "portfolio_rebalance_started",
             Self::PortfolioRebalanceCompleted => "portfolio_rebalance_completed",
@@ -158,6 +173,7 @@ impl EventType {
             "equity_predictions_started" => Some(Self::EquityPredictionsStarted),
             "equity_predictions_completed" => Some(Self::EquityPredictionsCompleted),
             "equity_predictions_errored" => Some(Self::EquityPredictionsErrored),
+            "trading_session_started" => Some(Self::TradingSessionStarted),
             "portfolio_evaluation_requested" => Some(Self::PortfolioEvaluationRequested),
             "portfolio_rebalance_started" => Some(Self::PortfolioRebalanceStarted),
             "portfolio_rebalance_completed" => Some(Self::PortfolioRebalanceCompleted),
@@ -367,6 +383,7 @@ mod tests {
             EventType::EquityPredictionsStarted,
             EventType::EquityPredictionsCompleted,
             EventType::EquityPredictionsErrored,
+            EventType::TradingSessionStarted,
             EventType::PortfolioEvaluationRequested,
             EventType::PortfolioRebalanceStarted,
             EventType::PortfolioRebalanceCompleted,
@@ -557,6 +574,7 @@ mod tests {
                 "database_purge_completed",
             ),
             (EventType::DatabasePurgeErrored, "database_purge_errored"),
+            (EventType::TradingSessionStarted, "trading_session_started"),
             (
                 EventType::PortfolioEvaluationRequested,
                 "portfolio_evaluation_requested",
@@ -641,6 +659,7 @@ mod tests {
             EventType::EquityPredictionsStarted,
             EventType::EquityPredictionsCompleted,
             EventType::EquityPredictionsErrored,
+            EventType::TradingSessionStarted,
             EventType::PortfolioEvaluationRequested,
             EventType::PortfolioRebalanceStarted,
             EventType::PortfolioRebalanceCompleted,
@@ -670,6 +689,10 @@ mod tests {
         assert_ne!(
             EventType::PortfolioEvaluationRequested,
             EventType::EquityPredictionsStarted
+        );
+        assert_ne!(
+            EventType::TradingSessionStarted,
+            EventType::PortfolioEvaluationRequested
         );
     }
 

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -208,6 +208,12 @@ pub const CONSUMER_PORTFOLIO: &str = "portfolio";
 /// so the predictions offset cannot mask a missed end-of-day liquidation.
 pub const CONSUMER_PORTFOLIO_LIQUIDATION: &str = "portfolio-liquidation";
 
+/// Consumer name for the portfolio session-start consumer.
+/// Tracks the last processed `trading_session_started` event so a process that
+/// was down at the open can still build the portfolio when it comes back, for
+/// as long as the session is still trading.
+pub const CONSUMER_PORTFOLIO_SESSION: &str = "portfolio-session";
+
 /// Consumer name for the data equity bars sync consumer.
 pub const CONSUMER_DATA_EQUITY_BARS_SYNC: &str = "data-equity-bars-sync";
 

--- a/src/common/market_hours.rs
+++ b/src/common/market_hours.rs
@@ -1,12 +1,23 @@
 //! US equity market session helpers.
 //!
-//! Provides timezone-aware checks for whether the current time falls within
-//! the regular US equity trading session (09:30–16:00 Eastern) or the wider
-//! quote-stream window used by `data` to capture quotes around open
-//! and close.
+//! Provides timezone-aware checks for whether the current time falls within the
+//! regular US equity trading session or the wider quote-stream window that the
+//! portfolio's quote producer and live exit trigger run inside.
+//!
+//! Two families of check live here, and the difference matters. [`MarketSession`]
+//! is built from Alpaca's reported close, so it handles early closes and market
+//! holidays without a local calendar. The free functions below assume a regular
+//! 09:30–16:00 session and only exclude weekends; they exist as a fallback for
+//! paths that must keep working when the clock endpoint is unreachable.
 
 use chrono::{DateTime, Datelike, Duration, NaiveTime, TimeZone, Timelike, Utc, Weekday};
 use chrono_tz::US::Eastern;
+
+/// Minutes the quote-stream window extends either side of the trading session.
+///
+/// Opening early means quotes are already flowing when the first evaluation pass
+/// runs; closing late covers fills landing just after the bell.
+pub const QUOTE_STREAM_LEAD_MINUTES: i64 = 5;
 
 /// A regular US equity trading session, anchored on Alpaca's reported close time.
 ///
@@ -55,9 +66,39 @@ impl MarketSession {
         self.is_open
     }
 
+    /// Returns the session open instant, derived as 09:30 Eastern on the close's date.
+    pub fn open(&self) -> DateTime<Utc> {
+        self.open
+    }
+
     /// Returns the session close instant.
     pub fn close(&self) -> DateTime<Utc> {
         self.close
+    }
+
+    /// Returns `true` when `now` falls inside the quote-stream window for this session.
+    ///
+    /// The window brackets the real session by [`QUOTE_STREAM_LEAD_MINUTES`] on
+    /// each side, so quotes are already flowing when the first evaluation runs
+    /// and late fills are still covered after the close. Because both edges come
+    /// from Alpaca's reported close, an early close pulls the whole window
+    /// forward and a holiday never opens one at all — neither of which a fixed
+    /// wall-clock window can express.
+    pub fn contains_quote_stream_window(&self, now: DateTime<Utc>) -> bool {
+        let lead = Duration::minutes(QUOTE_STREAM_LEAD_MINUTES);
+        now >= self.open - lead && now < self.close + lead
+    }
+
+    /// Returns the duration from `now` until this session's quote-stream window
+    /// opens, or `Duration::zero()` when it is already open or has passed.
+    pub fn time_until_quote_stream_window(&self, now: DateTime<Utc>) -> Duration {
+        let window_open = self.open - Duration::minutes(QUOTE_STREAM_LEAD_MINUTES);
+        let remaining = window_open.signed_duration_since(now);
+        if remaining < Duration::zero() {
+            Duration::zero()
+        } else {
+            remaining
+        }
     }
 
     /// Returns `true` when this session closes on the same Eastern date as `now`.
@@ -126,9 +167,10 @@ pub fn is_within_trading_session() -> bool {
 /// Returns `true` when `now` falls within the quote-stream window
 /// (09:25–16:05 Eastern, weekdays only). DST-safe.
 ///
-/// The window opens 5 minutes before market open so quotes are already flowing
-/// when the first rebalance cycle runs, and closes 5 minutes after market close
-/// to capture any late fills and the liquidation event.
+/// Assumes a regular close and knows nothing about market holidays, so on a
+/// holiday it reports a window that will carry no quotes. Callers that can reach
+/// Alpaca's clock should prefer [`MarketSession::contains_quote_stream_window`];
+/// this remains the fallback for when that fetch fails.
 pub fn is_within_quote_stream_window_at(now: DateTime<Utc>) -> bool {
     is_weekday_minutes_in_range(now, 9 * 60 + 25, 16 * 60 + 5)
 }
@@ -246,6 +288,53 @@ mod tests {
         assert!(session.contains(utc("2024-07-15T19:59:00Z")));
         assert!(!session.contains(utc("2024-07-15T20:00:00Z")));
         assert!(!session.contains(utc("2024-07-15T13:29:00Z")));
+    }
+
+    #[test]
+    fn test_session_open_is_derived_at_nine_thirty_eastern() {
+        // 20:00 UTC = 16:00 EDT, so the open derives to 13:30 UTC.
+        let session = MarketSession::new(true, utc("2024-07-15T20:00:00Z")).unwrap();
+        assert_eq!(session.open(), utc("2024-07-15T13:30:00Z"));
+
+        // In December the same 09:30 Eastern is 14:30 UTC.
+        let winter = MarketSession::new(true, utc("2024-12-16T21:00:00Z")).unwrap();
+        assert_eq!(winter.open(), utc("2024-12-16T14:30:00Z"));
+    }
+
+    #[test]
+    fn test_quote_stream_window_brackets_the_session() {
+        let session = MarketSession::new(true, utc("2024-07-15T20:00:00Z")).unwrap();
+
+        // Five minutes before the open, and one minute before that.
+        assert!(session.contains_quote_stream_window(utc("2024-07-15T13:25:00Z")));
+        assert!(!session.contains_quote_stream_window(utc("2024-07-15T13:24:00Z")));
+
+        // Five minutes past the close is the exclusive edge.
+        assert!(session.contains_quote_stream_window(utc("2024-07-15T20:04:59Z")));
+        assert!(!session.contains_quote_stream_window(utc("2024-07-15T20:05:00Z")));
+    }
+
+    #[test]
+    fn test_quote_stream_window_shifts_with_an_early_close() {
+        // 17:00 UTC = 13:00 EDT. The window must end at 13:05 Eastern, not 16:05.
+        let session = MarketSession::new(true, utc("2024-07-03T17:00:00Z")).unwrap();
+        assert!(session.contains_quote_stream_window(utc("2024-07-03T17:04:00Z")));
+        assert!(!session.contains_quote_stream_window(utc("2024-07-03T17:06:00Z")));
+    }
+
+    #[test]
+    fn test_time_until_quote_stream_window_saturates_at_zero() {
+        let session = MarketSession::new(false, utc("2024-07-15T20:00:00Z")).unwrap();
+        // 12:00 UTC = 08:00 EDT: 85 minutes until the 09:25 window open.
+        assert_eq!(
+            session.time_until_quote_stream_window(utc("2024-07-15T12:00:00Z")),
+            Duration::minutes(85)
+        );
+        // Already inside the session: the window opened long ago.
+        assert_eq!(
+            session.time_until_quote_stream_window(utc("2024-07-15T15:00:00Z")),
+            Duration::zero()
+        );
     }
 
     #[test]

--- a/src/domain/freshness.rs
+++ b/src/domain/freshness.rs
@@ -19,6 +19,22 @@ pub const PREDICTIONS_STALENESS_WINDOW_HOURS: i64 = 20;
 /// on smaller names is expected rather than exceptional.
 pub const QUOTES_STALENESS_WINDOW_SECONDS: i64 = 60;
 
+/// Named staleness window for quotes pulled from the REST snapshot endpoint.
+///
+/// Deliberately wider than [`QUOTES_STALENESS_WINDOW_SECONDS`], and the reason
+/// is not that REST data is more trustworthy — it is the same IEX feed. A symbol
+/// quiet on the stream is quiet in the snapshot for exactly the same reason, so
+/// reusing the sixty-second window would reject the snapshot in precisely the
+/// cases it was added to cover, leaving it useful only when the subscription
+/// dropped a symbol that is otherwise quoting normally.
+///
+/// Five minutes was chosen against a measured sample of the traded universe:
+/// 64% of symbols had quoted within sixty seconds, 80% within five minutes, and
+/// 86% within fifteen. The marginal six points between five and fifteen minutes
+/// come from names whose books are too wide to price against anyway, so the
+/// book-quality gate rejects them regardless of how recent the quote is.
+pub const REST_QUOTES_STALENESS_WINDOW_SECONDS: i64 = 300;
+
 /// Error returned when constructing a `StalenessWindow` with a non-positive duration.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ZeroDurationError;
@@ -54,6 +70,12 @@ impl StalenessWindow {
     pub fn quotes() -> Self {
         StalenessWindow::new(Duration::seconds(QUOTES_STALENESS_WINDOW_SECONDS))
             .expect("QUOTES_STALENESS_WINDOW_SECONDS must be positive")
+    }
+
+    /// Returns the staleness window for REST snapshot quotes (5 minutes).
+    pub fn rest_quotes() -> Self {
+        StalenessWindow::new(Duration::seconds(REST_QUOTES_STALENESS_WINDOW_SECONDS))
+            .expect("REST_QUOTES_STALENESS_WINDOW_SECONDS must be positive")
     }
 }
 

--- a/src/domain/market.rs
+++ b/src/domain/market.rs
@@ -397,6 +397,160 @@ impl EquityQuote {
     }
 }
 
+/// Widest book, as a fraction of the midpoint, whose mid is treated as a price.
+///
+/// Derived from trade economics rather than from the observed distribution. A
+/// pair crosses the spread on both legs entering and both legs exiting, so the
+/// round-trip cost is roughly the sum of the two legs' spreads: at 25 basis
+/// points a leg that is about 50 basis points a round turn, which the strategy's
+/// edge has to clear before anything is left. Measured liquid names quote 1–15
+/// basis points, so this leaves generous room while excluding the several
+/// hundred to several thousand basis point books seen on thin symbols.
+pub const MAXIMUM_RELATIVE_SPREAD: f64 = 0.0025;
+
+/// Smallest quoted size, per side, accepted as real liquidity.
+///
+/// One round lot. This excludes odd-lot-only books rather than expressing a view
+/// on depth: the observed sample quoted exactly 100 on both sides often enough
+/// that a higher floor would cut aggressively for reasons no measurement here
+/// supports. Raising it should follow a study of the size distribution across
+/// the traded universe, not intuition.
+pub const MINIMUM_QUOTE_SIZE: i32 = 100;
+
+/// Bounds a two-sided book must satisfy before its midpoint is treated as a price.
+///
+/// Both limits exist because a quote can be arithmetically valid and still
+/// economically meaningless. The IEX feed carries a few percent of consolidated
+/// volume, so a thinly quoted name routinely shows a book hundreds of basis
+/// points wide whose midpoint sits nowhere near any price the symbol traded at.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BookQualityLimits {
+    maximum_relative_spread: f64,
+    minimum_size: i32,
+}
+
+/// Error returned when constructing [`BookQualityLimits`] with unusable bounds.
+#[derive(Debug, Clone, PartialEq)]
+pub struct InvalidBookQualityLimits;
+
+impl std::fmt::Display for InvalidBookQualityLimits {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Maximum relative spread must be positive and finite, and minimum size non-negative."
+        )
+    }
+}
+
+impl std::error::Error for InvalidBookQualityLimits {}
+
+impl BookQualityLimits {
+    /// Creates limits, rejecting a non-positive or non-finite spread bound.
+    pub fn new(
+        maximum_relative_spread: f64,
+        minimum_size: i32,
+    ) -> Result<Self, InvalidBookQualityLimits> {
+        if !maximum_relative_spread.is_finite() || maximum_relative_spread <= 0.0 {
+            return Err(InvalidBookQualityLimits);
+        }
+        if minimum_size < 0 {
+            return Err(InvalidBookQualityLimits);
+        }
+        Ok(Self {
+            maximum_relative_spread,
+            minimum_size,
+        })
+    }
+
+    pub fn maximum_relative_spread(&self) -> f64 {
+        self.maximum_relative_spread
+    }
+
+    pub fn minimum_size(&self) -> i32 {
+        self.minimum_size
+    }
+}
+
+impl Default for BookQualityLimits {
+    fn default() -> Self {
+        Self::new(MAXIMUM_RELATIVE_SPREAD, MINIMUM_QUOTE_SIZE)
+            .expect("MAXIMUM_RELATIVE_SPREAD and MINIMUM_QUOTE_SIZE must be valid bounds")
+    }
+}
+
+/// An [`EquityQuote`] proven to carry a book worth pricing against.
+///
+/// Holding one is proof that every check in [`UsableQuote::new`] passed, so
+/// [`UsableQuote::mid_price`] is a price rather than a candidate for
+/// re-validation downstream. Both the streamed and the REST-snapshot paths
+/// construct through here, which is what keeps them from drifting apart: an
+/// earlier arrangement validated `bid > 0 && ask > 0` on one path and
+/// additionally rejected crossed books on the other, so the same quote could be
+/// usable or not depending on which code reached it first.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct UsableQuote {
+    mid_price: f64,
+    relative_spread: f64,
+    observed_at: DateTime<Utc>,
+}
+
+impl UsableQuote {
+    /// Returns the validated quote, or `None` when the book fails any check.
+    ///
+    /// Each side is validated independently before the midpoint is formed.
+    /// Checking only the average would accept a one-sided book such as
+    /// `bid = 0, ask = 200`, whose mean is a plausible-looking 100 but is really
+    /// half a real price — and it would then feed every spread that leg appears
+    /// in. A crossed book (`bid > ask`) is rejected for a related reason: it is
+    /// a stale frame or a feed artifact, and its midpoint is not a price
+    /// anything traded at.
+    ///
+    /// Size is checked because a tight spread quoted for a handful of shares is
+    /// not liquidity a real position can cross.
+    pub fn new(quote: &EquityQuote, limits: BookQualityLimits) -> Option<Self> {
+        let bid_price = quote.bid_price();
+        let ask_price = quote.ask_price();
+
+        if !bid_price.is_finite() || bid_price <= 0.0 {
+            return None;
+        }
+        if !ask_price.is_finite() || ask_price <= 0.0 {
+            return None;
+        }
+        if bid_price > ask_price {
+            return None;
+        }
+        if quote.bid_size() < limits.minimum_size() || quote.ask_size() < limits.minimum_size() {
+            return None;
+        }
+
+        let mid_price = (bid_price + ask_price) / 2.0;
+        let relative_spread = (ask_price - bid_price) / mid_price;
+        if relative_spread > limits.maximum_relative_spread() {
+            return None;
+        }
+
+        Some(Self {
+            mid_price,
+            relative_spread,
+            observed_at: quote.timestamp(),
+        })
+    }
+
+    pub fn mid_price(&self) -> f64 {
+        self.mid_price
+    }
+
+    /// Spread as a fraction of the midpoint; multiply by 10,000 for basis points.
+    pub fn relative_spread(&self) -> f64 {
+        self.relative_spread
+    }
+
+    pub fn observed_at(&self) -> DateTime<Utc> {
+        self.observed_at
+    }
+}
+
 /// Ticker metadata record seeded from the S3 details CSV.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EquityDetail {
@@ -935,5 +1089,129 @@ mod tests {
         let mut map: HashMap<PairID, i32> = HashMap::new();
         map.insert(key.clone(), 42);
         assert_eq!(map.get(&key), Some(&42));
+    }
+
+    // --- BookQualityLimits / UsableQuote ---
+
+    fn book(bid: f64, ask: f64, bid_size: i32, ask_size: i32) -> EquityQuote {
+        EquityQuote::new(
+            Utc::now(),
+            Ticker::new("AAPL").expect("valid ticker"),
+            bid,
+            ask,
+            bid_size,
+            ask_size,
+        )
+    }
+
+    /// Limits that admit any width, isolating the price and size rules.
+    fn any_width() -> BookQualityLimits {
+        BookQualityLimits::new(f64::MAX, 0).expect("valid limits")
+    }
+
+    #[test]
+    fn test_book_quality_limits_reject_non_positive_spread() {
+        assert_eq!(
+            BookQualityLimits::new(0.0, 100).unwrap_err(),
+            InvalidBookQualityLimits
+        );
+        assert_eq!(
+            BookQualityLimits::new(-0.01, 100).unwrap_err(),
+            InvalidBookQualityLimits
+        );
+        assert_eq!(
+            BookQualityLimits::new(f64::NAN, 100).unwrap_err(),
+            InvalidBookQualityLimits
+        );
+    }
+
+    #[test]
+    fn test_book_quality_limits_reject_negative_size() {
+        assert_eq!(
+            BookQualityLimits::new(0.0025, -1).unwrap_err(),
+            InvalidBookQualityLimits
+        );
+    }
+
+    #[test]
+    fn test_book_quality_limits_default_matches_constants() {
+        let limits = BookQualityLimits::default();
+        assert_eq!(limits.maximum_relative_spread(), MAXIMUM_RELATIVE_SPREAD);
+        assert_eq!(limits.minimum_size(), MINIMUM_QUOTE_SIZE);
+    }
+
+    #[test]
+    fn test_usable_quote_accepts_tight_book() {
+        let quote = UsableQuote::new(&book(180.0, 180.2, 100, 100), BookQualityLimits::default())
+            .expect("tight book is usable");
+        assert!((quote.mid_price() - 180.1).abs() < 1e-9);
+        // (180.2 - 180.0) / 180.1 = 11.1 basis points.
+        assert!((quote.relative_spread() * 10_000.0 - 11.105).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_usable_quote_accepts_touching_book() {
+        // Bid equal to ask is valid, not crossed, and has zero spread.
+        let quote = UsableQuote::new(&book(180.0, 180.0, 100, 100), BookQualityLimits::default())
+            .expect("touching book is usable");
+        assert_eq!(quote.mid_price(), 180.0);
+        assert_eq!(quote.relative_spread(), 0.0);
+    }
+
+    #[test]
+    fn test_usable_quote_validates_each_side_independently() {
+        // A one-sided book averages to a plausible-looking positive number.
+        // Validating only the midpoint would accept 100.0 for a symbol with no
+        // bid, and that value would feed every spread the leg appears in.
+        assert!(UsableQuote::new(&book(0.0, 200.0, 100, 100), any_width()).is_none());
+        assert!(UsableQuote::new(&book(200.0, 0.0, 100, 100), any_width()).is_none());
+        assert!(UsableQuote::new(&book(-1.0, 200.0, 100, 100), any_width()).is_none());
+        assert!(UsableQuote::new(&book(f64::NAN, 180.0, 100, 100), any_width()).is_none());
+        assert!(UsableQuote::new(&book(180.0, f64::INFINITY, 100, 100), any_width()).is_none());
+    }
+
+    #[test]
+    fn test_usable_quote_rejects_crossed_book() {
+        assert!(UsableQuote::new(&book(181.0, 180.0, 100, 100), any_width()).is_none());
+    }
+
+    #[test]
+    fn test_usable_quote_rejects_book_wider_than_limit() {
+        // 180.0 / 200.0 spans 1,053 basis points against a 25 basis point bound.
+        assert!(
+            UsableQuote::new(&book(180.0, 200.0, 100, 100), BookQualityLimits::default()).is_none()
+        );
+    }
+
+    #[test]
+    fn test_usable_quote_accepts_book_exactly_at_spread_limit() {
+        // Boundary is inclusive: rejection requires exceeding the limit.
+        let limits = BookQualityLimits::new(0.01, 0).expect("valid limits");
+        let quote = UsableQuote::new(&book(99.5, 100.5, 0, 0), limits)
+            .expect("a book exactly at the limit is usable");
+        assert!((quote.relative_spread() - 0.01).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_usable_quote_rejects_undersized_side() {
+        let limits = BookQualityLimits::new(1.0, 100).expect("valid limits");
+        assert!(UsableQuote::new(&book(180.0, 180.2, 1, 100), limits).is_none());
+        assert!(UsableQuote::new(&book(180.0, 180.2, 100, 1), limits).is_none());
+        assert!(UsableQuote::new(&book(180.0, 180.2, 100, 100), limits).is_some());
+    }
+
+    #[test]
+    fn test_usable_quote_preserves_observation_time() {
+        let observed_at = Utc::now();
+        let quote = EquityQuote::new(
+            observed_at,
+            Ticker::new("AAPL").expect("valid ticker"),
+            180.0,
+            180.2,
+            100,
+            100,
+        );
+        let usable = UsableQuote::new(&quote, BookQualityLimits::default()).expect("usable");
+        assert_eq!(usable.observed_at(), observed_at);
     }
 }

--- a/src/portfolio/alpaca.rs
+++ b/src/portfolio/alpaca.rs
@@ -13,6 +13,7 @@ use tracing::info;
 
 use crate::common::alpaca::AlpacaCredentials;
 use crate::common::market_hours::MarketSession;
+use crate::domain::market::{EquityQuote, Ticker};
 
 /// Base URL for paper trading (sandbox environment).
 const PAPER_BASE_URL: &str = "https://paper-api.alpaca.markets";
@@ -28,6 +29,14 @@ const HEADER_KEY_ID: &str = "APCA-API-KEY-ID";
 
 /// Header name for the Alpaca API secret key.
 const HEADER_SECRET_KEY: &str = "APCA-API-SECRET-KEY";
+
+/// Symbols requested per snapshot call.
+///
+/// The endpoint imposes no documented symbol ceiling and was measured accepting
+/// 2,000 symbols in a 9,424-character URL. The cap here is not the API's limit
+/// but a bound on request-line length, which intermediaries do restrict, and it
+/// keeps a single failed request from losing the whole universe.
+const SNAPSHOT_SYMBOLS_PER_REQUEST: usize = 1_000;
 
 /// Account information returned by the Alpaca account endpoint.
 ///
@@ -71,12 +80,40 @@ pub struct Position {
 }
 
 /// Latest quote snapshot for a single symbol from the Alpaca data API.
+///
+/// Carries the raw two-sided book rather than a precomputed mid so callers can
+/// apply [`UsableQuote`] and a staleness window themselves. Returning only a mid
+/// discarded the information needed to tell a tradeable book from a book
+/// hundreds of basis points wide, and a quote posted a second ago from one
+/// posted hours earlier — both of which the snapshot reports identically.
 #[derive(Debug, Clone)]
 pub struct LatestQuote {
     /// Ticker symbol.
     pub symbol: String,
-    /// Mid price computed as `(bid + ask) / 2`.
-    pub mid_price: f64,
+    /// Best bid price.
+    pub bid_price: f64,
+    /// Best ask price.
+    pub ask_price: f64,
+    /// Size quoted at the bid.
+    pub bid_size: i32,
+    /// Size quoted at the ask.
+    pub ask_size: i32,
+    /// Exchange timestamp of the quote.
+    pub observed_at: DateTime<Utc>,
+}
+
+impl LatestQuote {
+    /// Converts to the domain quote type, returning `None` for an invalid ticker.
+    pub fn to_equity_quote(&self) -> Option<EquityQuote> {
+        Some(EquityQuote::new(
+            self.observed_at,
+            Ticker::new(&self.symbol)?,
+            self.bid_price,
+            self.ask_price,
+            self.bid_size,
+            self.ask_size,
+        ))
+    }
 }
 
 /// The fill information for a submitted order.
@@ -450,8 +487,20 @@ impl TradingClient {
 
         let mut tradable = std::collections::HashSet::new();
         let mut shortable = std::collections::HashSet::new();
+        let mut inactive_rejected: usize = 0;
 
         for asset in assets {
+            // Checked here as well as in the query string. The `status=active`
+            // parameter above already filters server-side, so this rejects
+            // nothing today — it exists so that a change to the URL cannot
+            // silently admit delisted or suspended symbols into the universe.
+            if asset.status.as_deref() != Some("active") {
+                inactive_rejected += 1;
+                continue;
+            }
+            // `fractionable` is required, not incidental: beta-neutral sizing
+            // solves for fractional weights on the long leg, so a symbol that
+            // only trades in whole shares cannot express the resulting position.
             if asset.tradable.unwrap_or(false) && asset.fractionable.unwrap_or(false) {
                 tradable.insert(asset.symbol.clone());
                 if asset.shortable.unwrap_or(false) && asset.easy_to_borrow.unwrap_or(false) {
@@ -463,6 +512,7 @@ impl TradingClient {
         info!(
             tradable = tradable.len(),
             shortable = shortable.len(),
+            inactive_rejected,
             "Tradable asset universe fetched"
         );
 
@@ -596,8 +646,15 @@ impl TradingClient {
 
     /// Fetches latest quote snapshots for the given symbols from the Alpaca data API.
     ///
-    /// Returns a list of mid prices `(bid + ask) / 2`. Symbols without
-    /// a valid quote are omitted from the result.
+    /// Symbols are requested in chunks of [`SNAPSHOT_SYMBOLS_PER_REQUEST`] and
+    /// the results concatenated, so a caller may pass the whole filtered
+    /// universe without splitting it. No book validation happens here: the raw
+    /// two-sided quote is returned and callers gate it through
+    /// [`UsableQuote`], which is the same gate the streamed path uses.
+    ///
+    /// Symbols the API returns without a usable `latestQuote` object are
+    /// omitted rather than defaulted, because a missing side is indistinguishable
+    /// from a zero one after the fact.
     pub async fn fetch_latest_quotes(
         &self,
         symbols: &[String],
@@ -606,6 +663,25 @@ impl TradingClient {
             return Ok(Vec::new());
         }
 
+        let mut quotes: Vec<LatestQuote> = Vec::new();
+        for chunk in symbols.chunks(SNAPSHOT_SYMBOLS_PER_REQUEST) {
+            quotes.extend(self.fetch_latest_quotes_chunk(chunk).await?);
+        }
+
+        info!(
+            requested = symbols.len(),
+            returned = quotes.len(),
+            requests = symbols.len().div_ceil(SNAPSHOT_SYMBOLS_PER_REQUEST),
+            "Latest quotes fetched from Alpaca data API"
+        );
+        Ok(quotes)
+    }
+
+    /// Fetches one chunk of symbols, small enough to fit a single request URL.
+    async fn fetch_latest_quotes_chunk(
+        &self,
+        symbols: &[String],
+    ) -> Result<Vec<LatestQuote>, ClientError> {
         let symbols_param = symbols.join(",");
         let url = format!(
             "{}/v2/stocks/snapshots?symbols={}&feed=iex",
@@ -630,28 +706,22 @@ impl TradingClient {
                 ClientError::Parse(format!("Failed to parse snapshots response: {error}"))
             })?;
 
-        let quotes: Vec<LatestQuote> = snapshots
+        Ok(snapshots
             .into_iter()
             .filter_map(|(symbol, snapshot)| {
                 let quote = snapshot.latest_quote?;
-                let bid = quote.bp?;
-                let ask = quote.ap?;
-                if bid <= 0.0 || ask <= 0.0 {
-                    return None;
-                }
                 Some(LatestQuote {
                     symbol,
-                    mid_price: (bid + ask) / 2.0,
+                    bid_price: quote.bp?,
+                    ask_price: quote.ap?,
+                    // A quote reporting a price but no size is treated as
+                    // zero size, which the book-quality gate then rejects.
+                    bid_size: quote.bs.unwrap_or(0),
+                    ask_size: quote.ask_size.unwrap_or(0),
+                    observed_at: quote.t?,
                 })
             })
-            .collect();
-
-        info!(
-            requested = symbols.len(),
-            returned = quotes.len(),
-            "Latest quotes fetched from Alpaca data API"
-        );
-        Ok(quotes)
+            .collect())
     }
 }
 
@@ -769,6 +839,7 @@ struct OrderResponse {
 #[derive(Deserialize)]
 struct AssetResponse {
     symbol: String,
+    status: Option<String>,
     tradable: Option<bool>,
     fractionable: Option<bool>,
     shortable: Option<bool>,
@@ -796,10 +867,21 @@ struct SnapshotResponse {
     latest_quote: Option<SnapshotQuote>,
 }
 
+/// The `latestQuote` object from a snapshot response.
+///
+/// Field names are Alpaca's and are not renamed: `bp`/`ap` are bid and ask
+/// price, `bs`/`as` their sizes, and `t` the exchange timestamp. The timestamp
+/// and sizes were previously discarded, which left the REST path unable to tell
+/// a quote posted a second ago from one posted at the open, and unable to
+/// distinguish a tight book from a tight book quoted for five shares.
 #[derive(Deserialize)]
 struct SnapshotQuote {
     bp: Option<f64>,
     ap: Option<f64>,
+    bs: Option<i32>,
+    #[serde(rename = "as")]
+    ask_size: Option<i32>,
+    t: Option<DateTime<Utc>>,
 }
 
 /// Test-only mock implementation of the [`Trading`] trait.
@@ -1131,12 +1213,12 @@ mod tests {
             .with_status(200)
             .with_body(
                 r#"[
-                {"symbol": "AAPL", "tradable": true,  "fractionable": true,  "shortable": true,  "easy_to_borrow": true},
-                {"symbol": "MSFT", "tradable": true,  "fractionable": true,  "shortable": false, "easy_to_borrow": true},
-                {"symbol": "GOOG", "tradable": true,  "fractionable": true,  "shortable": true,  "easy_to_borrow": false},
-                {"symbol": "NVDA", "tradable": true,  "fractionable": true,  "shortable": true,  "easy_to_borrow": true},
-                {"symbol": "AMZN", "tradable": true,  "fractionable": false, "shortable": true,  "easy_to_borrow": true},
-                {"symbol": "META", "tradable": false, "fractionable": true,  "shortable": true,  "easy_to_borrow": true}
+                {"symbol": "AAPL", "status": "active", "tradable": true,  "fractionable": true,  "shortable": true,  "easy_to_borrow": true},
+                {"symbol": "MSFT", "status": "active", "tradable": true,  "fractionable": true,  "shortable": false, "easy_to_borrow": true},
+                {"symbol": "GOOG", "status": "active", "tradable": true,  "fractionable": true,  "shortable": true,  "easy_to_borrow": false},
+                {"symbol": "NVDA", "status": "active", "tradable": true,  "fractionable": true,  "shortable": true,  "easy_to_borrow": true},
+                {"symbol": "AMZN", "status": "active", "tradable": true,  "fractionable": false, "shortable": true,  "easy_to_borrow": true},
+                {"symbol": "META", "status": "active", "tradable": false, "fractionable": true,  "shortable": true,  "easy_to_borrow": true}
             ]"#,
             )
             .create_async()
@@ -1163,6 +1245,36 @@ mod tests {
 
         assert_eq!(assets.tradable_count(), 4);
         assert_eq!(assets.shortable_count(), 2);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_tradable_assets_rejects_non_active_status() {
+        // The query string already filters server-side, so this can only fire
+        // if that parameter is changed or dropped. It is the guard that keeps a
+        // delisted or suspended symbol out of the universe when it does.
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", "/v2/assets?status=active&asset_class=us_equity")
+            .with_status(200)
+            .with_body(
+                r#"[
+                {"symbol": "AAPL", "status": "active",   "tradable": true, "fractionable": true, "shortable": true, "easy_to_borrow": true},
+                {"symbol": "DEAD", "status": "inactive", "tradable": true, "fractionable": true, "shortable": true, "easy_to_borrow": true},
+                {"symbol": "NONE",                       "tradable": true, "fractionable": true, "shortable": true, "easy_to_borrow": true}
+            ]"#,
+            )
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(make_credentials(), server.url());
+        let assets = client.fetch_tradable_assets().await.unwrap();
+
+        assert!(assets.is_tradable("AAPL"));
+        assert!(!assets.is_tradable("DEAD"));
+        // A missing status is treated as not active rather than assumed good.
+        assert!(!assets.is_tradable("NONE"));
+        assert_eq!(assets.tradable_count(), 1);
         mock.assert_async().await;
     }
 
@@ -1380,8 +1492,10 @@ mod tests {
             .with_status(200)
             .with_body(
                 r#"{
-                "AAPL": {"latestQuote": {"bp": 150.00, "ap": 150.20}},
-                "MSFT": {"latestQuote": {"bp": 420.00, "ap": 420.40}}
+                "AAPL": {"latestQuote": {"bp": 150.00, "ap": 150.20, "bs": 300, "as": 400,
+                                          "t": "2026-07-28T18:13:05.263989222Z"}},
+                "MSFT": {"latestQuote": {"bp": 420.00, "ap": 420.40, "bs": 100, "as": 200,
+                                          "t": "2026-07-28T18:13:04.100000000Z"}}
             }"#,
             )
             .create_async()
@@ -1393,10 +1507,102 @@ mod tests {
 
         assert_eq!(quotes.len(), 2);
         quotes.sort_by(|a, b| a.symbol.cmp(&b.symbol));
+
         assert_eq!(quotes[0].symbol, "AAPL");
-        assert!((quotes[0].mid_price - 150.10).abs() < 1e-6);
+        assert!((quotes[0].bid_price - 150.00).abs() < 1e-6);
+        assert!((quotes[0].ask_price - 150.20).abs() < 1e-6);
+        assert_eq!(quotes[0].bid_size, 300);
+        assert_eq!(quotes[0].ask_size, 400);
+
         assert_eq!(quotes[1].symbol, "MSFT");
-        assert!((quotes[1].mid_price - 420.20).abs() < 1e-6);
+        assert!((quotes[1].bid_price - 420.00).abs() < 1e-6);
+        assert_eq!(quotes[1].ask_size, 200);
+
+        // Nanosecond precision must survive deserialization: the timestamp is
+        // what the staleness window is measured against.
+        assert!(quotes[0].observed_at > quotes[1].observed_at);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_latest_quotes_converts_to_domain_quote() {
+        // The REST path must produce a quote the shared book-quality gate can
+        // read, so both pricing paths accept and reject identically.
+        let latest = LatestQuote {
+            symbol: "AAPL".to_string(),
+            bid_price: 150.00,
+            ask_price: 150.20,
+            bid_size: 300,
+            ask_size: 400,
+            observed_at: Utc::now(),
+        };
+        let quote = latest.to_equity_quote().expect("valid ticker");
+        assert_eq!(quote.ticker().as_str(), "AAPL");
+        assert_eq!(quote.bid_size(), 300);
+
+        let usable = crate::domain::market::UsableQuote::new(
+            &quote,
+            crate::domain::market::BookQualityLimits::default(),
+        )
+        .expect("tight, round-lot book is usable");
+        assert!((usable.mid_price() - 150.10).abs() < 1e-6);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_latest_quotes_skips_quote_without_timestamp() {
+        // A quote with no exchange timestamp cannot be aged, and an unaged
+        // quote is exactly what the staleness window exists to exclude.
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", "/v2/stocks/snapshots?symbols=AAPL&feed=iex")
+            .with_status(200)
+            .with_body(
+                r#"{"AAPL": {"latestQuote": {"bp": 150.00, "ap": 150.20, "bs": 100, "as": 100}}}"#,
+            )
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(make_credentials(), server.url());
+        let quotes = client
+            .fetch_latest_quotes(&["AAPL".to_string()])
+            .await
+            .unwrap();
+
+        assert!(quotes.is_empty());
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_latest_quotes_defaults_missing_sizes_to_zero() {
+        // Zero size is then rejected by the book-quality gate rather than being
+        // silently treated as unlimited depth.
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("GET", "/v2/stocks/snapshots?symbols=AAPL&feed=iex")
+            .with_status(200)
+            .with_body(
+                r#"{"AAPL": {"latestQuote": {"bp": 150.00, "ap": 150.20,
+                                              "t": "2026-07-28T18:13:05Z"}}}"#,
+            )
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(make_credentials(), server.url());
+        let quotes = client
+            .fetch_latest_quotes(&["AAPL".to_string()])
+            .await
+            .unwrap();
+
+        assert_eq!(quotes.len(), 1);
+        assert_eq!(quotes[0].bid_size, 0);
+        assert_eq!(quotes[0].ask_size, 0);
+
+        let quote = quotes[0].to_equity_quote().expect("valid ticker");
+        assert!(crate::domain::market::UsableQuote::new(
+            &quote,
+            crate::domain::market::BookQualityLimits::default()
+        )
+        .is_none());
         mock.assert_async().await;
     }
 
@@ -1437,7 +1643,8 @@ mod tests {
             .with_status(200)
             .with_body(
                 r#"{
-                "AAPL": {"latestQuote": {"bp": 150.00, "ap": 150.20}},
+                "AAPL": {"latestQuote": {"bp": 150.00, "ap": 150.20, "bs": 100, "as": 100,
+                                          "t": "2026-07-28T18:13:05Z"}},
                 "MSFT": {"latestQuote": null}
             }"#,
             )
@@ -1450,7 +1657,7 @@ mod tests {
 
         assert_eq!(quotes.len(), 1);
         assert_eq!(quotes[0].symbol, "AAPL");
-        assert!((quotes[0].mid_price - 150.10).abs() < 1e-6);
+        assert!((quotes[0].bid_price - 150.00).abs() < 1e-6);
         mock.assert_async().await;
     }
 

--- a/src/portfolio/alpaca.rs
+++ b/src/portfolio/alpaca.rs
@@ -712,13 +712,13 @@ impl TradingClient {
                 let quote = snapshot.latest_quote?;
                 Some(LatestQuote {
                     symbol,
-                    bid_price: quote.bp?,
-                    ask_price: quote.ap?,
+                    bid_price: quote.bid_price?,
+                    ask_price: quote.ask_price?,
                     // A quote reporting a price but no size is treated as
                     // zero size, which the book-quality gate then rejects.
-                    bid_size: quote.bs.unwrap_or(0),
+                    bid_size: quote.bid_size.unwrap_or(0),
                     ask_size: quote.ask_size.unwrap_or(0),
-                    observed_at: quote.t?,
+                    observed_at: quote.timestamp?,
                 })
             })
             .collect())
@@ -884,19 +884,27 @@ struct SnapshotResponse {
 
 /// The `latestQuote` object from a snapshot response.
 ///
-/// Field names are Alpaca's and are not renamed: `bp`/`ap` are bid and ask
-/// price, `bs`/`as` their sizes, and `t` the exchange timestamp. The timestamp
-/// and sizes were previously discarded, which left the REST path unable to tell
-/// a quote posted a second ago from one posted at the open, and unable to
-/// distinguish a tight book from a tight book quoted for five shares.
+/// Alpaca's wire names are pinned in the `serde` attributes, which is what the
+/// external contract actually is; the Rust fields spell them out. This matches
+/// how `stream::alpaca_equities::StreamMessage` deserializes the identical
+/// fields from the WebSocket feed, so the two representations of an Alpaca
+/// quote read the same way.
+///
+/// The timestamp and sizes were previously discarded, which left the REST path
+/// unable to tell a quote posted a second ago from one posted at the open, and
+/// unable to distinguish a tight book from a tight book quoted for five shares.
 #[derive(Deserialize)]
 struct SnapshotQuote {
-    bp: Option<f64>,
-    ap: Option<f64>,
-    bs: Option<i32>,
+    #[serde(rename = "bp")]
+    bid_price: Option<f64>,
+    #[serde(rename = "ap")]
+    ask_price: Option<f64>,
+    #[serde(rename = "bs")]
+    bid_size: Option<i32>,
     #[serde(rename = "as")]
     ask_size: Option<i32>,
-    t: Option<DateTime<Utc>>,
+    #[serde(rename = "t")]
+    timestamp: Option<DateTime<Utc>>,
 }
 
 /// Test-only mock implementation of the [`Trading`] trait.

--- a/src/portfolio/alpaca.rs
+++ b/src/portfolio/alpaca.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::common::alpaca::AlpacaCredentials;
 use crate::common::market_hours::MarketSession;
@@ -34,8 +34,12 @@ const HEADER_SECRET_KEY: &str = "APCA-API-SECRET-KEY";
 ///
 /// The endpoint imposes no documented symbol ceiling and was measured accepting
 /// 2,000 symbols in a 9,424-character URL. The cap here is not the API's limit
-/// but a bound on request-line length, which intermediaries do restrict, and it
-/// keeps a single failed request from losing the whole universe.
+/// but a bound on request-line length, which intermediaries do restrict.
+///
+/// Chunking also limits the blast radius of a single failed request, but only
+/// because [`TradingClient::fetch_latest_quotes`] keeps the chunks that
+/// succeeded. Propagating the first error instead would have made a smaller cap
+/// strictly worse, by giving one failure more chunks to take down with it.
 const SNAPSHOT_SYMBOLS_PER_REQUEST: usize = 1_000;
 
 /// Account information returned by the Alpaca account endpoint.
@@ -82,10 +86,11 @@ pub struct Position {
 /// Latest quote snapshot for a single symbol from the Alpaca data API.
 ///
 /// Carries the raw two-sided book rather than a precomputed mid so callers can
-/// apply [`UsableQuote`] and a staleness window themselves. Returning only a mid
-/// discarded the information needed to tell a tradeable book from a book
-/// hundreds of basis points wide, and a quote posted a second ago from one
-/// posted hours earlier — both of which the snapshot reports identically.
+/// apply [`crate::domain::market::UsableQuote`] and a staleness window
+/// themselves. Returning only a mid discarded the information needed to tell a
+/// tradeable book from a book hundreds of basis points wide, and a quote posted
+/// a second ago from one posted hours earlier — both of which the snapshot
+/// reports identically.
 #[derive(Debug, Clone)]
 pub struct LatestQuote {
     /// Ticker symbol.
@@ -646,11 +651,12 @@ impl TradingClient {
 
     /// Fetches latest quote snapshots for the given symbols from the Alpaca data API.
     ///
-    /// Symbols are requested in chunks of [`SNAPSHOT_SYMBOLS_PER_REQUEST`] and
+    /// Symbols are requested in bounded chunks and
     /// the results concatenated, so a caller may pass the whole filtered
     /// universe without splitting it. No book validation happens here: the raw
     /// two-sided quote is returned and callers gate it through
-    /// [`UsableQuote`], which is the same gate the streamed path uses.
+    /// [`crate::domain::market::UsableQuote`], the same gate the streamed path
+    /// uses.
     ///
     /// Symbols the API returns without a usable `latestQuote` object are
     /// omitted rather than defaulted, because a missing side is indistinguishable
@@ -659,19 +665,60 @@ impl TradingClient {
         &self,
         symbols: &[String],
     ) -> Result<Vec<LatestQuote>, ClientError> {
+        self.fetch_latest_quotes_over_chunks(symbols, SNAPSHOT_SYMBOLS_PER_REQUEST)
+            .await
+    }
+
+    /// Fetches `symbols` in chunks of `chunk_size`.
+    ///
+    /// Split out so the partial-failure behaviour is testable without building
+    /// a symbol list large enough to span the production chunk size.
+    async fn fetch_latest_quotes_over_chunks(
+        &self,
+        symbols: &[String],
+        chunk_size: usize,
+    ) -> Result<Vec<LatestQuote>, ClientError> {
         if symbols.is_empty() {
             return Ok(Vec::new());
         }
 
         let mut quotes: Vec<LatestQuote> = Vec::new();
-        for chunk in symbols.chunks(SNAPSHOT_SYMBOLS_PER_REQUEST) {
-            quotes.extend(self.fetch_latest_quotes_chunk(chunk).await?);
+        let mut failed_chunks: usize = 0;
+        let mut last_error: Option<ClientError> = None;
+        let mut requests: usize = 0;
+
+        for chunk in symbols.chunks(chunk_size) {
+            requests += 1;
+            match self.fetch_latest_quotes_chunk(chunk).await {
+                Ok(chunk_quotes) => quotes.extend(chunk_quotes),
+                Err(error) => {
+                    // One bad request must not discard the chunks that
+                    // succeeded. Partial pricing narrows the entry set and
+                    // holds the exits it cannot price, both of which beat
+                    // pricing nothing at all.
+                    warn!(
+                        error = %error,
+                        symbols = chunk.len(),
+                        "Snapshot chunk failed; its symbols stay unpriced"
+                    );
+                    failed_chunks += 1;
+                    last_error = Some(error);
+                }
+            }
+        }
+
+        // Only a total failure is an error. Reporting one keeps the caller's
+        // own warning meaningful for the common single-chunk case, which would
+        // otherwise become unreachable and take that log line with it.
+        if failed_chunks == requests {
+            return Err(last_error.expect("a failed chunk records its error"));
         }
 
         info!(
             requested = symbols.len(),
             returned = quotes.len(),
-            requests = symbols.len().div_ceil(SNAPSHOT_SYMBOLS_PER_REQUEST),
+            requests,
+            failed_chunks,
             "Latest quotes fetched from Alpaca data API"
         );
         Ok(quotes)
@@ -1555,6 +1602,66 @@ mod tests {
         // what the staleness window is measured against.
         assert!(quotes[0].observed_at > quotes[1].observed_at);
         mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_latest_quotes_keeps_chunks_that_succeeded() {
+        // A universe split across requests must not be lost to one bad
+        // response. Chunk size is forced to 1 by requesting two symbols so the
+        // mock can fail exactly one of the two calls.
+        let mut server = Server::new_async().await;
+        let ok = server
+            .mock("GET", "/v2/stocks/snapshots?symbols=AAPL&feed=iex")
+            .with_status(200)
+            .with_body(
+                r#"{"AAPL": {"latestQuote": {"bp": 150.00, "ap": 150.20, "bs": 100, "as": 100,
+                                              "t": "2026-07-28T18:13:05Z"}}}"#,
+            )
+            .create_async()
+            .await;
+        let failed = server
+            .mock("GET", "/v2/stocks/snapshots?symbols=MSFT&feed=iex")
+            .with_status(500)
+            .with_body(r#"{"message": "Internal Server Error"}"#)
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(make_credentials(), server.url());
+        let quotes = client
+            .fetch_latest_quotes_over_chunks(&["AAPL".to_string(), "MSFT".to_string()], 1)
+            .await
+            .expect("a partial failure is not a total failure");
+
+        assert_eq!(quotes.len(), 1);
+        assert_eq!(quotes[0].symbol, "AAPL");
+        ok.assert_async().await;
+        failed.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_fetch_latest_quotes_errors_only_when_every_chunk_fails() {
+        let mut server = Server::new_async().await;
+        let first = server
+            .mock("GET", "/v2/stocks/snapshots?symbols=AAPL&feed=iex")
+            .with_status(500)
+            .with_body(r#"{"message": "Internal Server Error"}"#)
+            .create_async()
+            .await;
+        let second = server
+            .mock("GET", "/v2/stocks/snapshots?symbols=MSFT&feed=iex")
+            .with_status(503)
+            .with_body(r#"{"message": "Service Unavailable"}"#)
+            .create_async()
+            .await;
+
+        let client = TradingClient::with_base_url(make_credentials(), server.url());
+        let result = client
+            .fetch_latest_quotes_over_chunks(&["AAPL".to_string(), "MSFT".to_string()], 1)
+            .await;
+
+        assert!(matches!(result, Err(ClientError::Api { .. })));
+        first.assert_async().await;
+        second.assert_async().await;
     }
 
     #[tokio::test]

--- a/src/portfolio/alpaca.rs
+++ b/src/portfolio/alpaca.rs
@@ -924,6 +924,9 @@ pub struct MockTrading {
     pub should_fail_short_order: bool,
     pub should_fail_cancel: bool,
     pub should_fail_close: bool,
+    /// Makes `fetch_market_session` return an API error, for exercising the
+    /// clock-unavailable paths.
+    pub should_fail_session_fetch: bool,
     pub market_open: bool,
     /// Session close returned by `fetch_market_session`. Defaults to 16:00
     /// Eastern today; set it earlier to exercise early-close behavior.
@@ -963,6 +966,7 @@ impl Default for MockTrading {
             should_fail_short_order: false,
             should_fail_cancel: false,
             should_fail_close: false,
+            should_fail_session_fetch: false,
             market_open: true,
             session_close: default_mock_session_close(),
             tradable_assets: TradableAssets {
@@ -1058,6 +1062,12 @@ impl Trading for MockTrading {
     }
 
     async fn fetch_market_session(&self) -> Result<MarketSession, ClientError> {
+        if self.should_fail_session_fetch {
+            return Err(ClientError::Api {
+                status: 503,
+                body: "mock clock unavailable".to_string(),
+            });
+        }
         MarketSession::new(self.market_open, self.session_close).ok_or_else(|| {
             ClientError::Parse(format!(
                 "Mock session close is unusable: {}",

--- a/src/portfolio/alpaca.rs
+++ b/src/portfolio/alpaca.rs
@@ -783,6 +783,21 @@ pub struct TradableAssets {
 }
 
 impl TradableAssets {
+    /// Builds a universe directly from two symbol sets.
+    ///
+    /// Test-only: production values come from [`TradingClient::fetch_tradable_assets`],
+    /// which derives both sets from the broker's own asset flags.
+    #[cfg(test)]
+    pub fn from_sets(
+        tradable: std::collections::HashSet<String>,
+        shortable: std::collections::HashSet<String>,
+    ) -> Self {
+        Self {
+            tradable,
+            shortable,
+        }
+    }
+
     /// Returns `true` when the symbol can be bought (long leg eligibility).
     pub fn is_tradable(&self, symbol: &str) -> bool {
         self.tradable.contains(symbol)

--- a/src/portfolio/consumer.rs
+++ b/src/portfolio/consumer.rs
@@ -9,11 +9,17 @@
 //!   fresh prediction set is acted on immediately.
 //! - Runs end-of-day liquidation on each `portfolio_liquidation_requested` event.
 //!
-//! Nothing here runs on a timer. A five-minute evaluation heartbeat previously
-//! drove a full rebalance pass whether or not anything had changed, up to 78
-//! times a session. The work that genuinely needs a schedule — opening the
+//! No unconditional timer drives work here. A five-minute evaluation heartbeat
+//! previously ran a full rebalance pass whether or not anything had changed, up
+//! to 78 times a session. The work that genuinely needs a schedule — opening the
 //! session, closing it — is scheduled directly, and the rest is driven by
 //! spreads actually crossing thresholds.
+//!
+//! Two timers do exist, and both are conditional on something having gone
+//! differently than planned: the liquidation timer, armed once per session from
+//! the real close, and the entry retry, armed only when the session-start pass
+//! opened nothing. A session that opens normally and closes normally arms one
+//! timer and fires one rebalance.
 //!
 //! Predictions are requested pre-market by pg_cron. They derive from daily bars,
 //! so a single run produces every distinct value the session will have;
@@ -32,10 +38,10 @@ use tracing::{error, info, warn};
 
 use crate::common::events::{
     emit_event, get_consumer_offset, latest_event_after, update_consumer_offset, EventType,
-    CONSUMER_PORTFOLIO, CONSUMER_PORTFOLIO_LIQUIDATION,
+    CONSUMER_PORTFOLIO, CONSUMER_PORTFOLIO_LIQUIDATION, CONSUMER_PORTFOLIO_SESSION,
 };
 use crate::common::market_hours::MarketSession;
-use crate::portfolio::database::predictions_exist_for_today;
+use crate::portfolio::database::{fetch_open_pairs, predictions_exist_for_today};
 use crate::portfolio::rebalance::{run_end_of_day_liquidation, run_rebalance, RebalanceError};
 use crate::portfolio::reconciliation;
 use crate::portfolio::state::AppState;
@@ -47,6 +53,15 @@ use crate::portfolio::state::AppState;
 /// 15:45 Eastern remains as a fail-safe for the case where the clock endpoint is
 /// unreachable; liquidation is idempotent, so both firing is harmless.
 const LIQUIDATION_LEAD_TIME_MINUTES: i64 = 15;
+
+/// Backoff, in minutes, for re-attempting entry after a session start that
+/// opened nothing.
+///
+/// Bounded rather than indefinite: three failures spread over the first hour of
+/// the session mean the cause is not transient, and continuing to retry would
+/// only add load to whatever is already failing. Spacing widens so the first
+/// attempt catches a brief outage without waiting long.
+const ENTRY_RETRY_BACKOFF_MINUTES: [i64; 3] = [5, 15, 30];
 
 /// Spawns the event consumer as a background task.
 pub fn spawn_event_consumer(state: AppState, shutdown_token: CancellationToken) -> JoinHandle<()> {
@@ -130,6 +145,40 @@ async fn run_consumer(
         handle_equity_predictions_completed(state, pool, event_id).await;
     }
 
+    // Catch up on trading_session_started if we were down when it fired. Without
+    // this a process restarted at any point after 09:25 Eastern would trade
+    // nothing for the rest of the day: the event is emitted once, and the live
+    // evaluator that drives everything else cannot fire until pairs are open.
+    // The retired five-minute heartbeat used to cover this within five minutes.
+    let session_offset = get_consumer_offset(pool, CONSUMER_PORTFOLIO_SESSION).await?;
+    if let Some(event_id) =
+        latest_event_after(pool, EventType::TradingSessionStarted, session_offset).await?
+    {
+        // Guarded on the real session so a restart after the close, or on the
+        // day after, does not replay a stale open into a shut market.
+        let session_is_live = match state.alpaca_client().fetch_market_session().await {
+            Ok(session) => session.is_open() && session.trades_on_date_of(Utc::now()),
+            Err(error) => {
+                warn!(error = %error, "Market session fetch failed during session-start catch-up");
+                false
+            }
+        };
+        if session_is_live {
+            info!(event_id, "Catching up on missed trading_session_started");
+            handle_trading_session_started(state, pool, event_id, shutdown_token).await;
+        } else {
+            info!(
+                event_id,
+                "Skipping missed trading_session_started: not inside a live session"
+            );
+            if let Err(error) =
+                update_consumer_offset(pool, CONSUMER_PORTFOLIO_SESSION, event_id).await
+            {
+                warn!(error = %error, "Failed to update session consumer offset");
+            }
+        }
+    }
+
     // Catch up on portfolio_liquidation_requested if we missed it while the
     // market was still open. Guarded by the real session so a restart after an
     // early close does not submit orders into a shut market.
@@ -191,7 +240,7 @@ async fn run_consumer(
 
         if event_type == EventType::TradingSessionStarted.as_str() {
             info!(event_id, "Received trading_session_started");
-            handle_trading_session_started(state, pool, shutdown_token).await;
+            handle_trading_session_started(state, pool, event_id, shutdown_token).await;
         } else if event_type == EventType::PortfolioEvaluationRequested.as_str() {
             handle_portfolio_evaluation(state, pool).await;
         } else if event_type == EventType::EquityPredictionsCompleted.as_str() {
@@ -223,6 +272,7 @@ async fn run_consumer(
 async fn handle_trading_session_started(
     state: &AppState,
     pool: &PgPool,
+    event_id: i64,
     shutdown_token: &CancellationToken,
 ) {
     let session = match state.alpaca_client().fetch_market_session().await {
@@ -238,6 +288,7 @@ async fn handle_trading_session_started(
             session_close = %session.close(),
             "Skipping session start: the market does not trade today"
         );
+        record_session_offset(pool, event_id).await;
         return;
     }
 
@@ -250,10 +301,115 @@ async fn handle_trading_session_started(
 
     if !state.try_begin_rebalance() {
         info!("Skipping session start rebalance: a pass is already running");
+        record_session_offset(pool, event_id).await;
         return;
     }
     run_rebalance_pass(state, pool).await;
     state.finish_rebalance();
+
+    // A pass that opened nothing is the case the retired heartbeat used to
+    // cover. Predictions land before this event, and the live evaluator cannot
+    // fire without open pairs, so without a retry a single transient failure
+    // here costs the whole session.
+    match fetch_open_pairs(pool).await {
+        Ok(pairs) if pairs.is_empty() => {
+            spawn_entry_retry_timer(pool.clone(), session, shutdown_token.clone());
+        }
+        Ok(pairs) => info!(
+            open_pairs = pairs.len(),
+            "Session start opened positions; no entry retry armed"
+        ),
+        Err(error) => {
+            // Arm anyway: not knowing whether the portfolio is empty is not a
+            // reason to give up on the session. The retry re-reads before
+            // acting, so a spurious arm costs one query.
+            warn!(error = %error, "Could not read open pairs after session start; arming entry retry");
+            spawn_entry_retry_timer(pool.clone(), session, shutdown_token.clone());
+        }
+    }
+
+    record_session_offset(pool, event_id).await;
+}
+
+/// Records progress past a `trading_session_started` event.
+async fn record_session_offset(pool: &PgPool, event_id: i64) {
+    if let Err(error) = update_consumer_offset(pool, CONSUMER_PORTFOLIO_SESSION, event_id).await {
+        warn!(error = %error, "Failed to update session consumer offset");
+    }
+}
+
+/// Re-requests an evaluation on a backoff while the portfolio is still empty.
+///
+/// Spawned only when the session-start pass opened nothing, so a healthy session
+/// arms no timer at all. Each attempt re-reads the open pairs first and stops as
+/// soon as any exist, whatever opened them.
+///
+/// Emits `portfolio_evaluation_requested` rather than calling the rebalance
+/// directly, so a retry inherits everything [`handle_portfolio_evaluation`]
+/// already does: the clock check, the close-proximity guard, the prediction
+/// re-request, and the `try_begin_rebalance` exclusion that keeps it from
+/// colliding with a pass already under way. This task holds no rebalance state.
+fn spawn_entry_retry_timer(
+    pool: PgPool,
+    session: MarketSession,
+    shutdown_token: CancellationToken,
+) {
+    info!(
+        attempts = ENTRY_RETRY_BACKOFF_MINUTES.len(),
+        "Session start opened no positions; arming entry retry"
+    );
+
+    tokio::spawn(async move {
+        for (attempt, minutes) in ENTRY_RETRY_BACKOFF_MINUTES.iter().enumerate() {
+            let wait = Duration::from_secs((*minutes as u64) * 60);
+            tokio::select! {
+                _ = sleep(wait) => {}
+                _ = shutdown_token.cancelled() => {
+                    info!("Entry retry cancelled for shutdown");
+                    return;
+                }
+            }
+
+            // Opening positions minutes before the close is what the
+            // exit-feasibility gate exists to prevent, and liquidation is about
+            // to run regardless.
+            if close_is_near(&session, Utc::now()) {
+                info!("Entry retry stopped: session close is near");
+                return;
+            }
+
+            match fetch_open_pairs(&pool).await {
+                Ok(pairs) if !pairs.is_empty() => {
+                    info!(
+                        open_pairs = pairs.len(),
+                        "Entry retry stopped: positions are open"
+                    );
+                    return;
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    warn!(error = %error, "Entry retry could not read open pairs; requesting anyway");
+                }
+            }
+
+            info!(
+                attempt = attempt + 1,
+                of = ENTRY_RETRY_BACKOFF_MINUTES.len(),
+                "Portfolio still empty; requesting evaluation"
+            );
+            if let Err(error) = emit_event(
+                &pool,
+                EventType::PortfolioEvaluationRequested,
+                &serde_json::json!({"reason": "entry_retry", "attempt": attempt + 1}),
+            )
+            .await
+            {
+                warn!(error = %error, "Failed to emit entry retry evaluation request");
+            }
+        }
+
+        info!("Entry retry attempts exhausted; portfolio stays empty this session");
+    });
 }
 
 /// Sleeps until [`LIQUIDATION_LEAD_TIME_MINUTES`] before the close, then emits
@@ -551,13 +707,15 @@ async fn handle_portfolio_liquidation(state: &AppState, pool: &PgPool, event_id:
 #[cfg(test)]
 mod tests {
     use super::{
-        CONSUMER_PORTFOLIO, CONSUMER_PORTFOLIO_LIQUIDATION, LIQUIDATION_LEAD_TIME_MINUTES,
+        CONSUMER_PORTFOLIO, CONSUMER_PORTFOLIO_LIQUIDATION, CONSUMER_PORTFOLIO_SESSION,
+        ENTRY_RETRY_BACKOFF_MINUTES, LIQUIDATION_LEAD_TIME_MINUTES,
     };
     use crate::common::events::EventType;
 
     #[test]
     fn test_consumer_names_are_stable() {
         assert_eq!(CONSUMER_PORTFOLIO, "portfolio");
+        assert_eq!(CONSUMER_PORTFOLIO_SESSION, "portfolio-session");
         assert_eq!(CONSUMER_PORTFOLIO_LIQUIDATION, "portfolio-liquidation");
     }
 
@@ -594,7 +752,7 @@ mod tests {
 
     use super::{
         close_is_near, handle_portfolio_evaluation, handle_trading_session_started,
-        spawn_liquidation_timer,
+        spawn_entry_retry_timer, spawn_liquidation_timer,
     };
     use crate::common::market_hours::MarketSession;
     use crate::portfolio::alpaca::MockTrading;
@@ -639,7 +797,7 @@ mod tests {
         let state = make_test_state(mock);
         let token = CancellationToken::new();
 
-        handle_trading_session_started(&state, state.pool(), &token).await;
+        handle_trading_session_started(&state, state.pool(), 1, &token).await;
 
         // Returned before claiming the rebalance slot.
         assert!(!state.rebalance_in_progress());
@@ -656,9 +814,46 @@ mod tests {
         let state = make_test_state(mock);
         let token = CancellationToken::new();
 
-        handle_trading_session_started(&state, state.pool(), &token).await;
+        handle_trading_session_started(&state, state.pool(), 1, &token).await;
 
         assert!(!state.rebalance_in_progress());
+    }
+
+    #[tokio::test]
+    async fn test_entry_retry_backoff_widens_and_is_bounded() {
+        // Bounded so a persistent failure does not retry all session, and
+        // widening so the first attempt catches a brief outage quickly.
+        assert_eq!(ENTRY_RETRY_BACKOFF_MINUTES, [5, 15, 30]);
+        let mut previous = 0;
+        for minutes in ENTRY_RETRY_BACKOFF_MINUTES {
+            assert!(minutes > previous, "backoff must widen");
+            previous = minutes;
+        }
+        // Every attempt lands inside the session, so none can be armed only to
+        // be discarded by the close-proximity guard.
+        let total: i64 = ENTRY_RETRY_BACKOFF_MINUTES.iter().sum();
+        assert!(total < 390 - LIQUIDATION_LEAD_TIME_MINUTES);
+    }
+
+    #[tokio::test]
+    async fn test_entry_retry_cancels_on_shutdown() {
+        // The first attempt is five minutes out, so a test can only observe
+        // that cancellation resolves the task rather than waiting it out.
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://localhost:1/nonexistent_consumer_test")
+            .expect("lazy pool creation should not fail");
+        let token = CancellationToken::new();
+
+        spawn_entry_retry_timer(pool, regular_session(), token.clone());
+        token.cancel();
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !token.is_cancelled() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancellation should resolve promptly");
     }
 
     #[tokio::test]

--- a/src/portfolio/consumer.rs
+++ b/src/portfolio/consumer.rs
@@ -1,17 +1,24 @@
 //! PostgreSQL event consumer for the portfolio service.
 //!
 //! Listens on the `events` channel and:
+//! - Opens the session on `trading_session_started`: builds the initial
+//!   portfolio and arms a one-shot timer for the real session close.
 //! - Runs an evaluation pass on each `portfolio_evaluation_requested` event,
-//!   which also triggers liquidation once the session close is near.
+//!   which now arrives only from a live-quote threshold crossing.
 //! - Runs a rebalance cycle on each `equity_predictions_completed` event so a
 //!   fresh prediction set is acted on immediately.
 //! - Runs end-of-day liquidation on each `portfolio_liquidation_requested` event.
 //!
-//! Predictions are requested pre-market by pg_cron rather than on a recurring
-//! intraday tick. They derive from daily bars, so a single run produces every
-//! distinct value the session will have; re-running mid-session recomputed an
-//! identical answer. The evaluation pass re-requests them only when a session
-//! begins with none recorded.
+//! Nothing here runs on a timer. A five-minute evaluation heartbeat previously
+//! drove a full rebalance pass whether or not anything had changed, up to 78
+//! times a session. The work that genuinely needs a schedule — opening the
+//! session, closing it — is scheduled directly, and the rest is driven by
+//! spreads actually crossing thresholds.
+//!
+//! Predictions are requested pre-market by pg_cron. They derive from daily bars,
+//! so a single run produces every distinct value the session will have;
+//! re-running mid-session recomputed an identical answer. The session start
+//! re-requests them only when the day has none recorded.
 
 use std::time::Duration;
 
@@ -182,7 +189,10 @@ async fn run_consumer(
             .and_then(|value| value.as_i64())
             .unwrap_or(0);
 
-        if event_type == EventType::PortfolioEvaluationRequested.as_str() {
+        if event_type == EventType::TradingSessionStarted.as_str() {
+            info!(event_id, "Received trading_session_started");
+            handle_trading_session_started(state, pool, shutdown_token).await;
+        } else if event_type == EventType::PortfolioEvaluationRequested.as_str() {
             handle_portfolio_evaluation(state, pool).await;
         } else if event_type == EventType::EquityPredictionsCompleted.as_str() {
             info!(event_id, "Received equity_predictions_completed");
@@ -200,20 +210,121 @@ async fn run_consumer(
     Ok(())
 }
 
+/// Starts the trading session in response to `trading_session_started`.
+///
+/// Confirms the market actually trades today, builds the initial portfolio, and
+/// arms the liquidation timer from the real session close. Emitted once shortly
+/// before the regular open, so on a holiday this is the point at which the
+/// session is recognised as not happening and nothing further runs.
+///
+/// Fails closed on a clock error, matching every other trading path: without a
+/// session there is no close to schedule liquidation against, and the fixed
+/// 15:45 Eastern pg_cron job remains the backstop.
+async fn handle_trading_session_started(
+    state: &AppState,
+    pool: &PgPool,
+    shutdown_token: &CancellationToken,
+) {
+    let session = match state.alpaca_client().fetch_market_session().await {
+        Ok(session) => session,
+        Err(error) => {
+            warn!(error = %error, "Skipping session start: market session fetch failed");
+            return;
+        }
+    };
+
+    if !session.trades_on_date_of(Utc::now()) {
+        info!(
+            session_close = %session.close(),
+            "Skipping session start: the market does not trade today"
+        );
+        return;
+    }
+
+    // Armed before the portfolio is built, not after. A rebalance that hangs or
+    // errors must not be able to leave the session without a liquidation timer;
+    // the timer only emits an event, and liquidation is idempotent.
+    spawn_liquidation_timer(pool.clone(), &session, shutdown_token.clone());
+
+    ensure_predictions_requested(state, pool).await;
+
+    if !state.try_begin_rebalance() {
+        info!("Skipping session start rebalance: a pass is already running");
+        return;
+    }
+    run_rebalance_pass(state, pool).await;
+    state.finish_rebalance();
+}
+
+/// Sleeps until [`LIQUIDATION_LEAD_TIME_MINUTES`] before the close, then emits
+/// `portfolio_liquidation_requested`.
+///
+/// A one-shot timer rather than a poll. The close is known the moment the
+/// session is read, so waiting for it needs no repeated clock reads, and
+/// deriving the instant from Alpaca's reported close is what pulls liquidation
+/// forward on an early-close day without a local calendar.
+///
+/// The fixed 15:45 Eastern pg_cron job stays as a fail-safe for the case where
+/// this process is not running when the timer would have fired. Liquidation is
+/// idempotent, so both firing is harmless.
+fn spawn_liquidation_timer(
+    pool: PgPool,
+    session: &MarketSession,
+    shutdown_token: CancellationToken,
+) {
+    let close = session.close();
+    let fires_at = close - chrono::Duration::minutes(LIQUIDATION_LEAD_TIME_MINUTES);
+    let wait = fires_at
+        .signed_duration_since(Utc::now())
+        .to_std()
+        .unwrap_or(std::time::Duration::ZERO);
+
+    info!(
+        session_close = %close,
+        fires_at = %fires_at,
+        wait_seconds = wait.as_secs(),
+        "Liquidation timer armed"
+    );
+
+    tokio::spawn(async move {
+        tokio::select! {
+            _ = sleep(wait) => {}
+            _ = shutdown_token.cancelled() => {
+                info!("Liquidation timer cancelled for shutdown");
+                return;
+            }
+        }
+
+        info!(session_close = %close, "Liquidation timer fired; requesting liquidation");
+        if let Err(error) = emit_event(
+            &pool,
+            EventType::PortfolioLiquidationRequested,
+            &serde_json::json!({"reason": "session_close_approaching"}),
+        )
+        .await
+        {
+            // The pg_cron fail-safe at 15:45 Eastern still covers this, which is
+            // why a failed emit is not retried here.
+            warn!(error = %error, "Failed to emit portfolio_liquidation_requested from timer");
+        }
+    });
+}
+
 /// Runs one evaluation pass in response to `portfolio_evaluation_requested`.
 ///
-/// The pass is skipped entirely when the market is closed. Otherwise it:
-/// 1. Emits `portfolio_liquidation_requested` and returns when the session close
-///    is within [`LIQUIDATION_LEAD_TIME_MINUTES`], so an early close pulls
-///    liquidation forward without a calendar.
-/// 2. Re-requests predictions when the day has none recorded, then continues —
-///    exit monitoring does not depend on predictions and must not be blocked by
-///    their absence.
-/// 3. Runs the rebalance pass.
+/// Reached only from a live-quote threshold crossing, so unlike the session
+/// start this is a reaction to something having moved. The pass is skipped
+/// entirely when the market is closed, then re-requests predictions if the day
+/// has none recorded — exit monitoring does not depend on predictions and must
+/// not be blocked by their absence — and runs the rebalance.
+///
+/// Detecting a nearing close is no longer this function's job. That moved to the
+/// one-shot timer armed at session start, which derives the instant from the
+/// reported close instead of noticing it on whatever tick happens to land inside
+/// the lead time.
 ///
 /// Fails closed on a clock error: an unreachable clock endpoint skips the pass
-/// rather than trading on degraded connectivity. The 15:45 Eastern pg_cron job
-/// still guarantees liquidation in that case.
+/// rather than trading on degraded connectivity.
 ///
 /// No consumer offset tracking, because a stale evaluation tick carries no
 /// meaningful signal.
@@ -231,7 +342,12 @@ async fn handle_portfolio_evaluation(state: &AppState, pool: &PgPool) {
         return;
     }
 
-    if request_liquidation_if_close_is_near(pool, &session, Utc::now()).await {
+    if close_is_near(&session, Utc::now()) {
+        info!(
+            minutes_to_close = session.time_until_close(Utc::now()).num_minutes(),
+            session_close = %session.close(),
+            "Skipping evaluation: session close is near"
+        );
         return;
     }
 
@@ -246,36 +362,19 @@ async fn handle_portfolio_evaluation(state: &AppState, pool: &PgPool) {
     state.finish_rebalance();
 }
 
-/// Emits `portfolio_liquidation_requested` when the close is within the lead time.
+/// Returns `true` when the session close is within [`LIQUIDATION_LEAD_TIME_MINUTES`].
 ///
-/// Returns `true` when liquidation was requested, signalling the caller to skip
-/// the rebalance pass: opening positions minutes before the close is exactly what
-/// the exit-feasibility gate exists to prevent.
-async fn request_liquidation_if_close_is_near(
-    pool: &PgPool,
-    session: &MarketSession,
-    now: DateTime<Utc>,
-) -> bool {
-    let minutes_to_close = session.time_until_close(now).num_minutes();
-    if minutes_to_close > LIQUIDATION_LEAD_TIME_MINUTES {
-        return false;
-    }
-
-    info!(
-        minutes_to_close,
-        session_close = %session.close(),
-        "Session close is near; requesting liquidation"
-    );
-    if let Err(error) = emit_event(
-        pool,
-        EventType::PortfolioLiquidationRequested,
-        &serde_json::json!({"reason": "session_close_approaching"}),
-    )
-    .await
-    {
-        warn!(error = %error, "Failed to emit portfolio_liquidation_requested");
-    }
-    true
+/// A crossing detected this late must not open new positions — that is exactly
+/// what the exit-feasibility gate exists to prevent — so the evaluation pass
+/// declines rather than racing the liquidation that is about to run.
+///
+/// This no longer emits the liquidation itself. The timer armed at session start
+/// owns that, and the fixed pg_cron job backs it up; emitting from here as well
+/// would fire liquidation twice for one close. Idempotency makes that harmless
+/// but not free, and two emitters for one decision is a worse arrangement than
+/// one.
+fn close_is_near(session: &MarketSession, now: DateTime<Utc>) -> bool {
+    session.time_until_close(now).num_minutes() <= LIQUIDATION_LEAD_TIME_MINUTES
 }
 
 /// Re-requests predictions when today has none and the retry backoff has elapsed.
@@ -493,12 +592,17 @@ mod tests {
 
     // --- evaluation handler state machine tests ---
 
-    use super::{handle_portfolio_evaluation, request_liquidation_if_close_is_near};
+    use super::{
+        close_is_near, handle_portfolio_evaluation, handle_trading_session_started,
+        spawn_liquidation_timer,
+    };
     use crate::common::market_hours::MarketSession;
     use crate::portfolio::alpaca::MockTrading;
     use crate::portfolio::state::AppState;
     use chrono::{DateTime, Utc};
     use std::sync::Arc;
+    use std::time::Duration;
+    use tokio_util::sync::CancellationToken;
 
     fn utc(rfc3339: &str) -> DateTime<Utc> {
         DateTime::parse_from_rfc3339(rfc3339)
@@ -519,6 +623,67 @@ mod tests {
             .connect_lazy("postgres://localhost:1/nonexistent_consumer_test")
             .expect("lazy pool creation should not fail");
         AppState::with_mock(pool, Arc::new(mock))
+    }
+
+    // --- session start ---
+
+    #[tokio::test]
+    async fn test_session_start_skips_when_the_market_does_not_trade_today() {
+        // Asked on Thursday July 4th, Alpaca reports Friday's close, so no
+        // session trades today and nothing should be built or armed.
+        let mock = MockTrading {
+            market_open: false,
+            session_close: utc("2024-07-05T20:00:00Z"),
+            ..MockTrading::default()
+        };
+        let state = make_test_state(mock);
+        let token = CancellationToken::new();
+
+        handle_trading_session_started(&state, state.pool(), &token).await;
+
+        // Returned before claiming the rebalance slot.
+        assert!(!state.rebalance_in_progress());
+    }
+
+    #[tokio::test]
+    async fn test_session_start_skips_when_the_clock_is_unavailable() {
+        // Fails closed, unlike the quote stream: without a session there is no
+        // close to schedule liquidation against.
+        let mock = MockTrading {
+            should_fail_session_fetch: true,
+            ..MockTrading::default()
+        };
+        let state = make_test_state(mock);
+        let token = CancellationToken::new();
+
+        handle_trading_session_started(&state, state.pool(), &token).await;
+
+        assert!(!state.rebalance_in_progress());
+    }
+
+    #[tokio::test]
+    async fn test_liquidation_timer_cancels_on_shutdown() {
+        // The timer must not outlive the process it was armed by. Its wait is
+        // hours long, so a test can only observe that cancellation resolves it
+        // rather than waiting the timer out.
+        let session = regular_session();
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://localhost:1/nonexistent_consumer_test")
+            .expect("lazy pool creation should not fail");
+        let token = CancellationToken::new();
+
+        spawn_liquidation_timer(pool, &session, token.clone());
+        token.cancel();
+
+        // A cancelled token resolves the timer's select arm immediately; if the
+        // sleep won instead this would hang until the test harness timed out.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while !token.is_cancelled() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancellation should resolve promptly");
     }
 
     #[tokio::test]
@@ -572,57 +737,48 @@ mod tests {
         MarketSession::new(true, utc("2024-07-15T20:00:00Z")).expect("regular session")
     }
 
-    #[tokio::test]
-    async fn test_liquidation_requested_when_close_is_near() {
-        let mock = MockTrading::default();
-        let state = make_test_state(mock);
-
-        // 15:50 EDT: ten minutes to a 16:00 close, inside the lead time.
-        let now = utc("2024-07-15T19:50:00Z");
-
-        assert!(request_liquidation_if_close_is_near(state.pool(), &regular_session(), now).await);
+    #[test]
+    fn test_close_is_near_inside_the_lead_time() {
+        // 15:50 EDT: ten minutes to a 16:00 close, inside the lead time, so an
+        // evaluation arriving now must decline rather than open positions.
+        assert!(close_is_near(
+            &regular_session(),
+            utc("2024-07-15T19:50:00Z")
+        ));
     }
 
-    #[tokio::test]
-    async fn test_liquidation_not_requested_mid_session() {
-        let mock = MockTrading::default();
-        let state = make_test_state(mock);
-
+    #[test]
+    fn test_close_is_not_near_mid_session() {
         // 13:00 EDT: three hours to the close.
-        let now = utc("2024-07-15T17:00:00Z");
-
-        assert!(!request_liquidation_if_close_is_near(state.pool(), &regular_session(), now).await);
+        assert!(!close_is_near(
+            &regular_session(),
+            utc("2024-07-15T17:00:00Z")
+        ));
     }
 
-    #[tokio::test]
-    async fn test_liquidation_requested_after_close_passed() {
-        let mock = MockTrading::default();
-        let state = make_test_state(mock);
-
-        // time_until_close saturates at zero, so a close already behind us is
-        // inside the lead time and still requests liquidation.
-        let now = utc("2024-07-15T20:30:00Z");
-
-        assert!(request_liquidation_if_close_is_near(state.pool(), &regular_session(), now).await);
+    #[test]
+    fn test_close_is_near_once_the_close_has_passed() {
+        // time_until_close saturates at zero, so a close already behind us
+        // counts as near and the pass still declines.
+        assert!(close_is_near(
+            &regular_session(),
+            utc("2024-07-15T20:30:00Z")
+        ));
     }
 
-    #[tokio::test]
-    async fn test_early_close_triggers_liquidation_when_regular_close_would_not() {
-        let mock = MockTrading::default();
-        let state = make_test_state(mock);
-
-        // 12:50 Eastern. Under a 16:00 close this is mid-session and the 15:45
-        // pg_cron backstop is still hours away; under a 13:00 early close it is
-        // ten minutes out and liquidation must be requested now. This is the
-        // case the fixed cron schedule missed entirely.
+    #[test]
+    fn test_close_proximity_follows_an_early_close() {
+        // 12:50 Eastern. Under a 16:00 close this is mid-session; under a 13:00
+        // early close it is ten minutes out. The distinction is the reason the
+        // proximity check reads Alpaca's session rather than a wall clock.
         let now = utc("2024-07-03T16:50:00Z");
         let early_close =
             MarketSession::new(true, utc("2024-07-03T17:00:00Z")).expect("early close session");
         let regular_close =
             MarketSession::new(true, utc("2024-07-03T20:00:00Z")).expect("regular close session");
 
-        assert!(request_liquidation_if_close_is_near(state.pool(), &early_close, now).await);
-        assert!(!request_liquidation_if_close_is_near(state.pool(), &regular_close, now).await);
+        assert!(close_is_near(&early_close, now));
+        assert!(!close_is_near(&regular_close, now));
     }
 
     // --- rebalance slot claiming ---

--- a/src/portfolio/live_evaluator.rs
+++ b/src/portfolio/live_evaluator.rs
@@ -205,9 +205,18 @@ async fn run_live_evaluator(
 
     loop {
         // Outside the quote-stream window the cache is guaranteed empty, because
-        // the producer sleeps through the same window. Refreshing baselines here
-        // would issue queries a minute, all night and all weekend, for a check
-        // that cannot fire.
+        // the producer sleeps through it too. Refreshing baselines here would
+        // issue queries a minute, all night and all weekend, for a check that
+        // cannot fire.
+        //
+        // The fixed window is used rather than Alpaca's real session, unlike the
+        // producer, which derives its own. That is safe because the fixed window
+        // is a strict superset: every real session falls inside 09:25–16:05 on a
+        // weekday, so this never sleeps through live quotes. It only costs
+        // unnecessary polling on a holiday or after an early close, where the
+        // producer has already stopped and the cache stays empty. Deriving the
+        // session here would need the Alpaca client threaded into this task for
+        // a saving that is entirely in idle queries.
         if !is_within_quote_stream_window() {
             let wait = duration_until_quote_stream_window(Utc::now());
             info!(

--- a/src/portfolio/live_prices.rs
+++ b/src/portfolio/live_prices.rs
@@ -20,57 +20,34 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
 use crate::domain::freshness::StalenessWindow;
-use crate::domain::market::{EquityQuote, Ticker};
+use crate::domain::market::{BookQualityLimits, EquityQuote, Ticker, UsableQuote};
 use crate::stream::buffer::MarketDataBuffer;
 
-/// Returns the mid-price when both sides of the book are usable.
+/// Latest streamed book per ticker, with a staleness guard on read.
 ///
-/// Each side is validated independently. Checking only the average would accept
-/// a one-sided book such as `bid = 0, ask = 200`, whose mean is a plausible-looking
-/// 100 but is really half a real price — and it would then feed every spread that
-/// leg appears in.
-///
-/// A crossed book (`bid > ask`) is rejected as well: it is either a stale frame
-/// or a feed artifact, and its midpoint is not a price anything traded at.
-fn usable_mid_price(bid_price: f64, ask_price: f64) -> Option<f64> {
-    if !bid_price.is_finite() || bid_price <= 0.0 {
-        return None;
-    }
-    if !ask_price.is_finite() || ask_price <= 0.0 {
-        return None;
-    }
-    if bid_price > ask_price {
-        return None;
-    }
-    Some((bid_price + ask_price) / 2.0)
-}
-
-/// The most recent quote observed for a ticker.
-#[derive(Debug, Clone, Copy)]
-struct LiveMidPrice {
-    mid_price: f64,
-    observed_at: DateTime<Utc>,
-}
-
-/// Latest streamed mid-price per ticker, with a staleness guard on read.
+/// Stores the validated quote rather than a bare mid so the spread it was drawn
+/// from survives into the cache. Downstream filters need the spread to decide
+/// entry eligibility, and recovering it from a midpoint is impossible.
 #[derive(Clone)]
 pub struct LivePriceCache {
-    prices: Arc<RwLock<HashMap<Ticker, LiveMidPrice>>>,
+    quotes: Arc<RwLock<HashMap<Ticker, UsableQuote>>>,
     staleness_window: StalenessWindow,
+    book_limits: BookQualityLimits,
 }
 
 impl Default for LivePriceCache {
     fn default() -> Self {
-        Self::new(StalenessWindow::quotes())
+        Self::new(StalenessWindow::quotes(), BookQualityLimits::default())
     }
 }
 
 impl LivePriceCache {
-    /// Creates an empty cache using `staleness_window` for read filtering.
-    pub fn new(staleness_window: StalenessWindow) -> Self {
+    /// Creates an empty cache using `staleness_window` and `book_limits` on read.
+    pub fn new(staleness_window: StalenessWindow, book_limits: BookQualityLimits) -> Self {
         Self {
-            prices: Arc::new(RwLock::new(HashMap::new())),
+            quotes: Arc::new(RwLock::new(HashMap::new())),
             staleness_window,
+            book_limits,
         }
     }
 
@@ -81,31 +58,27 @@ impl LivePriceCache {
     /// reconnects, and rewinding a price would flip a spread back across a
     /// threshold it had already crossed.
     pub async fn record(&self, quote: &EquityQuote) {
-        let Some(mid_price) = usable_mid_price(quote.bid_price(), quote.ask_price()) else {
-            // Debug rather than warn: a symbol quoting one-sided does so on
-            // every frame, which on a busy feed is thousands of warnings a
+        let Some(usable) = UsableQuote::new(quote, self.book_limits) else {
+            // Debug rather than warn: a symbol quoting one-sided or wide does so
+            // on every frame, which on a busy feed is thousands of warnings a
             // second through the file appender.
             debug!(
                 ticker = quote.ticker().as_str(),
                 bid = quote.bid_price(),
                 ask = quote.ask_price(),
+                bid_size = quote.bid_size(),
+                ask_size = quote.ask_size(),
                 "Ignoring quote with an unusable book"
             );
             return;
         };
 
-        let mut prices = self.prices.write().await;
-        match prices.get(quote.ticker()) {
-            Some(existing) if existing.observed_at >= quote.timestamp() => return,
+        let mut quotes = self.quotes.write().await;
+        match quotes.get(quote.ticker()) {
+            Some(existing) if existing.observed_at() >= quote.timestamp() => return,
             _ => {}
         }
-        prices.insert(
-            quote.ticker().clone(),
-            LiveMidPrice {
-                mid_price,
-                observed_at: quote.timestamp(),
-            },
-        );
+        quotes.insert(quote.ticker().clone(), usable);
     }
 
     /// Returns every mid-price still inside the staleness window at `now`.
@@ -113,19 +86,31 @@ impl LivePriceCache {
     /// Stale entries are filtered rather than evicted: the symbol may resume
     /// quoting, and dropping it would lose the timestamp used to decide that.
     pub async fn fresh_mid_prices(&self, now: DateTime<Utc>) -> HashMap<Ticker, f64> {
-        let prices = self.prices.read().await;
-        prices
+        self.fresh_quotes(now)
+            .await
+            .into_iter()
+            .map(|(ticker, quote)| (ticker, quote.mid_price()))
+            .collect()
+    }
+
+    /// Returns every validated quote still inside the staleness window at `now`.
+    ///
+    /// Callers needing the spread — entry eligibility, feed health logging — use
+    /// this rather than reconstructing it from a midpoint, which cannot be done.
+    pub async fn fresh_quotes(&self, now: DateTime<Utc>) -> HashMap<Ticker, UsableQuote> {
+        let quotes = self.quotes.read().await;
+        quotes
             .iter()
-            .filter(|(_, price)| {
-                now.signed_duration_since(price.observed_at) <= self.staleness_window.0
+            .filter(|(_, quote)| {
+                now.signed_duration_since(quote.observed_at()) <= self.staleness_window.0
             })
-            .map(|(ticker, price)| (ticker.clone(), price.mid_price))
+            .map(|(ticker, quote)| (ticker.clone(), *quote))
             .collect()
     }
 
     /// Returns the number of cached symbols, fresh or not.
     pub async fn len(&self) -> usize {
-        self.prices.read().await.len()
+        self.quotes.read().await.len()
     }
 
     /// Returns whether the cache holds no quotes at all.
@@ -175,8 +160,17 @@ mod tests {
         Ticker::new(symbol).expect("valid ticker")
     }
 
+    /// Builds a quote sized at the round-lot minimum so fixtures exercise the
+    /// price and staleness rules rather than tripping the size gate.
     fn quote_at(symbol: &str, bid: f64, ask: f64, observed_at: DateTime<Utc>) -> EquityQuote {
-        EquityQuote::new(observed_at, ticker(symbol), bid, ask, 1, 1)
+        EquityQuote::new(
+            observed_at,
+            ticker(symbol),
+            bid,
+            ask,
+            crate::domain::market::MINIMUM_QUOTE_SIZE,
+            crate::domain::market::MINIMUM_QUOTE_SIZE,
+        )
     }
 
     #[tokio::test]
@@ -286,18 +280,50 @@ mod tests {
         assert!(cache.is_empty().await);
     }
 
-    #[test]
-    fn test_usable_mid_price_validates_each_side() {
-        assert_eq!(usable_mid_price(180.0, 180.2), Some(180.1));
-        // Touching book: bid equals ask is valid, not crossed.
-        assert_eq!(usable_mid_price(180.0, 180.0), Some(180.0));
+    #[tokio::test]
+    async fn test_wide_book_is_rejected() {
+        // 180.0 / 200.0 is a 1,053 basis point book. Its midpoint of 190 is not
+        // a price either side would trade at, and both legs of a pair built on
+        // it would carry that error into the spread.
+        let now = Utc::now();
+        let cache = LivePriceCache::default();
+        cache.record(&quote_at("AAPL", 180.0, 200.0, now)).await;
 
-        assert_eq!(usable_mid_price(0.0, 200.0), None);
-        assert_eq!(usable_mid_price(200.0, 0.0), None);
-        assert_eq!(usable_mid_price(-1.0, 200.0), None);
-        assert_eq!(usable_mid_price(181.0, 180.0), None);
-        assert_eq!(usable_mid_price(f64::NAN, 180.0), None);
-        assert_eq!(usable_mid_price(180.0, f64::INFINITY), None);
+        assert!(cache.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn test_odd_lot_book_is_rejected() {
+        // A tight spread quoted for a handful of shares is not liquidity a real
+        // position can cross.
+        let now = Utc::now();
+        let cache = LivePriceCache::default();
+        cache
+            .record(&EquityQuote::new(
+                now,
+                ticker("AAPL"),
+                180.0,
+                180.2,
+                1,
+                crate::domain::market::MINIMUM_QUOTE_SIZE,
+            ))
+            .await;
+
+        assert!(cache.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn test_fresh_quotes_exposes_spread() {
+        // The cache must retain the spread, not just the midpoint: entry
+        // eligibility needs it and it cannot be recovered from a mid.
+        let now = Utc::now();
+        let cache = LivePriceCache::default();
+        cache.record(&quote_at("AAPL", 180.0, 180.18, now)).await;
+
+        let quotes = cache.fresh_quotes(now).await;
+        let quote = quotes[&ticker("AAPL")];
+        assert!((quote.mid_price() - 180.09).abs() < 1e-9);
+        assert!((quote.relative_spread() * 10_000.0 - 9.995).abs() < 0.01);
     }
 
     #[tokio::test]

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -29,7 +29,7 @@ use chrono::{DateTime, Utc};
 use num_traits::ToPrimitive;
 use rust_decimal::Decimal;
 use tokio::sync::RwLock;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::common::events::{emit_event, EventType};
@@ -1066,14 +1066,23 @@ async fn select_size_execute(
 
     let tradable_assets = resolve_tradable_assets(alpaca, tradable_assets_cache).await?;
 
+    // Settle tradability and quote quality before the convergence loop. Both are
+    // properties of the symbols rather than of how a set was sized, so neither
+    // belongs inside a loop whose purpose is resolving the joint sizing problem.
+    let (eligible_candidates, entry_prices) =
+        screen_entry_candidates(alpaca, &scored_pairs, &tradable_assets).await;
+
+    if eligible_candidates.is_empty() {
+        info!("No candidates survived screening; no pairs will be opened");
+        return Ok(Vec::new());
+    }
+
     let eligible_pairs = converge_entry_set(
-        alpaca,
         risk_gate_config,
         market_session,
-        &scored_pairs,
-        &tradable_assets,
+        &eligible_candidates,
+        &entry_prices,
         market_betas,
-        historical_prices,
         alpaca_positions,
         current_equity,
         buying_power,
@@ -1081,8 +1090,7 @@ async fn select_size_execute(
         exposure_scale,
         candidate_pool,
         minimum_pairs,
-    )
-    .await?;
+    )?;
 
     let pending = execute_open_pairs(alpaca, pool, &eligible_pairs).await;
 
@@ -1148,29 +1156,32 @@ async fn resolve_tradable_assets(
     Ok(assets)
 }
 
-/// Fetches entry prices for `tickers`, falling back to the latest daily close.
+/// Fetches validated entry prices for `tickers`.
 ///
 /// Quotes are gated through [`UsableQuote`] and the REST staleness window, so a
-/// book too wide or too old to price against is discarded rather than averaged
-/// into a midpoint. Rejections are counted and logged: they are the measurement
-/// that tells us whether the book-quality bound is set sensibly.
+/// book too wide, too thin, or too old to price against is absent from the
+/// result rather than averaged into a midpoint. A ticker missing from the
+/// returned map has no usable price, and callers must drop it rather than
+/// substitute one — see [`screen_quoted_candidates`].
 ///
-/// The close-price fallback remains for now so that sizing always has a number
-/// to work with. It is the weak point — a symbol rejected for a 3,000 basis
-/// point book still gets sized off its prior close and can still be entered.
-/// Closing that hole belongs to the candidate filter, which excludes such
-/// symbols before they are ever scored, not to this function.
-async fn fetch_entry_prices(
-    alpaca: &dyn Trading,
-    tickers: &[Ticker],
-    historical_prices: &HashMap<Ticker, Vec<f64>>,
-) -> HashMap<Ticker, f64> {
+/// Rejections are counted and logged by cause. They are the measurement that
+/// says whether the book-quality bound is set sensibly, and there is no
+/// production history for this yet.
+///
+/// A failed request yields no prices, which screens out every candidate and
+/// opens nothing this pass. That is the intended outcome: entering a basket
+/// priced off unavailable market data is worse than entering nothing.
+async fn fetch_entry_prices(alpaca: &dyn Trading, tickers: &[Ticker]) -> HashMap<Ticker, f64> {
+    if tickers.is_empty() {
+        return HashMap::new();
+    }
+
     let ticker_strings: Vec<String> = tickers.iter().map(Ticker::to_string).collect();
     let latest_quotes = alpaca
         .fetch_latest_quotes(&ticker_strings)
         .await
         .unwrap_or_else(|error| {
-            warn!(error = %error, "Failed to fetch Alpaca quotes; falling back to close prices");
+            warn!(error = %error, "Failed to fetch Alpaca quotes; no entries will be opened this pass");
             Vec::new()
         });
 
@@ -1206,51 +1217,124 @@ async fn fetch_entry_prices(
         "Entry quote pricing"
     );
 
-    for ticker in tickers {
-        if !entry_prices.contains_key(ticker) {
-            if let Some(latest_close) = historical_prices
-                .get(ticker)
-                .and_then(|closes| closes.last())
-            {
-                entry_prices.insert(ticker.clone(), *latest_close);
-            }
-        }
-    }
-
     entry_prices
 }
-
-/// Splits sized pairs into those Alpaca will trade and the identifiers of those it will not.
-fn partition_tradable_pairs(
-    sized_pairs: Vec<crate::portfolio::sizing::SizedPair>,
+/// Keeps candidates whose long leg is tradable and short leg shortable.
+///
+/// Runs before sizing rather than after. Tradability is a property of the
+/// symbol, fixed for the session and known from a cached asset list, so
+/// discovering it after the joint sizing optimization wasted the whole
+/// computation: a working set of ten could size successfully and then lose six
+/// pairs here, leaving too few to meet the target and aborting the pass.
+fn screen_tradable_candidates(
+    scored_pairs: &[ScoredPair],
     tradable_assets: &TradableAssets,
-) -> (Vec<crate::portfolio::sizing::SizedPair>, Vec<PairID>) {
+) -> (Vec<ScoredPair>, usize) {
     let mut kept = Vec::new();
-    let mut rejected = Vec::new();
+    let mut rejected: usize = 0;
 
-    for pair in sized_pairs {
+    for scored in scored_pairs {
+        let pair = scored.pair();
         let long_ok = tradable_assets.is_tradable(pair.long_ticker().as_str());
         let short_ok = tradable_assets.is_shortable(pair.short_ticker().as_str());
-        if !long_ok {
-            info!(
-                ticker = pair.long_ticker().as_str(),
-                "Long leg not tradable on Alpaca; dropping pair"
-            );
-        }
-        if !short_ok {
-            info!(
-                ticker = pair.short_ticker().as_str(),
-                "Short leg not shortable on Alpaca; dropping pair"
-            );
-        }
         if long_ok && short_ok {
-            kept.push(pair);
+            kept.push(scored.clone());
         } else {
-            rejected.push(pair.pair_id().clone());
+            // Debug rather than info: the untradable set is stable across a
+            // session, so this repeats identically on every pass.
+            debug!(
+                pair_id = pair.pair_id().as_str(),
+                long_tradable = long_ok,
+                short_shortable = short_ok,
+                "Candidate dropped: leg not tradable on Alpaca"
+            );
+            rejected += 1;
         }
     }
 
     (kept, rejected)
+}
+
+/// Keeps candidates whose legs both carry a usable, current quote.
+///
+/// A pair is dropped when either leg fails the book-quality gate or the REST
+/// staleness window. It is dropped for this pass only: the snapshot is retaken
+/// every pass, so a symbol quoting temporarily wide becomes eligible again once
+/// it tightens, and no persistent state has to be reconciled when it does.
+///
+/// Dropping is the point. The previous behaviour substituted the prior daily
+/// close whenever a quote was unusable, which meant a symbol rejected for a
+/// three thousand basis point book was still sized and still entered, priced off
+/// a number from the day before. Entering a position that cannot be priced is
+/// entering one that cannot be exited.
+fn screen_quoted_candidates(
+    scored_pairs: Vec<ScoredPair>,
+    entry_prices: &HashMap<Ticker, f64>,
+) -> (Vec<ScoredPair>, usize) {
+    let mut kept = Vec::new();
+    let mut rejected: usize = 0;
+
+    for scored in scored_pairs {
+        let pair = scored.pair();
+        let long_priced = entry_prices.contains_key(pair.long_ticker());
+        let short_priced = entry_prices.contains_key(pair.short_ticker());
+        if long_priced && short_priced {
+            kept.push(scored);
+        } else {
+            debug!(
+                pair_id = pair.pair_id().as_str(),
+                long_priced, short_priced, "Candidate dropped: leg lacks a usable current quote"
+            );
+            rejected += 1;
+        }
+    }
+
+    (kept, rejected)
+}
+
+/// Screens candidates down to those that can actually be opened, and prices them.
+///
+/// One batched snapshot call covers every distinct leg of every surviving
+/// candidate; the client chunks internally, so the whole set goes in one call
+/// from here regardless of size. The former arrangement fetched incrementally
+/// inside the convergence loop, re-entering the network on each iteration, which
+/// only made sense while the request was believed to be symbol-capped.
+async fn screen_entry_candidates(
+    alpaca: &dyn Trading,
+    scored_pairs: &[ScoredPair],
+    tradable_assets: &TradableAssets,
+) -> (Vec<ScoredPair>, HashMap<Ticker, f64>) {
+    let considered = scored_pairs.len();
+    let (tradable_candidates, rejected_untradable) =
+        screen_tradable_candidates(scored_pairs, tradable_assets);
+
+    let legs: Vec<Ticker> = tradable_candidates
+        .iter()
+        .flat_map(|scored| {
+            [
+                scored.pair().long_ticker().clone(),
+                scored.pair().short_ticker().clone(),
+            ]
+        })
+        .collect::<HashSet<Ticker>>()
+        .into_iter()
+        .collect();
+
+    let entry_prices = fetch_entry_prices(alpaca, &legs).await;
+    let (eligible, rejected_unquoted) =
+        screen_quoted_candidates(tradable_candidates, &entry_prices);
+
+    info!(
+        considered,
+        rejected_untradable,
+        rejected_unquoted,
+        eligible = eligible.len(),
+        legs_priced = entry_prices.len(),
+        legs_requested = legs.len(),
+        "Entry candidates screened"
+    );
+
+    (eligible, entry_prices)
 }
 
 /// Applies the risk gate to each pair, returning approvals and rejected identifiers.
@@ -1363,9 +1447,15 @@ fn partition_risk_gated_pairs(
 /// for N pairs but executed with fewer, whose parity weights no longer summed to
 /// one and whose beta was no longer neutral.
 ///
-/// The loop closes that gap. Each pass selects a working set, sizes it, filters
-/// it, and gates it; any rejection excludes those pairs and re-runs the whole
-/// pass, so whatever is finally executed was sized as exactly that set.
+/// The loop closes that gap. Each pass selects a working set, sizes it, and
+/// gates it; any rejection excludes those pairs and re-runs the whole pass, so
+/// whatever is finally executed was sized as exactly that set.
+///
+/// Only the risk gate can reject here. Tradability and quote quality are settled
+/// by [`screen_entry_candidates`] before the loop starts, because neither
+/// depends on how a pair was sized — feeding them through the joint optimization
+/// only to discard the result was wasted work, and losing enough pairs that way
+/// aborted the whole pass.
 ///
 /// Two properties make re-selection worthwhile rather than merely correct:
 ///
@@ -1379,14 +1469,12 @@ fn partition_risk_gated_pairs(
 /// Degrades gracefully: a target that cannot be met is lowered rather than
 /// aborting the pass, since filling four of ten slots beats filling none.
 #[allow(clippy::too_many_arguments)]
-async fn converge_entry_set(
-    alpaca: &dyn Trading,
+fn converge_entry_set(
     risk_gate_config: &risk_gate::RiskGateConfiguration,
     market_session: &MarketSession,
     scored_pairs: &[ScoredPair],
-    tradable_assets: &TradableAssets,
+    entry_prices: &HashMap<Ticker, f64>,
     market_betas: &HashMap<Ticker, f64>,
-    historical_prices: &HashMap<Ticker, Vec<f64>>,
     alpaca_positions: &[crate::portfolio::alpaca::Position],
     current_equity: f64,
     buying_power: f64,
@@ -1396,7 +1484,6 @@ async fn converge_entry_set(
     target_pairs: usize,
 ) -> Result<Vec<crate::portfolio::sizing::SizedPair>, RebalanceError> {
     let mut excluded: HashSet<PairID> = HashSet::new();
-    let mut entry_prices: HashMap<Ticker, f64> = HashMap::new();
     let mut target = target_pairs;
 
     // The iteration budget scales with the working set because each iteration
@@ -1423,22 +1510,11 @@ async fn converge_entry_set(
             return Ok(Vec::new());
         }
 
-        // Price any tickers this iteration introduced. Earlier entries are kept
-        // so a re-selection that reuses a pair does not re-fetch its quote.
-        let unpriced: Vec<Ticker> = working_set
-            .iter()
-            .flat_map(|pair| [pair.long_ticker().clone(), pair.short_ticker().clone()])
-            .filter(|ticker| !entry_prices.contains_key(ticker))
-            .collect();
-        if !unpriced.is_empty() {
-            entry_prices.extend(fetch_entry_prices(alpaca, &unpriced, historical_prices).await);
-        }
-
         let sized_pairs = match size_pairs_with_volatility_parity(
             &working_set,
             capital,
             market_betas,
-            &entry_prices,
+            entry_prices,
             exposure_scale,
             target,
         ) {
@@ -1460,8 +1536,6 @@ async fn converge_entry_set(
             Err(error) => return Err(error.into()),
         };
 
-        let (tradable_pairs, untradable) = partition_tradable_pairs(sized_pairs, tradable_assets);
-
         // Rebuilt every iteration: the snapshot accumulates approvals, so it
         // must start from real portfolio state rather than a previous attempt.
         let mut snapshot = build_portfolio_snapshot(current_equity, buying_power, alpaca_positions);
@@ -1469,11 +1543,11 @@ async fn converge_entry_set(
             risk_gate_config,
             market_session,
             &mut snapshot,
-            tradable_pairs,
+            sized_pairs,
             Utc::now(),
         );
 
-        if untradable.is_empty() && gate_rejected.is_empty() {
+        if gate_rejected.is_empty() {
             info!(
                 iteration,
                 approved = approved.len(),
@@ -1483,8 +1557,7 @@ async fn converge_entry_set(
             return Ok(approved);
         }
 
-        let newly_excluded = untradable.len() + gate_rejected.len();
-        excluded.extend(untradable);
+        let newly_excluded = gate_rejected.len();
         excluded.extend(gate_rejected);
         info!(
             iteration,
@@ -1663,6 +1736,177 @@ async fn persist_filled_pairs(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- Entry candidate screening ---
+
+    mod screening {
+        use super::*;
+        use crate::portfolio::alpaca::{LatestQuote, MockTrading};
+        use crate::portfolio::statistical_arbitrage::CandidatePair;
+        use chrono::Duration;
+
+        fn ticker(symbol: &str) -> Ticker {
+            Ticker::new(symbol).expect("valid ticker")
+        }
+
+        fn candidate(long: &str, short: &str) -> ScoredPair {
+            let pair = CandidatePair::new(
+                PairID::new(ticker(long), ticker(short)),
+                ticker(long),
+                ticker(short),
+                2.0,
+                1.0,
+                0.05,
+                0.02,
+                0.02,
+            )
+            .expect("valid candidate pair");
+            ScoredPair::new(pair, 1.0)
+        }
+
+        /// Builds an asset universe where every listed symbol is both tradable
+        /// and shortable, and nothing else is.
+        fn assets(symbols: &[&str]) -> TradableAssets {
+            TradableAssets::from_sets(
+                symbols.iter().map(|s| s.to_string()).collect(),
+                symbols.iter().map(|s| s.to_string()).collect(),
+            )
+        }
+
+        fn quote(symbol: &str, bid: f64, ask: f64, age: Duration) -> LatestQuote {
+            LatestQuote {
+                symbol: symbol.to_string(),
+                bid_price: bid,
+                ask_price: ask,
+                bid_size: crate::domain::market::MINIMUM_QUOTE_SIZE,
+                ask_size: crate::domain::market::MINIMUM_QUOTE_SIZE,
+                observed_at: Utc::now() - age,
+            }
+        }
+
+        #[test]
+        fn test_screen_tradable_drops_pair_when_either_leg_ineligible() {
+            let candidates = vec![
+                candidate("AAPL", "MSFT"),
+                candidate("GOOG", "META"),
+                candidate("NVDA", "TSLA"),
+            ];
+            // META is absent, so GOOG-META loses its short leg.
+            let universe = assets(&["AAPL", "MSFT", "GOOG", "NVDA", "TSLA"]);
+
+            let (kept, rejected) = screen_tradable_candidates(&candidates, &universe);
+
+            assert_eq!(rejected, 1);
+            assert_eq!(kept.len(), 2);
+            assert!(kept
+                .iter()
+                .all(|scored| scored.pair().pair_id().as_str() != "GOOG-META"));
+        }
+
+        #[test]
+        fn test_screen_quoted_drops_pair_missing_either_price() {
+            let candidates = vec![candidate("AAPL", "MSFT"), candidate("GOOG", "META")];
+            let mut prices = HashMap::new();
+            prices.insert(ticker("AAPL"), 180.0);
+            prices.insert(ticker("MSFT"), 400.0);
+            // GOOG priced, META not: the pair must go, not just the leg.
+            prices.insert(ticker("GOOG"), 150.0);
+
+            let (kept, rejected) = screen_quoted_candidates(candidates, &prices);
+
+            assert_eq!(rejected, 1);
+            assert_eq!(kept.len(), 1);
+            assert_eq!(kept[0].pair().pair_id().as_str(), "AAPL-MSFT");
+        }
+
+        #[tokio::test]
+        async fn test_fetch_entry_prices_rejects_wide_and_stale_books() {
+            let mock = MockTrading {
+                latest_quotes: vec![
+                    // Tight and current: accepted.
+                    quote("AAPL", 180.00, 180.20, Duration::seconds(5)),
+                    // 1,053 basis points wide: rejected on book quality.
+                    quote("WIDE", 180.00, 200.00, Duration::seconds(5)),
+                    // Tight but older than the five-minute REST window.
+                    quote("OLD", 180.00, 180.20, Duration::seconds(400)),
+                ],
+                ..MockTrading::default()
+            };
+
+            let prices =
+                fetch_entry_prices(&mock, &[ticker("AAPL"), ticker("WIDE"), ticker("OLD")]).await;
+
+            assert_eq!(prices.len(), 1);
+            assert!((prices[&ticker("AAPL")] - 180.1).abs() < 1e-9);
+            assert!(!prices.contains_key(&ticker("WIDE")));
+            assert!(!prices.contains_key(&ticker("OLD")));
+        }
+
+        #[tokio::test]
+        async fn test_fetch_entry_prices_does_not_substitute_a_close() {
+            // The behaviour this replaces: an unusable quote fell back to the
+            // prior daily close, so a symbol rejected for its book was still
+            // sized and still entered.
+            let mock = MockTrading {
+                latest_quotes: vec![quote("WIDE", 180.00, 200.00, Duration::seconds(5))],
+                ..MockTrading::default()
+            };
+
+            let prices = fetch_entry_prices(&mock, &[ticker("WIDE")]).await;
+
+            assert!(prices.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_fetch_entry_prices_returns_empty_for_no_tickers() {
+            let mock = MockTrading::default();
+            assert!(fetch_entry_prices(&mock, &[]).await.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_screen_entry_candidates_applies_both_screens() {
+            let candidates = vec![
+                candidate("AAPL", "MSFT"),
+                // Tradable, but NOQT quotes too wide to price.
+                candidate("GOOG", "NOQT"),
+                // TSLA is not in the tradable universe at all.
+                candidate("NVDA", "TSLA"),
+            ];
+            let universe = assets(&["AAPL", "MSFT", "GOOG", "NOQT", "NVDA"]);
+            let mock = MockTrading {
+                latest_quotes: vec![
+                    quote("AAPL", 180.00, 180.20, Duration::seconds(5)),
+                    quote("MSFT", 400.00, 400.30, Duration::seconds(5)),
+                    quote("GOOG", 150.00, 150.10, Duration::seconds(5)),
+                    quote("NOQT", 10.00, 12.00, Duration::seconds(5)),
+                ],
+                ..MockTrading::default()
+            };
+
+            let (eligible, prices) = screen_entry_candidates(&mock, &candidates, &universe).await;
+
+            assert_eq!(eligible.len(), 1);
+            assert_eq!(eligible[0].pair().pair_id().as_str(), "AAPL-MSFT");
+            // NVDA never reached pricing: its pair failed the tradable screen,
+            // so it must not appear in the request at all.
+            assert!(!prices.contains_key(&ticker("NVDA")));
+            assert!(!prices.contains_key(&ticker("NOQT")));
+        }
+
+        #[tokio::test]
+        async fn test_screen_entry_candidates_yields_nothing_when_quotes_unavailable() {
+            // A failed or empty quote response must open nothing rather than
+            // fall through to some other price source.
+            let candidates = vec![candidate("AAPL", "MSFT")];
+            let universe = assets(&["AAPL", "MSFT"]);
+            let mock = MockTrading::default();
+
+            let (eligible, prices) = screen_entry_candidates(&mock, &candidates, &universe).await;
+
+            assert!(eligible.is_empty());
+            assert!(prices.is_empty());
+        }
+    }
 
     #[test]
     fn test_rebalance_error_display_stale_predictions() {

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -34,7 +34,8 @@ use uuid::Uuid;
 
 use crate::common::events::{emit_event, EventType};
 use crate::common::market_hours::MarketSession;
-use crate::domain::market::{PairID, Ticker};
+use crate::domain::freshness::StalenessWindow;
+use crate::domain::market::{BookQualityLimits, PairID, Ticker, UsableQuote};
 use crate::domain::orders::{FilledPair, Order, Pending};
 use crate::domain::portfolio::{Portfolio, PortfolioError};
 use crate::domain::trading::{
@@ -1149,8 +1150,16 @@ async fn resolve_tradable_assets(
 
 /// Fetches entry prices for `tickers`, falling back to the latest daily close.
 ///
-/// One batched REST call per invocation. A quote failure degrades to close
-/// prices rather than aborting the pass.
+/// Quotes are gated through [`UsableQuote`] and the REST staleness window, so a
+/// book too wide or too old to price against is discarded rather than averaged
+/// into a midpoint. Rejections are counted and logged: they are the measurement
+/// that tells us whether the book-quality bound is set sensibly.
+///
+/// The close-price fallback remains for now so that sizing always has a number
+/// to work with. It is the weak point — a symbol rejected for a 3,000 basis
+/// point book still gets sized off its prior close and can still be entered.
+/// Closing that hole belongs to the candidate filter, which excludes such
+/// symbols before they are ever scored, not to this function.
 async fn fetch_entry_prices(
     alpaca: &dyn Trading,
     tickers: &[Ticker],
@@ -1165,10 +1174,37 @@ async fn fetch_entry_prices(
             Vec::new()
         });
 
-    let mut entry_prices: HashMap<Ticker, f64> = latest_quotes
-        .into_iter()
-        .filter_map(|quote| Ticker::new(&quote.symbol).map(|ticker| (ticker, quote.mid_price)))
-        .collect();
+    let book_limits = BookQualityLimits::default();
+    let staleness_window = StalenessWindow::rest_quotes();
+    let now = Utc::now();
+    let returned = latest_quotes.len();
+    let mut rejected_book: usize = 0;
+    let mut rejected_stale: usize = 0;
+
+    let mut entry_prices: HashMap<Ticker, f64> = HashMap::new();
+    for latest in latest_quotes {
+        let Some(quote) = latest.to_equity_quote() else {
+            continue;
+        };
+        let Some(usable) = UsableQuote::new(&quote, book_limits) else {
+            rejected_book += 1;
+            continue;
+        };
+        if now.signed_duration_since(usable.observed_at()) > staleness_window.0 {
+            rejected_stale += 1;
+            continue;
+        }
+        entry_prices.insert(quote.ticker().clone(), usable.mid_price());
+    }
+
+    info!(
+        requested = tickers.len(),
+        returned,
+        accepted = entry_prices.len(),
+        rejected_book,
+        rejected_stale,
+        "Entry quote pricing"
+    );
 
     for ticker in tickers {
         if !entry_prices.contains_key(ticker) {

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -55,7 +55,7 @@ use crate::portfolio::database::{
 use crate::portfolio::execution::{
     close_positions, confirm_fills, execute_open_pairs, ExecutionError,
 };
-use crate::portfolio::math::{z_score_against, z_score_last};
+use crate::portfolio::math::z_score_against;
 use crate::portfolio::reconciliation;
 use crate::portfolio::regime::classify_regime;
 use crate::portfolio::risk_gate::{
@@ -234,13 +234,40 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
     // Phase 4: exit evaluation — always runs when open pairs exist.
     let mut pairs_closed: usize = 0;
     if !open_pairs.is_empty() {
-        let live_mid_prices = state.live_prices().fresh_mid_prices(Utc::now()).await;
+        // Tier 1: streamed mids, already filtered by the sixty-second guard.
+        let mut exit_mid_prices = state.live_prices().fresh_mid_prices(Utc::now()).await;
+        let streamed = exit_mid_prices.len();
+
+        // Tier 2: one batched snapshot for legs the stream did not cover. Only
+        // the gap is fetched, so a fully streamed book costs no request at all.
+        // A leg stale in the cache is already absent from `fresh_mid_prices`,
+        // so "not streamed" and "streamed but stale" are the same case here.
+        let unpriced_legs: Vec<Ticker> = open_pairs
+            .iter()
+            .flat_map(|pair| [pair.long_ticker().clone(), pair.short_ticker().clone()])
+            .filter(|ticker| !exit_mid_prices.contains_key(ticker))
+            .collect::<HashSet<Ticker>>()
+            .into_iter()
+            .collect();
+
+        let snapshot_filled = if unpriced_legs.is_empty() {
+            0
+        } else {
+            let filled = fetch_validated_mid_prices(alpaca, &unpriced_legs, "exit").await;
+            let count = filled.len();
+            exit_mid_prices.extend(filled);
+            count
+        };
+
         info!(
-            live_quotes = live_mid_prices.len(),
             open_pairs = open_pairs.len(),
+            legs = open_pairs.len() * 2,
+            priced_from_stream = streamed,
+            priced_from_snapshot = snapshot_filled,
+            unpriced = unpriced_legs.len() - snapshot_filled,
             "Exit evaluation pricing"
         );
-        let close_signals = evaluate_open_pairs(&open_pairs, &historical_prices, &live_mid_prices);
+        let close_signals = evaluate_open_pairs(&open_pairs, &historical_prices, &exit_mid_prices);
         pairs_closed = close_triggered_pairs(alpaca, pool, &close_signals).await?;
         let pairs_kept_after_exits = open_pairs.len() - pairs_closed;
         info!(
@@ -772,15 +799,21 @@ struct PairCloseSignal {
 ///
 /// Pairs where either leg lacks historical price data are silently skipped (kept open).
 ///
-/// `live_mid_prices` carries streamed mid-prices that passed the staleness
-/// guard. When both legs of a pair are present, the current spread is appended
-/// to the daily series so the z-score reflects the intraday book rather than
-/// the prior session's close. Predictions remain the directional alpha; this is
-/// what makes the exit timing intraday.
+/// `current_mid_prices` carries validated same-session mid prices, streamed
+/// where the feed covers a symbol and pulled from the REST snapshot where it
+/// does not. Daily closes supply the distribution the z-score is measured
+/// against; they never supply the current observation.
+///
+/// A pair whose legs are not both priced is kept and re-evaluated next pass. The
+/// alternative, and the previous behaviour, was to fall back to `z_score_last`
+/// over the daily series — which scored the position on the *prior session's
+/// close*, up to 65 hours old on a Monday afternoon, and did so with a different
+/// estimator than the live path. That produced closes triggered by a symbol
+/// going quiet rather than by the spread moving.
 fn evaluate_open_pairs(
     open_pairs: &[OpenPair],
     historical_prices: &HashMap<Ticker, Vec<f64>>,
-    live_mid_prices: &HashMap<Ticker, f64>,
+    current_mid_prices: &HashMap<Ticker, f64>,
 ) -> Vec<PairCloseSignal> {
     let mut signals = Vec::new();
 
@@ -816,33 +849,29 @@ fn evaluate_open_pairs(
             .map(|(long, short)| long - pair.hedge_ratio() * short)
             .collect();
 
-        // Both legs must be fresh or neither is used: pricing one leg live
+        // Both legs must be priced or neither is used: pricing one leg current
         // against the other's prior close would move the spread by a day of
         // drift in that leg alone and read as a signal.
-        let current_z = match (
-            live_mid_prices.get(pair.long_ticker()),
-            live_mid_prices.get(pair.short_ticker()),
-        ) {
-            (Some(long_mid), Some(short_mid)) => {
-                // Measured against the historical distribution, not one that
-                // includes it. Appending the live point first would let a large
-                // move pull the mean toward itself and inflate the deviation,
-                // shrinking its own z-score, and would put this pass on a
-                // different scale from `PairBaseline::live_z_score`, which
-                // standardizes against history only. The trigger would then fire
-                // on a larger magnitude than this pass computes, keep the pair
-                // open, and fire again after the debounce.
-                let live_spread = long_mid - pair.hedge_ratio() * short_mid;
-                z_score_against(&spread, live_spread)
-            }
-            _ => {
-                info!(
-                    pair_id = pair.pair_id().as_str(),
-                    "No fresh quotes for both legs; evaluating on daily closes"
-                );
-                z_score_last(&spread)
-            }
+        let (Some(long_mid), Some(short_mid)) = (
+            current_mid_prices.get(pair.long_ticker()),
+            current_mid_prices.get(pair.short_ticker()),
+        ) else {
+            info!(
+                pair_id = pair.pair_id().as_str(),
+                "No usable current price for both legs; keeping pair for re-evaluation"
+            );
+            continue;
         };
+
+        // Measured against the historical distribution, not one that includes
+        // it. Appending the current point first would let a large move pull the
+        // mean toward itself and inflate the deviation, shrinking its own
+        // z-score, and would put this pass on a different scale from
+        // `PairBaseline::live_z_score`, which standardizes against history only.
+        // The trigger would then fire on a larger magnitude than this pass
+        // computes, keep the pair open, and fire again after the debounce.
+        let current_spread = long_mid - pair.hedge_ratio() * short_mid;
+        let current_z = z_score_against(&spread, current_spread);
 
         match close_reason_for(pair.entry_z_score(), current_z) {
             Some(CloseReason::ProfitTaken) => {
@@ -1156,22 +1185,30 @@ async fn resolve_tradable_assets(
     Ok(assets)
 }
 
-/// Fetches validated entry prices for `tickers`.
+/// Fetches validated mid prices for `tickers` from the REST snapshot endpoint.
 ///
 /// Quotes are gated through [`UsableQuote`] and the REST staleness window, so a
 /// book too wide, too thin, or too old to price against is absent from the
 /// result rather than averaged into a midpoint. A ticker missing from the
 /// returned map has no usable price, and callers must drop it rather than
-/// substitute one — see [`screen_quoted_candidates`].
+/// substitute one — see [`screen_quoted_candidates`] on the entry side and
+/// [`evaluate_open_pairs`] on the exit side.
 ///
 /// Rejections are counted and logged by cause. They are the measurement that
 /// says whether the book-quality bound is set sensibly, and there is no
 /// production history for this yet.
 ///
-/// A failed request yields no prices, which screens out every candidate and
-/// opens nothing this pass. That is the intended outcome: entering a basket
-/// priced off unavailable market data is worse than entering nothing.
-async fn fetch_entry_prices(alpaca: &dyn Trading, tickers: &[Ticker]) -> HashMap<Ticker, f64> {
+/// A failed request yields no prices. On the entry side that opens nothing this
+/// pass; on the exit side it leaves pairs unpriced and therefore held. Both are
+/// intended: acting on unavailable market data is worse than not acting.
+///
+/// `purpose` distinguishes the two call sites in the logs, which otherwise
+/// produce identical lines from different phases of the same pass.
+async fn fetch_validated_mid_prices(
+    alpaca: &dyn Trading,
+    tickers: &[Ticker],
+    purpose: &'static str,
+) -> HashMap<Ticker, f64> {
     if tickers.is_empty() {
         return HashMap::new();
     }
@@ -1181,7 +1218,7 @@ async fn fetch_entry_prices(alpaca: &dyn Trading, tickers: &[Ticker]) -> HashMap
         .fetch_latest_quotes(&ticker_strings)
         .await
         .unwrap_or_else(|error| {
-            warn!(error = %error, "Failed to fetch Alpaca quotes; no entries will be opened this pass");
+            warn!(error = %error, purpose, "Failed to fetch Alpaca quotes; symbols will be left unpriced");
             Vec::new()
         });
 
@@ -1192,7 +1229,7 @@ async fn fetch_entry_prices(alpaca: &dyn Trading, tickers: &[Ticker]) -> HashMap
     let mut rejected_book: usize = 0;
     let mut rejected_stale: usize = 0;
 
-    let mut entry_prices: HashMap<Ticker, f64> = HashMap::new();
+    let mut mid_prices: HashMap<Ticker, f64> = HashMap::new();
     for latest in latest_quotes {
         let Some(quote) = latest.to_equity_quote() else {
             continue;
@@ -1205,19 +1242,20 @@ async fn fetch_entry_prices(alpaca: &dyn Trading, tickers: &[Ticker]) -> HashMap
             rejected_stale += 1;
             continue;
         }
-        entry_prices.insert(quote.ticker().clone(), usable.mid_price());
+        mid_prices.insert(quote.ticker().clone(), usable.mid_price());
     }
 
     info!(
+        purpose,
         requested = tickers.len(),
         returned,
-        accepted = entry_prices.len(),
+        accepted = mid_prices.len(),
         rejected_book,
         rejected_stale,
-        "Entry quote pricing"
+        "Snapshot quote pricing"
     );
 
-    entry_prices
+    mid_prices
 }
 /// Keeps candidates whose long leg is tradable and short leg shortable.
 ///
@@ -1327,7 +1365,7 @@ async fn screen_entry_candidates(
         .into_iter()
         .collect();
 
-    let entry_prices = fetch_entry_prices(alpaca, &legs).await;
+    let entry_prices = fetch_validated_mid_prices(alpaca, &legs, "entry").await;
     let (eligible, rejected_unquoted) =
         screen_quoted_candidates(tradable_candidates, &entry_prices);
 
@@ -1845,7 +1883,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_fetch_entry_prices_rejects_wide_and_stale_books() {
+        async fn test_fetch_validated_mid_prices_rejects_wide_and_stale_books() {
             let mock = MockTrading {
                 latest_quotes: vec![
                     // Tight and current: accepted.
@@ -1858,8 +1896,12 @@ mod tests {
                 ..MockTrading::default()
             };
 
-            let prices =
-                fetch_entry_prices(&mock, &[ticker("AAPL"), ticker("WIDE"), ticker("OLD")]).await;
+            let prices = fetch_validated_mid_prices(
+                &mock,
+                &[ticker("AAPL"), ticker("WIDE"), ticker("OLD")],
+                "test",
+            )
+            .await;
 
             assert_eq!(prices.len(), 1);
             assert!((prices[&ticker("AAPL")] - 180.1).abs() < 1e-9);
@@ -1868,7 +1910,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_fetch_entry_prices_does_not_substitute_a_close() {
+        async fn test_fetch_validated_mid_prices_does_not_substitute_a_close() {
             // The behaviour this replaces: an unusable quote fell back to the
             // prior daily close, so a symbol rejected for its book was still
             // sized and still entered.
@@ -1877,15 +1919,17 @@ mod tests {
                 ..MockTrading::default()
             };
 
-            let prices = fetch_entry_prices(&mock, &[ticker("WIDE")]).await;
+            let prices = fetch_validated_mid_prices(&mock, &[ticker("WIDE")], "test").await;
 
             assert!(prices.is_empty());
         }
 
         #[tokio::test]
-        async fn test_fetch_entry_prices_returns_empty_for_no_tickers() {
+        async fn test_fetch_validated_mid_prices_returns_empty_for_no_tickers() {
             let mock = MockTrading::default();
-            assert!(fetch_entry_prices(&mock, &[]).await.is_empty());
+            assert!(fetch_validated_mid_prices(&mock, &[], "test")
+                .await
+                .is_empty());
         }
 
         #[tokio::test]
@@ -2059,6 +2103,21 @@ mod tests {
             .collect()
     }
 
+    /// Prices every leg at its own final historical close.
+    ///
+    /// The resulting current spread equals the last point of the daily series,
+    /// so `z_score_against(&spread, current)` returns exactly what the retired
+    /// `z_score_last(&spread)` did — same mean, same deviation, same numerator.
+    /// Fixtures written against the daily-close path therefore keep asserting
+    /// the same signal boundaries, now expressed through the one estimator the
+    /// exit path still uses.
+    fn priced_at_last_close(prices: &HashMap<Ticker, Vec<f64>>) -> HashMap<Ticker, f64> {
+        prices
+            .iter()
+            .filter_map(|(ticker, series)| series.last().map(|last| (ticker.clone(), *last)))
+            .collect()
+    }
+
     #[test]
     fn test_evaluate_open_pairs_convergence_positive_entry() {
         // Entry z > 0 (spread was wide), and current spread has collapsed below mean → converged.
@@ -2068,7 +2127,7 @@ mod tests {
         prices.insert(Ticker::new("AAPL").unwrap(), make_prices(60, 150.0, -1.0));
         prices.insert(Ticker::new("MSFT").unwrap(), make_prices(60, 100.0, 1.0));
 
-        let signals = evaluate_open_pairs(&[pair], &prices, &HashMap::new());
+        let signals = evaluate_open_pairs(&[pair], &prices, &priced_at_last_close(&prices));
         assert_eq!(signals.len(), 1);
         assert_eq!(signals[0].reason, CloseReason::ProfitTaken);
     }
@@ -2082,7 +2141,7 @@ mod tests {
         prices.insert(Ticker::new("AAPL").unwrap(), make_prices(60, 100.0, 1.0));
         prices.insert(Ticker::new("MSFT").unwrap(), make_prices(60, 150.0, -1.0));
 
-        let signals = evaluate_open_pairs(&[pair], &prices, &HashMap::new());
+        let signals = evaluate_open_pairs(&[pair], &prices, &priced_at_last_close(&prices));
         assert_eq!(signals.len(), 1);
         assert_eq!(signals[0].reason, CloseReason::ProfitTaken);
     }
@@ -2102,7 +2161,7 @@ mod tests {
         prices.insert(Ticker::new("AAPL").unwrap(), long_prices);
         prices.insert(Ticker::new("MSFT").unwrap(), short_prices);
 
-        let signals = evaluate_open_pairs(&[pair], &prices, &HashMap::new());
+        let signals = evaluate_open_pairs(&[pair], &prices, &priced_at_last_close(&prices));
         assert_eq!(signals.len(), 1);
         assert_eq!(signals[0].reason, CloseReason::StopLoss);
     }
@@ -2116,7 +2175,7 @@ mod tests {
         prices.insert(Ticker::new("AAPL").unwrap(), make_prices(60, 150.0, 1.0));
         prices.insert(Ticker::new("MSFT").unwrap(), make_prices(60, 100.0, 0.5));
 
-        let signals = evaluate_open_pairs(&[pair], &prices, &HashMap::new());
+        let signals = evaluate_open_pairs(&[pair], &prices, &priced_at_last_close(&prices));
         assert!(signals.is_empty());
     }
 
@@ -2125,7 +2184,7 @@ mod tests {
         let pair = make_open_pair("AAPL", "MSFT", 2.5, 1.0);
         let prices = HashMap::new(); // No price data at all.
 
-        let signals = evaluate_open_pairs(&[pair], &prices, &HashMap::new());
+        let signals = evaluate_open_pairs(&[pair], &prices, &priced_at_last_close(&prices));
         assert!(signals.is_empty()); // Pair kept open due to missing data.
     }
 
@@ -2149,8 +2208,11 @@ mod tests {
         prices.insert(Ticker::new("E").unwrap(), long_e);
         prices.insert(Ticker::new("F").unwrap(), vec![100.0; 60]);
 
-        let signals =
-            evaluate_open_pairs(&[converging, stable, diverging], &prices, &HashMap::new());
+        let signals = evaluate_open_pairs(
+            &[converging, stable, diverging],
+            &prices,
+            &priced_at_last_close(&prices),
+        );
         assert_eq!(signals.len(), 2);
 
         let reasons: Vec<&CloseReason> = signals.iter().map(|signal| &signal.reason).collect();
@@ -2168,7 +2230,7 @@ mod tests {
         prices.insert(Ticker::new("AAPL").unwrap(), vec![150.0; 60]);
         prices.insert(Ticker::new("MSFT").unwrap(), vec![100.0; 60]);
 
-        let signals = evaluate_open_pairs(&[pair], &prices, &HashMap::new());
+        let signals = evaluate_open_pairs(&[pair], &prices, &priced_at_last_close(&prices));
         assert!(signals.is_empty());
     }
 
@@ -2222,7 +2284,7 @@ mod tests {
 
         assert_eq!(
             evaluate_open_pairs(std::slice::from_ref(&pair), &prices, &live).len(),
-            evaluate_open_pairs(&[pair], &prices, &HashMap::new()).len()
+            evaluate_open_pairs(&[pair], &prices, &priced_at_last_close(&prices)).len()
         );
     }
 
@@ -2238,18 +2300,50 @@ mod tests {
     }
 
     #[test]
-    fn test_absent_live_quotes_preserve_daily_close_behavior() {
-        // The staleness guard hands back an empty map whenever quotes stop
-        // flowing, so this is the degraded path the system runs in outside the
-        // quote window or on a halted symbol.
+    fn test_unpriced_pair_is_kept_rather_than_scored_on_daily_closes() {
+        // The inverse of the previous behaviour, and the reason it changed.
+        // These fixtures describe a converged pair: scored against its own last
+        // daily close it yields ProfitTaken, which is what the retired fallback
+        // returned whenever quotes stopped flowing. But that close can be two
+        // and a half days old on a Monday afternoon, so the signal reported the
+        // symbol going quiet, not the spread moving. With no current price the
+        // pair is now held for the next pass.
         let pair = make_open_pair("AAPL", "MSFT", 2.5, 1.0);
         let mut prices = HashMap::new();
         prices.insert(Ticker::new("AAPL").unwrap(), make_prices(60, 150.0, -1.0));
         prices.insert(Ticker::new("MSFT").unwrap(), make_prices(60, 100.0, 1.0));
 
-        let signals = evaluate_open_pairs(&[pair], &prices, &HashMap::new());
-        assert_eq!(signals.len(), 1);
-        assert_eq!(signals[0].reason, CloseReason::ProfitTaken);
+        // Priced, the same fixtures do signal a close.
+        assert_eq!(
+            evaluate_open_pairs(
+                std::slice::from_ref(&pair),
+                &prices,
+                &priced_at_last_close(&prices)
+            )
+            .len(),
+            1
+        );
+
+        // Unpriced, nothing is signalled and the pair stays open.
+        assert!(evaluate_open_pairs(&[pair], &prices, &HashMap::new()).is_empty());
+    }
+
+    #[test]
+    fn test_one_priced_leg_does_not_score_the_pair() {
+        // Pricing one leg current against the other's stale value measures a
+        // day of drift in one name and reads as a spread move.
+        let pair = make_open_pair("AAPL", "MSFT", 2.5, 1.0);
+        let mut prices = HashMap::new();
+        prices.insert(Ticker::new("AAPL").unwrap(), make_prices(60, 150.0, -1.0));
+        prices.insert(Ticker::new("MSFT").unwrap(), make_prices(60, 100.0, 1.0));
+
+        let mut long_only = HashMap::new();
+        long_only.insert(Ticker::new("AAPL").unwrap(), 91.0);
+        assert!(evaluate_open_pairs(std::slice::from_ref(&pair), &prices, &long_only).is_empty());
+
+        let mut short_only = HashMap::new();
+        short_only.insert(Ticker::new("MSFT").unwrap(), 159.0);
+        assert!(evaluate_open_pairs(&[pair], &prices, &short_only).is_empty());
     }
 
     #[test]
@@ -2359,7 +2453,7 @@ mod tests {
         prices.insert(Ticker::new("AAPL").unwrap(), vec![150.0]);
         prices.insert(Ticker::new("MSFT").unwrap(), vec![100.0]);
 
-        let signals = evaluate_open_pairs(&[pair], &prices, &HashMap::new());
+        let signals = evaluate_open_pairs(&[pair], &prices, &priced_at_last_close(&prices));
         assert!(signals.is_empty());
     }
 
@@ -2375,7 +2469,7 @@ mod tests {
         // Short: only 30 points increasing.
         prices.insert(Ticker::new("MSFT").unwrap(), make_prices(30, 100.0, 1.0));
 
-        let signals = evaluate_open_pairs(&[pair], &prices, &HashMap::new());
+        let signals = evaluate_open_pairs(&[pair], &prices, &priced_at_last_close(&prices));
         // Should still evaluate correctly using the last 30 points.
         assert_eq!(signals.len(), 1);
         assert_eq!(signals[0].reason, CloseReason::ProfitTaken);
@@ -2389,7 +2483,7 @@ mod tests {
         prices.insert(Ticker::new("AAPL").unwrap(), make_prices(60, 150.0, 1.0));
         // No MSFT prices.
 
-        let signals = evaluate_open_pairs(&[pair], &prices, &HashMap::new());
+        let signals = evaluate_open_pairs(&[pair], &prices, &priced_at_last_close(&prices));
         assert!(signals.is_empty());
     }
 
@@ -2408,7 +2502,7 @@ mod tests {
         prices.insert(Ticker::new("AAPL").unwrap(), long_prices);
         prices.insert(Ticker::new("MSFT").unwrap(), short_prices);
 
-        let signals = evaluate_open_pairs(&[pair], &prices, &HashMap::new());
+        let signals = evaluate_open_pairs(&[pair], &prices, &priced_at_last_close(&prices));
         assert_eq!(signals.len(), 1);
         assert_eq!(signals[0].reason, CloseReason::StopLoss);
     }
@@ -2426,7 +2520,7 @@ mod tests {
         prices.insert(Ticker::new("AAPL").unwrap(), make_prices(60, 150.0, 1.0));
         prices.insert(Ticker::new("MSFT").unwrap(), make_prices(60, 100.0, 1.5));
 
-        let signals = evaluate_open_pairs(&[pair], &prices, &HashMap::new());
+        let signals = evaluate_open_pairs(&[pair], &prices, &priced_at_last_close(&prices));
         assert_eq!(signals.len(), 1);
         assert_eq!(signals[0].reason, CloseReason::ProfitTaken);
     }

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -1236,7 +1236,14 @@ fn screen_tradable_candidates(
     for scored in scored_pairs {
         let pair = scored.pair();
         let long_ok = tradable_assets.is_tradable(pair.long_ticker().as_str());
-        let short_ok = tradable_assets.is_shortable(pair.short_ticker().as_str());
+        // The short leg is checked for tradability as well as shortability.
+        // `fetch_tradable_assets` only ever inserts into the shortable set from
+        // inside the tradable branch, so shortable is a subset of tradable and
+        // this rejects nothing today. It is here so that the subset property
+        // has to hold for the screen to pass, rather than being an invariant of
+        // a different function that this one silently depends on.
+        let short_ok = tradable_assets.is_shortable(pair.short_ticker().as_str())
+            && tradable_assets.is_tradable(pair.short_ticker().as_str());
         if long_ok && short_ok {
             kept.push(scored.clone());
         } else {
@@ -1245,7 +1252,7 @@ fn screen_tradable_candidates(
             debug!(
                 pair_id = pair.pair_id().as_str(),
                 long_tradable = long_ok,
-                short_shortable = short_ok,
+                short_eligible = short_ok,
                 "Candidate dropped: leg not tradable on Alpaca"
             );
             rejected += 1;
@@ -1801,6 +1808,24 @@ mod tests {
             assert!(kept
                 .iter()
                 .all(|scored| scored.pair().pair_id().as_str() != "GOOG-META"));
+        }
+
+        #[test]
+        fn test_screen_tradable_requires_short_leg_to_be_tradable_too() {
+            // A symbol marked shortable but not tradable cannot arise from
+            // `fetch_tradable_assets`, which only fills the shortable set from
+            // inside the tradable branch. The screen must not depend on that
+            // invariant holding elsewhere.
+            let candidates = vec![candidate("AAPL", "MSFT")];
+            let universe = TradableAssets::from_sets(
+                ["AAPL".to_string()].into_iter().collect(),
+                ["MSFT".to_string()].into_iter().collect(),
+            );
+
+            let (kept, rejected) = screen_tradable_candidates(&candidates, &universe);
+
+            assert!(kept.is_empty());
+            assert_eq!(rejected, 1);
         }
 
         #[test]

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -264,7 +264,7 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
             legs = open_pairs.len() * 2,
             priced_from_stream = streamed,
             priced_from_snapshot = snapshot_filled,
-            unpriced = unpriced_legs.len() - snapshot_filled,
+            unpriced = unpriced_legs.len().saturating_sub(snapshot_filled),
             "Exit evaluation pricing"
         );
         let close_signals = evaluate_open_pairs(&open_pairs, &historical_prices, &exit_mid_prices);

--- a/src/portfolio/state.rs
+++ b/src/portfolio/state.rs
@@ -235,6 +235,14 @@ impl AppState {
         self.alpaca_client.as_ref()
     }
 
+    /// Returns a shared handle to the Alpaca client.
+    ///
+    /// For tasks that outlive a borrow of the state — the quote stream producer
+    /// reads the market session from its own spawned task.
+    pub fn alpaca_client_handle(&self) -> Arc<dyn Trading> {
+        Arc::clone(&self.alpaca_client)
+    }
+
     /// Returns the confidence floor used to gate signals.
     pub fn confidence_floor(&self) -> ConfidenceFloor {
         self.confidence_floor

--- a/src/portfolio/statistical_arbitrage.rs
+++ b/src/portfolio/statistical_arbitrage.rs
@@ -142,6 +142,17 @@ pub struct ScoredPair {
 }
 
 impl ScoredPair {
+    /// Pairs one candidate with its rank score.
+    ///
+    /// Test-only: production values come from [`score_candidate_pairs`], which
+    /// derives the score from the whole reservoir. Exposing an unrestricted
+    /// constructor would let a caller invent a ranking that never went through
+    /// screening.
+    #[cfg(test)]
+    pub fn new(pair: CandidatePair, rank_score: f64) -> Self {
+        Self { pair, rank_score }
+    }
+
     pub fn pair(&self) -> &CandidatePair {
         &self.pair
     }

--- a/src/stream/alpaca_equities.rs
+++ b/src/stream/alpaca_equities.rs
@@ -17,7 +17,8 @@
 //! at connect time, and the portfolio turns over a handful of times per day, so
 //! a one-second reconnect on change is cheaper than threading an outbound
 //! channel through shared connection infrastructure. The gap is covered by the
-//! consumer's staleness guard, which falls back to the prior close.
+//! exit pricing cascade, which fills unstreamed legs from a REST snapshot and
+//! holds any pair it still cannot price.
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -32,10 +33,11 @@ use tracing::{debug, info, warn};
 
 use crate::common::alpaca::AlpacaCredentials;
 use crate::common::market_hours::{
-    duration_until_quote_stream_window, is_within_quote_stream_window,
+    duration_until_quote_stream_window, is_within_quote_stream_window_at,
 };
 use crate::domain::market::{EquityQuote, Ticker};
 use crate::domain::portfolio::MinimumPairs;
+use crate::portfolio::alpaca::Trading;
 use crate::portfolio::database::{fetch_open_pairs, OpenPair};
 use crate::stream::buffer::MarketDataBuffer;
 use crate::stream::connection::{run_connection, ConnectionConfiguration, MessagePayload};
@@ -59,6 +61,13 @@ const IDLE_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 
 /// How often an active session rechecks the quote-stream window.
 const WINDOW_CHECK_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Pause between dropping one subscription and opening the next.
+///
+/// The plan allows a single concurrent connection and the drop that ends a
+/// session is abrupt rather than a close handshake, so reconnecting immediately
+/// risks Alpaca still counting the old connection as live.
+const RESUBSCRIBE_SETTLE_DELAY: Duration = Duration::from_secs(1);
 
 /// Maximum symbols that may be subscribed on one connection.
 ///
@@ -366,6 +375,68 @@ async fn wait_for_subscription_change(
     }
 }
 
+/// How long the window decision is reused before the clock is re-read.
+///
+/// The session boundaries move only across a session, so re-reading per loop
+/// iteration would spend a request to learn the same close time repeatedly.
+const SESSION_REFRESH_INTERVAL: Duration = Duration::from_secs(600);
+
+/// Whether to stream right now, and how long to wait when the answer is no.
+enum WindowDecision {
+    Open,
+    Closed { wait: Duration },
+}
+
+/// Decides whether the quote-stream window is open, preferring Alpaca's clock.
+///
+/// Falls back to the fixed 09:25–16:05 weekday window when the clock cannot be
+/// reached. This fails *open*, which is the opposite of how the trading paths
+/// treat a clock failure, and deliberately so: the producer submits no orders,
+/// it only reads prices. Refusing to stream on a clock error would silently
+/// degrade every exit decision to snapshot pricing, whereas streaming on a
+/// holiday costs an idle socket.
+async fn decide_window(alpaca: &dyn Trading, now: DateTime<Utc>) -> WindowDecision {
+    match alpaca.fetch_market_session().await {
+        Ok(session) => {
+            if session.trades_on_date_of(now) && session.contains_quote_stream_window(now) {
+                return WindowDecision::Open;
+            }
+            // A holiday, a weekend, or a date whose session has ended all report
+            // a close on a later date, so the wait derives from that session's
+            // open rather than from a local calendar.
+            let wait = session
+                .time_until_quote_stream_window(now)
+                .to_std()
+                .unwrap_or(SESSION_REFRESH_INTERVAL);
+            WindowDecision::Closed {
+                // Bounded so a session whose window has already passed does not
+                // resolve to a zero wait and spin.
+                wait: wait.max(SESSION_REFRESH_INTERVAL).min(MAXIMUM_IDLE_SLEEP),
+            }
+        }
+        Err(error) => {
+            warn!(
+                error = %error,
+                "Market session fetch failed; falling back to the fixed quote stream window"
+            );
+            if is_within_quote_stream_window_at(now) {
+                WindowDecision::Open
+            } else {
+                WindowDecision::Closed {
+                    wait: duration_until_quote_stream_window(now).min(MAXIMUM_IDLE_SLEEP),
+                }
+            }
+        }
+    }
+}
+
+/// Longest the producer sleeps before re-checking the window.
+///
+/// Caps the weekend sleep so a session that becomes tradeable earlier than the
+/// clock reported — an unscheduled open, a corrected holiday calendar — is
+/// picked up within the hour rather than at the originally computed instant.
+const MAXIMUM_IDLE_SLEEP: Duration = Duration::from_secs(3_600);
+
 /// Runs the quote stream producer until shutdown.
 ///
 /// Sleeps outside the quote-stream window, waits for open pairs to exist, then
@@ -373,6 +444,7 @@ async fn wait_for_subscription_change(
 pub async fn run_quote_stream(
     configuration: QuoteStreamConfiguration,
     credentials: AlpacaCredentials,
+    alpaca: Arc<dyn Trading>,
     pool: PgPool,
     buffer: Arc<MarketDataBuffer<EquityQuote>>,
     shutdown_token: CancellationToken,
@@ -384,8 +456,7 @@ pub async fn run_quote_stream(
     );
 
     while !shutdown_token.is_cancelled() {
-        if !is_within_quote_stream_window() {
-            let wait = duration_until_quote_stream_window(Utc::now());
+        if let WindowDecision::Closed { wait } = decide_window(alpaca.as_ref(), Utc::now()).await {
             info!(
                 wait_seconds = wait.as_secs(),
                 "Outside quote stream window; sleeping"
@@ -421,12 +492,27 @@ pub async fn run_quote_stream(
         run_subscription_session(
             &configuration,
             &credentials,
+            alpaca.as_ref(),
             &pool,
             &buffer,
             &symbols,
             &shutdown_token,
         )
         .await;
+
+        // Let the dropped socket close before the next iteration dials again.
+        // The plan permits one concurrent connection, and the drop that ends a
+        // session is an abrupt close rather than a WebSocket close handshake, so
+        // Alpaca can still count the old connection as live and reject the new
+        // one with error 406. Precautionary: the reconnect backoff in
+        // `run_connection` would recover anyway, and the race has not been
+        // observed — there are no production logs from this subsystem yet.
+        if !shutdown_token.is_cancelled() {
+            tokio::select! {
+                _ = sleep(RESUBSCRIBE_SETTLE_DELAY) => {}
+                _ = shutdown_token.cancelled() => break,
+            }
+        }
     }
 
     info!("Quote stream producer stopped");
@@ -438,13 +524,13 @@ pub async fn run_quote_stream(
 /// set does not hold an Alpaca socket open overnight and through the weekend.
 /// Without this the producer's own window gate is only reached between sessions,
 /// which a stable set never triggers.
-async fn wait_for_window_close(shutdown_token: &CancellationToken) {
+async fn wait_for_window_close(alpaca: &dyn Trading, shutdown_token: &CancellationToken) {
     loop {
         tokio::select! {
             _ = sleep(WINDOW_CHECK_INTERVAL) => {}
             _ = shutdown_token.cancelled() => return,
         }
-        if !is_within_quote_stream_window() {
+        if let WindowDecision::Closed { .. } = decide_window(alpaca, Utc::now()).await {
             info!("Quote stream window closed; ending subscription");
             return;
         }
@@ -456,6 +542,7 @@ async fn wait_for_window_close(shutdown_token: &CancellationToken) {
 async fn run_subscription_session(
     configuration: &QuoteStreamConfiguration,
     credentials: &AlpacaCredentials,
+    alpaca: &dyn Trading,
     pool: &PgPool,
     buffer: &Arc<MarketDataBuffer<EquityQuote>>,
     symbols: &BTreeSet<String>,
@@ -500,7 +587,7 @@ async fn run_subscription_session(
             configuration.symbol_limit(),
             shutdown_token,
         ) => {}
-        _ = wait_for_window_close(shutdown_token) => {}
+        _ = wait_for_window_close(alpaca, shutdown_token) => {}
     }
 }
 
@@ -512,6 +599,121 @@ mod tests {
 
     fn minimum_pairs(count: u8) -> MinimumPairs {
         MinimumPairs(NonZeroU8::new(count).expect("count must be non-zero"))
+    }
+
+    // --- Session-derived quote stream window ---
+
+    mod window {
+        use super::*;
+        use crate::portfolio::alpaca::MockTrading;
+
+        fn utc(rfc3339: &str) -> DateTime<Utc> {
+            DateTime::parse_from_rfc3339(rfc3339)
+                .expect("valid timestamp")
+                .with_timezone(&Utc)
+        }
+
+        fn clock(market_open: bool, close: DateTime<Utc>) -> MockTrading {
+            MockTrading {
+                market_open,
+                session_close: close,
+                ..MockTrading::default()
+            }
+        }
+
+        fn is_open(decision: &WindowDecision) -> bool {
+            matches!(decision, WindowDecision::Open)
+        }
+
+        #[tokio::test]
+        async fn test_window_open_inside_the_reported_session() {
+            // 20:00Z close = 16:00 EDT. 14:00Z = 10:00 EDT, mid-session.
+            let alpaca = clock(true, utc("2024-07-15T20:00:00Z"));
+            assert!(is_open(
+                &decide_window(&alpaca, utc("2024-07-15T14:00:00Z")).await
+            ));
+        }
+
+        #[tokio::test]
+        async fn test_window_opens_before_the_bell_and_closes_after() {
+            let alpaca = clock(false, utc("2024-07-15T20:00:00Z"));
+            // 13:26Z = 09:26 EDT, inside the five-minute lead.
+            assert!(is_open(
+                &decide_window(&alpaca, utc("2024-07-15T13:26:00Z")).await
+            ));
+            // 13:24Z = 09:24 EDT, one minute too early.
+            assert!(!is_open(
+                &decide_window(&alpaca, utc("2024-07-15T13:24:00Z")).await
+            ));
+            // 20:03Z = 16:03 EDT, inside the trailing lead.
+            assert!(is_open(
+                &decide_window(&alpaca, utc("2024-07-15T20:03:00Z")).await
+            ));
+            // 20:06Z = 16:06 EDT, past it.
+            assert!(!is_open(
+                &decide_window(&alpaca, utc("2024-07-15T20:06:00Z")).await
+            ));
+        }
+
+        #[tokio::test]
+        async fn test_window_follows_an_early_close() {
+            // 17:00Z = 13:00 EDT, the standard early close. The fixed window
+            // would still report open until 16:05 EDT; this must not.
+            let alpaca = clock(true, utc("2024-07-03T17:00:00Z"));
+            assert!(is_open(
+                &decide_window(&alpaca, utc("2024-07-03T16:50:00Z")).await
+            ));
+            assert!(!is_open(
+                &decide_window(&alpaca, utc("2024-07-03T17:30:00Z")).await
+            ));
+            // The fixed fallback disagrees, which is the whole point of deriving.
+            assert!(is_within_quote_stream_window_at(utc(
+                "2024-07-03T17:30:00Z"
+            )));
+        }
+
+        #[tokio::test]
+        async fn test_window_closed_on_a_holiday() {
+            // Asked at 09:00 ET on Thursday July 4th, Alpaca reports Friday's
+            // close, so no session trades today and the producer must not dial.
+            let alpaca = clock(false, utc("2024-07-05T20:00:00Z"));
+            assert!(!is_open(
+                &decide_window(&alpaca, utc("2024-07-04T13:00:00Z")).await
+            ));
+        }
+
+        #[tokio::test]
+        async fn test_closed_window_never_yields_a_zero_wait() {
+            // A zero wait would spin the producer's loop against the clock
+            // endpoint. Every closed decision must carry a real delay.
+            let alpaca = clock(false, utc("2024-07-05T20:00:00Z"));
+            match decide_window(&alpaca, utc("2024-07-04T13:00:00Z")).await {
+                WindowDecision::Closed { wait } => {
+                    assert!(wait >= SESSION_REFRESH_INTERVAL);
+                    assert!(wait <= MAXIMUM_IDLE_SLEEP);
+                }
+                WindowDecision::Open => panic!("expected a closed window"),
+            }
+        }
+
+        #[tokio::test]
+        async fn test_clock_failure_fails_open_to_the_fixed_window() {
+            // The producer submits no orders, so refusing to stream on a clock
+            // error would silently degrade every exit to snapshot pricing.
+            // Streaming on a holiday only costs an idle socket.
+            let alpaca = MockTrading {
+                should_fail_session_fetch: true,
+                ..MockTrading::default()
+            };
+            // 14:00Z Monday = 10:00 EDT, inside the fixed window.
+            assert!(is_open(
+                &decide_window(&alpaca, utc("2024-07-15T14:00:00Z")).await
+            ));
+            // 02:00Z = 22:00 EDT the previous evening, outside it.
+            assert!(!is_open(
+                &decide_window(&alpaca, utc("2024-07-15T02:00:00Z")).await
+            ));
+        }
     }
 
     // --- SymbolSubscriptionLimit ---

--- a/src/stream/alpaca_equities.rs
+++ b/src/stream/alpaca_equities.rs
@@ -375,10 +375,18 @@ async fn wait_for_subscription_change(
     }
 }
 
-/// How long the window decision is reused before the clock is re-read.
+/// How long to wait before re-reading the clock when the current session has no
+/// remaining window to wait for.
 ///
-/// The session boundaries move only across a session, so re-reading per loop
-/// iteration would spend a request to learn the same close time repeatedly.
+/// Reached only when [`MarketSession::time_until_quote_stream_window`] saturates
+/// at zero, which means the reported session's window has already passed and
+/// Alpaca has not yet rolled its close forward. Waiting a fixed interval and
+/// asking again is the only useful move; without it the loop would spin against
+/// the clock endpoint.
+///
+/// This is a floor for that one case, not a general one. Applying it to every
+/// closed decision inflated a genuine one-minute wait before the open into ten
+/// minutes, so the producer woke well after the session had started.
 const SESSION_REFRESH_INTERVAL: Duration = Duration::from_secs(600);
 
 /// Whether to stream right now, and how long to wait when the answer is no.
@@ -404,14 +412,20 @@ async fn decide_window(alpaca: &dyn Trading, now: DateTime<Utc>) -> WindowDecisi
             // A holiday, a weekend, or a date whose session has ended all report
             // a close on a later date, so the wait derives from that session's
             // open rather than from a local calendar.
-            let wait = session
+            let remaining = session
                 .time_until_quote_stream_window(now)
                 .to_std()
-                .unwrap_or(SESSION_REFRESH_INTERVAL);
+                .unwrap_or_default();
             WindowDecision::Closed {
-                // Bounded so a session whose window has already passed does not
-                // resolve to a zero wait and spin.
-                wait: wait.max(SESSION_REFRESH_INTERVAL).min(MAXIMUM_IDLE_SLEEP),
+                // The floor applies only to the saturated-at-zero case. Applying
+                // it to a real remaining duration would round a one-minute wait
+                // before the open up to ten, so the lead time would never take
+                // effect and the session would start unstreamed.
+                wait: if remaining.is_zero() {
+                    SESSION_REFRESH_INTERVAL
+                } else {
+                    remaining.min(MAXIMUM_IDLE_SLEEP)
+                },
             }
         }
         Err(error) => {
@@ -456,16 +470,19 @@ pub async fn run_quote_stream(
     );
 
     while !shutdown_token.is_cancelled() {
-        if let WindowDecision::Closed { wait } = decide_window(alpaca.as_ref(), Utc::now()).await {
-            info!(
-                wait_seconds = wait.as_secs(),
-                "Outside quote stream window; sleeping"
-            );
-            tokio::select! {
-                _ = sleep(wait) => {}
-                _ = shutdown_token.cancelled() => break,
+        match decide_window(alpaca.as_ref(), Utc::now()).await {
+            WindowDecision::Closed { wait } => {
+                info!(
+                    wait_seconds = wait.as_secs(),
+                    "Outside quote stream window; sleeping"
+                );
+                tokio::select! {
+                    _ = sleep(wait) => {}
+                    _ = shutdown_token.cancelled() => break,
+                }
+                continue;
             }
-            continue;
+            WindowDecision::Open => {}
         }
 
         let symbols = match desired_symbols(&pool, configuration.symbol_limit()).await {
@@ -530,9 +547,12 @@ async fn wait_for_window_close(alpaca: &dyn Trading, shutdown_token: &Cancellati
             _ = sleep(WINDOW_CHECK_INTERVAL) => {}
             _ = shutdown_token.cancelled() => return,
         }
-        if let WindowDecision::Closed { .. } = decide_window(alpaca, Utc::now()).await {
-            info!("Quote stream window closed; ending subscription");
-            return;
+        match decide_window(alpaca, Utc::now()).await {
+            WindowDecision::Closed { .. } => {
+                info!("Quote stream window closed; ending subscription");
+                return;
+            }
+            WindowDecision::Open => {}
         }
     }
 }
@@ -682,18 +702,49 @@ mod tests {
             ));
         }
 
+        fn closed_wait(decision: WindowDecision) -> Duration {
+            match decision {
+                WindowDecision::Closed { wait } => wait,
+                WindowDecision::Open => panic!("expected a closed window"),
+            }
+        }
+
         #[tokio::test]
         async fn test_closed_window_never_yields_a_zero_wait() {
             // A zero wait would spin the producer's loop against the clock
             // endpoint. Every closed decision must carry a real delay.
             let alpaca = clock(false, utc("2024-07-05T20:00:00Z"));
-            match decide_window(&alpaca, utc("2024-07-04T13:00:00Z")).await {
-                WindowDecision::Closed { wait } => {
-                    assert!(wait >= SESSION_REFRESH_INTERVAL);
-                    assert!(wait <= MAXIMUM_IDLE_SLEEP);
-                }
-                WindowDecision::Open => panic!("expected a closed window"),
-            }
+            let wait = closed_wait(decide_window(&alpaca, utc("2024-07-04T13:00:00Z")).await);
+            assert!(!wait.is_zero());
+            assert!(wait <= MAXIMUM_IDLE_SLEEP);
+        }
+
+        #[tokio::test]
+        async fn test_wait_before_the_open_is_the_true_remaining_time() {
+            // The regression this guards: a blanket floor rounded every closed
+            // wait up to the refresh interval, so a check shortly before the
+            // window opened slept straight through it and the session started
+            // with no streamed quotes.
+            let alpaca = clock(false, utc("2024-07-15T20:00:00Z"));
+
+            // 13:24Z = 09:24 EDT, one minute before the 09:25 window opens.
+            let wait = closed_wait(decide_window(&alpaca, utc("2024-07-15T13:24:00Z")).await);
+            assert_eq!(wait, Duration::from_secs(60));
+            assert!(wait < SESSION_REFRESH_INTERVAL);
+
+            // 13:20Z = 09:20 EDT, five minutes out.
+            let wait = closed_wait(decide_window(&alpaca, utc("2024-07-15T13:20:00Z")).await);
+            assert_eq!(wait, Duration::from_secs(300));
+        }
+
+        #[tokio::test]
+        async fn test_long_wait_is_capped_for_re_checking() {
+            // A holiday reports the next trading day's session, which is many
+            // hours out. The cap keeps a corrected calendar from going unseen
+            // until the originally computed instant.
+            let alpaca = clock(false, utc("2024-07-05T20:00:00Z"));
+            let wait = closed_wait(decide_window(&alpaca, utc("2024-07-04T13:00:00Z")).await);
+            assert_eq!(wait, MAXIMUM_IDLE_SLEEP);
         }
 
         #[tokio::test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -126,8 +126,8 @@ pub async fn setup_test_bucket() -> (String, S3Client) {
     // Tolerates AlreadyExists / BucketAlreadyOwnedByYou across repeated runs.
     let _ = s3_client.create_bucket().bucket(TEST_BUCKET).send().await;
 
-    // MinIO persists between runs, unlike the container that was recreated each
-    // time, so emptying the bucket is now load-bearing rather than tidiness.
+    // The store persists between runs, unlike the container that was recreated
+    // each time, so emptying the bucket is load-bearing rather than tidiness.
     clean_bucket(&s3_client).await;
 
     (endpoint, s3_client)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,23 +4,34 @@ use aws_credential_types::Credentials;
 use aws_sdk_s3::{config::Region, primitives::ByteStream, Client as S3Client};
 use chrono::{DateTime, Duration, Utc};
 use sqlx::PgPool;
-use std::{sync::OnceLock, time::Duration as StdDuration};
-use testcontainers::{runners::AsyncRunner, ContainerAsync};
-use testcontainers_modules::localstack::LocalStack;
 use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
-// S3 / LocalStack
+// S3 (devenv-managed SeaweedFS)
 // ---------------------------------------------------------------------------
 
 const TEST_BUCKET: &str = "test-bucket";
-const TEST_ACCESS_KEY: &str = "test";
-const TEST_SECRET_KEY: &str = "test";
 const TEST_REGION: &str = "us-east-1";
 
-static LOCALSTACK_ENDPOINT: OnceLock<String> = OnceLock::new();
-static LOCALSTACK_CONTAINER: OnceLock<&'static ContainerAsync<LocalStack>> = OnceLock::new();
 static TRACING_INIT: std::sync::Once = std::sync::Once::new();
+
+/// Returns the S3-compatible endpoint, defaulting to the devenv object store.
+///
+/// The suite previously started a LocalStack container through testcontainers,
+/// which required a Docker daemon that neither the devenv shell nor CI has. It
+/// never needed Docker as such — only an HTTP endpoint speaking S3 — so it now
+/// points at a SeaweedFS process devenv runs directly.
+fn s3_endpoint() -> String {
+    std::env::var("TEST_S3_ENDPOINT").unwrap_or_else(|_| "http://127.0.0.1:8333".to_string())
+}
+
+fn s3_access_key() -> String {
+    std::env::var("TEST_S3_ACCESS_KEY").unwrap_or_else(|_| "fundtest".to_string())
+}
+
+fn s3_secret_key() -> String {
+    std::env::var("TEST_S3_SECRET_KEY").unwrap_or_else(|_| "fundtestsecret".to_string())
+}
 
 pub struct EnvironmentVariableGuard {
     name: String,
@@ -75,57 +86,8 @@ pub fn initialize_test_tracing() {
     });
 }
 
-pub async fn get_localstack_endpoint() -> String {
-    if let Some(endpoint) = LOCALSTACK_ENDPOINT.get() {
-        return endpoint.clone();
-    }
-
-    let container = LocalStack::default()
-        .start()
-        .await
-        .expect("Failed to start LocalStack container — is Docker running?");
-
-    // Give LocalStack additional time to fully initialize services
-    tokio::time::sleep(StdDuration::from_secs(5)).await;
-
-    let host = container.get_host().await.unwrap();
-    let port = {
-        let mut attempts = 0u32;
-        loop {
-            match container.get_host_port_ipv4(4566).await {
-                Ok(port) => break port,
-                Err(_) if attempts < 10 => {
-                    attempts += 1;
-                    tokio::time::sleep(StdDuration::from_millis(500)).await;
-                }
-                Err(error) => panic!(
-                    "LocalStack port 4566 not available after retries: {}",
-                    error
-                ),
-            }
-        }
-    };
-    let endpoint = format!("http://{}:{}", host, port);
-
-    // INTENTIONAL LEAK: Container is leaked to keep it alive for entire test run.
-    //
-    // Rationale:
-    // - Tests use #[serial] for sequential execution within this process
-    // - All tests share the same LocalStack container for performance
-    // - Container cleanup happens automatically when process exits
-    // - Storing container reference prevents testcontainers from losing port mapping
-    //
-    // Trade-off: Small memory leak during test execution vs architectural complexity
-    // Impact: Container memory is reclaimed when test process terminates
-    let leaked_container: &'static ContainerAsync<LocalStack> = Box::leak(Box::new(container));
-    let _ = LOCALSTACK_CONTAINER.set(leaked_container);
-    let _ = LOCALSTACK_ENDPOINT.set(endpoint.clone());
-
-    endpoint
-}
-
 pub async fn create_test_s3_client(endpoint_url: &str) -> S3Client {
-    let credentials = Credentials::new(TEST_ACCESS_KEY, TEST_SECRET_KEY, None, None, "tests");
+    let credentials = Credentials::new(s3_access_key(), s3_secret_key(), None, None, "tests");
 
     let shared_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
         .region(Region::new(TEST_REGION))
@@ -141,17 +103,31 @@ pub async fn create_test_s3_client(endpoint_url: &str) -> S3Client {
     S3Client::from_conf(s3_config)
 }
 
-/// Start LocalStack, create the test bucket, clean it, and return the endpoint URL
-/// and a ready-to-use S3 client.
+/// Creates the test bucket, empties it, and returns the endpoint and a client.
+///
+/// Reachability is asserted explicitly. `create_bucket` tolerates an
+/// already-exists error and `clean_bucket` swallows listing failures, so an
+/// absent object store would otherwise surface much later as a confusing
+/// assertion failure rather than as "the service is not running".
 pub async fn setup_test_bucket() -> (String, S3Client) {
     initialize_test_tracing();
 
-    let endpoint = get_localstack_endpoint().await;
+    let endpoint = s3_endpoint();
     let s3_client = create_test_s3_client(&endpoint).await;
 
-    // Create bucket (ignore AlreadyExists / BucketAlreadyOwnedByYou)
+    match s3_client.list_buckets().send().await {
+        Ok(_) => {}
+        Err(error) => panic!(
+            "S3-compatible endpoint at {endpoint} is unreachable: {error}\n\
+             Start it with `devenv --profile test up object-store --detach`."
+        ),
+    }
+
+    // Tolerates AlreadyExists / BucketAlreadyOwnedByYou across repeated runs.
     let _ = s3_client.create_bucket().bucket(TEST_BUCKET).send().await;
 
+    // MinIO persists between runs, unlike the container that was recreated each
+    // time, so emptying the bucket is now load-bearing rather than tidiness.
     clean_bucket(&s3_client).await;
 
     (endpoint, s3_client)
@@ -207,7 +183,7 @@ pub fn test_bucket_name() -> String {
 }
 
 // ---------------------------------------------------------------------------
-// PostgreSQL (testcontainers)
+// PostgreSQL (devenv-managed)
 // ---------------------------------------------------------------------------
 
 const SCHEMA_SQL: &str = include_str!("../../schema.sql");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,7 +7,6 @@ use sqlx::PgPool;
 use std::{sync::OnceLock, time::Duration as StdDuration};
 use testcontainers::{runners::AsyncRunner, ContainerAsync};
 use testcontainers_modules::localstack::LocalStack;
-use testcontainers_modules::postgres::Postgres;
 use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
@@ -213,79 +212,134 @@ pub fn test_bucket_name() -> String {
 
 const SCHEMA_SQL: &str = include_str!("../../schema.sql");
 
-static PG_POOL: tokio::sync::OnceCell<PgPool> = tokio::sync::OnceCell::const_new();
-static PG_CONTAINER: OnceLock<&'static ContainerAsync<Postgres>> = OnceLock::new();
+/// Database the integration tests own outright.
+///
+/// Deliberately not the development database: these tests truncate tables, and
+/// pointing them at `fund` would destroy local data on every run.
+const TEST_DATABASE: &str = "fund_test";
 
-/// Strips lines that require pg_cron or TimescaleDB (unavailable in vanilla Postgres).
+/// Marks that the test database exists and carries the schema.
+///
+/// Stores `()` rather than the pool on purpose. A `PgPool` is bound to the
+/// tokio runtime that created it, and every `#[tokio::test]` builds its own
+/// runtime; caching a pool here meant the second test to run inherited a handle
+/// whose background reaper had already died with the first test's runtime, and
+/// every acquire from it failed with `PoolTimedOut`. Caching only the setup
+/// keeps the expensive work once-per-binary while leaving each test to own a
+/// pool tied to its own runtime.
+static SCHEMA_READY: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+
+/// Connections per test pool.
+///
+/// Small because each test builds its own pool and the server allows 100 in
+/// total; the tests are `#[serial]` and none needs concurrency within a pool.
+const TEST_POOL_MAX_CONNECTIONS: u32 = 4;
+
+/// Returns the base connection URL, minus the database name.
+///
+/// Honours `TEST_DATABASE_URL_BASE` so CI can point at a different host without
+/// editing this file; defaults to the devenv-managed local Postgres.
+fn database_url_base() -> String {
+    std::env::var("TEST_DATABASE_URL_BASE")
+        .unwrap_or_else(|_| "postgresql://localhost:5432".to_string())
+}
+
+/// Strips the parts of `schema.sql` that cannot be applied to a second database.
+///
+/// Only pg_cron is removed, and not because it is unavailable in general: the
+/// extension is restricted by `cron.database_name` to a single database, so
+/// `CREATE EXTENSION` fails anywhere else. That covers the extension itself, the
+/// `DO` blocks that schedule jobs, and `cron.schedule_in_timezone`.
+///
+/// TimescaleDB is deliberately *not* stripped. It was, back when these tests ran
+/// against a vanilla Postgres container, which meant every assertion ran against
+/// a schema with no hypertables and no retention policies — measurably not the
+/// schema being shipped. The devenv Postgres carries the extension, so the real
+/// one applies.
 fn filter_schema_for_test(schema: &str) -> String {
-    let mut inside_cron_block = false;
+    let mut inside_do_block = false;
+    let mut inside_cron_function = false;
     schema
         .lines()
         .filter(|line| {
             let trimmed = line.trim().to_lowercase();
+
             if trimmed.starts_with("do $do$") {
-                inside_cron_block = true;
+                inside_do_block = true;
             }
-            if inside_cron_block {
+            if inside_do_block {
                 if trimmed.starts_with("$do$;") {
-                    inside_cron_block = false;
+                    inside_do_block = false;
                 }
                 return false;
             }
+
+            if trimmed.starts_with("create or replace function cron.") {
+                inside_cron_function = true;
+            }
+            if inside_cron_function {
+                if trimmed == "$$;" {
+                    inside_cron_function = false;
+                }
+                return false;
+            }
+
             !trimmed.starts_with("create extension if not exists pg_cron")
-                && !trimmed.starts_with("create extension if not exists timescaledb")
                 && !trimmed.starts_with("select cron.schedule")
-                && !trimmed.starts_with("select create_hypertable")
-                && !trimmed.starts_with("select add_retention_policy")
-                && !trimmed.starts_with("select remove_retention_policy")
         })
         .collect::<Vec<_>>()
         .join("\n")
 }
 
-/// Returns a connection pool to a shared testcontainers Postgres instance.
+/// Returns a connection pool to the shared test database.
 ///
-/// The first call starts the container, applies the filtered schema, and leaks
-/// the container handle so it lives for the entire test-binary process. Subsequent
-/// calls return a clone of the same pool, avoiding redundant connections.
+/// Creates the database if absent and applies the schema on first use, then
+/// hands back clones of the same pool. Uses the devenv-managed Postgres rather
+/// than a container, so the suite needs no Docker daemon and runs against a
+/// server carrying the same extensions as production.
 pub async fn get_pg_pool() -> PgPool {
-    PG_POOL
+    let base = database_url_base();
+
+    SCHEMA_READY
         .get_or_init(|| async {
-            let container = Postgres::default()
-                .start()
+            // Connect to the maintenance database to create the test one. This
+            // cannot run through a pool aimed at a database that may not exist.
+            let admin = PgPool::connect(&format!("{base}/postgres"))
                 .await
-                .expect("Failed to start PostgreSQL container — is Docker running?");
+                .expect("Failed to connect to Postgres — is `devenv up` running?");
 
-            let host = container.get_host().await.unwrap();
-            let port = container.get_host_port_ipv4(5432).await.unwrap();
-            let url = format!("postgresql://postgres:postgres@{}:{}/postgres", host, port);
+            let exists: Option<i32> =
+                sqlx::query_scalar("SELECT 1 FROM pg_database WHERE datname = $1")
+                    .bind(TEST_DATABASE)
+                    .fetch_optional(&admin)
+                    .await
+                    .expect("Failed to query for the test database");
+            if exists.is_none() {
+                // CREATE DATABASE cannot be parameterised or run in a
+                // transaction, and TEST_DATABASE is a compile-time constant.
+                sqlx::raw_sql(&format!("CREATE DATABASE {TEST_DATABASE}"))
+                    .execute(&admin)
+                    .await
+                    .expect("Failed to create the test database");
+            }
+            admin.close().await;
 
-            let connect_deadline = tokio::time::Instant::now() + StdDuration::from_secs(30);
-            let pool = loop {
-                match PgPool::connect(&url).await {
-                    Ok(pool) => break pool,
-                    Err(error) => {
-                        if tokio::time::Instant::now() >= connect_deadline {
-                            panic!("Failed to connect to PostgreSQL within timeout: {error}");
-                        }
-                        tokio::time::sleep(StdDuration::from_millis(250)).await;
-                    }
-                }
-            };
-
-            let filtered_schema = filter_schema_for_test(SCHEMA_SQL);
-            sqlx::raw_sql(&filtered_schema)
-                .execute(&pool)
+            let setup = PgPool::connect(&format!("{base}/{TEST_DATABASE}"))
                 .await
-                .unwrap();
-
-            let leaked: &'static ContainerAsync<Postgres> = Box::leak(Box::new(container));
-            let _ = PG_CONTAINER.set(leaked);
-
-            pool
+                .expect("Failed to connect to the test database");
+            sqlx::raw_sql(&filter_schema_for_test(SCHEMA_SQL))
+                .execute(&setup)
+                .await
+                .expect("Failed to apply schema.sql to the test database");
+            setup.close().await;
         })
+        .await;
+
+    sqlx::postgres::PgPoolOptions::new()
+        .max_connections(TEST_POOL_MAX_CONNECTIONS)
+        .connect(&format!("{base}/{TEST_DATABASE}"))
         .await
-        .clone()
+        .expect("Failed to connect to the test database")
 }
 
 /// Truncates all portfolio-related tables in dependency order.

--- a/tests/test_backfill.rs
+++ b/tests/test_backfill.rs
@@ -1,12 +1,9 @@
 //! S3 backfill integration test.
 //!
-//! NOT in the default `checks:rust:test` target list. It reaches S3 through
-//! LocalStack via testcontainers, so it needs a Docker daemon, which neither the
-//! devenv shell nor CI provides. Run it explicitly with
-//! `cargo test --test test_backfill --all-features` on a machine with Docker.
-//!
-//! Migrating this to a devenv-managed MinIO service would let it join the
-//! default run and retire the last testcontainers dependency.
+//! Runs against the devenv-managed SeaweedFS process, which serves an
+//! S3-compatible API. Start it with
+//! `devenv --profile test up object-store --detach`; `TEST_S3_ENDPOINT`
+//! overrides the address if it is running elsewhere.
 
 mod common;
 
@@ -57,8 +54,9 @@ async fn create_state(massive_base: String, s3_endpoint: &str) -> State {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[serial]
 async fn test_seed_start_after_end_returns_error() {
-    let (endpoint, _s3) = setup_test_bucket().await;
-    let state = create_state("http://127.0.0.1:1".to_string(), &endpoint).await;
+    // No bucket setup: the date range is rejected before any S3 call, so this
+    // test needs no object store at all. It used to start one regardless.
+    let state = create_state("http://127.0.0.1:1".to_string(), "http://127.0.0.1:1").await;
 
     let result = seed(
         &state,

--- a/tests/test_backfill.rs
+++ b/tests/test_backfill.rs
@@ -1,3 +1,13 @@
+//! S3 backfill integration test.
+//!
+//! NOT in the default `checks:rust:test` target list. It reaches S3 through
+//! LocalStack via testcontainers, so it needs a Docker daemon, which neither the
+//! devenv shell nor CI provides. Run it explicitly with
+//! `cargo test --test test_backfill --all-features` on a machine with Docker.
+//!
+//! Migrating this to a devenv-managed MinIO service would let it join the
+//! default run and retire the last testcontainers dependency.
+
 mod common;
 
 use chrono::NaiveDate;

--- a/tests/test_data.rs
+++ b/tests/test_data.rs
@@ -169,7 +169,11 @@ fn test_equity_bar_dataframe_parquet_roundtrip() {
     let cursor = Cursor::new(buffer);
     let deserialized_df = ParquetReader::new(cursor).finish().unwrap();
 
-    assert_eq!(deserialized_df.width(), 10);
+    // Nine columns, not ten: `inserted_at` is deliberately excluded so the S3
+    // parquet matches the equity_bars_schema pandera contract. Including it
+    // made backfilled files ten wide and broke the tide reader's per-day
+    // concat. This assertion still said ten because the file was never run.
+    assert_eq!(deserialized_df.width(), 9);
     assert_eq!(deserialized_df.height(), 1);
 
     assert!(deserialized_df.column("ticker").is_ok());
@@ -205,6 +209,6 @@ fn test_parquet_empty_dataframe_roundtrip() {
     let cursor = Cursor::new(buffer);
     let deserialized_df = ParquetReader::new(cursor).finish().unwrap();
 
-    assert_eq!(deserialized_df.width(), 10);
+    assert_eq!(deserialized_df.width(), 9);
     assert_eq!(deserialized_df.height(), 0);
 }

--- a/tests/test_ensemble_events.rs
+++ b/tests/test_ensemble_events.rs
@@ -1,6 +1,9 @@
 //! Integration tests for the ensemble service's event-system SQL: consumer
 //! offsets, event catch-up lookup, model_runs lineage upsert, and prediction
-//! inserts — run against a real Postgres via testcontainers.
+//! inserts.
+//!
+//! Run against the devenv-managed Postgres, which persists between runs. Tests
+//! must therefore be idempotent rather than assuming empty tables.
 
 mod common;
 
@@ -15,7 +18,12 @@ use uuid::Uuid;
 #[serial]
 async fn test_consumer_offset_round_trip() {
     let pool = common::get_pg_pool().await;
-    let consumer = "ensemble-offset-test";
+    // Unique per run. The test database persists between runs now that it is
+    // the devenv Postgres rather than a fresh container, so a fixed consumer
+    // name carried its offset forward and the "starts at zero" assertion only
+    // held the first time.
+    let consumer = format!("ensemble-offset-test-{}", Uuid::new_v4());
+    let consumer = consumer.as_str();
 
     assert_eq!(get_consumer_offset(&pool, consumer).await.unwrap(), 0);
 
@@ -127,8 +135,11 @@ async fn test_upsert_model_run_inserts_then_updates() {
 async fn test_insert_predictions_writes_rows() {
     let pool = common::get_pg_pool().await;
 
+    // Five characters: `Ticker` allows a 1-5 letter base, so the former
+    // eight-character "PREDTEST" fixture was rejected by the decoder. The file
+    // was never executed, so the invalid fixture went unnoticed.
     let predictions = vec![serde_json::json!({
-        "ticker": "PREDTEST",
+        "ticker": "PREDT",
         "timestamp": 1_735_689_600_000_i64,
         "quantile_10": -0.01,
         "quantile_50": 0.0,
@@ -141,7 +152,7 @@ async fn test_insert_predictions_writes_rows() {
     assert_eq!(rows, 1);
 
     let count: i64 =
-        sqlx::query_scalar("SELECT count(*) FROM equity_predictions WHERE ticker = 'PREDTEST'")
+        sqlx::query_scalar("SELECT count(*) FROM equity_predictions WHERE ticker = 'PREDT'")
             .fetch_one(&pool)
             .await
             .unwrap();


### PR DESCRIPTION
# Overview

Reworks how positions are priced and when the portfolio acts on them, and enables the integration test suite.

A live probe of the Alpaca free tier (44 symbols, volume-stratified, taken mid-session) measured what the data actually looks like. Three findings drove the work: quote freshness is good enough to rely on, book width is a larger hazard than staleness, and the snapshot endpoint has no symbol ceiling. The probe was read-only and touched clock and market-data endpoints only.

## Changes

**Quote validation**

- Add `BookQualityLimits` and `UsableQuote` to the market domain. The streamed and REST paths previously validated quotes differently — one rejected crossed books, the other only checked that bid and ask were positive — so the same quote could be usable or not depending on which reached it first. Both now construct through one type.
- Gate on relative spread (25 bps) and quoted size (one round lot) alongside the existing sign, finiteness, and crossed-book rules. The spread bound comes from round-trip cost: a pair crosses both legs entering and exiting, so 25 bps a leg is roughly 50 bps a round turn.
- Deserialize `t`, `bs`, and `as` from the snapshot response and return the raw book from `fetch_latest_quotes`. The timestamp and sizes were being discarded, leaving no way to tell a quote posted a second ago from one posted at the open.
- Store `UsableQuote` in `LivePriceCache` so the spread survives into the cache; it cannot be recovered from a midpoint.
- Read `status` from the assets endpoint and require `active`.
- Chunk snapshot requests at 1,000 symbols. Measured accepting 2,000 in a 9,424-character URL, so the cap bounds request-line length rather than the API.

**Entry path**

- Screen candidates on tradability and quote quality *before* the convergence loop. Both were previously discovered after the joint sizing optimization, so the work was wasted and losing enough pairs aborted the pass.
- Remove the close-price fallback from entry pricing. A symbol rejected for a 3,000 bps book was still sized off its prior close and could still be entered.
- Collapse the loop's per-iteration fetching into one batched call.

**Exit path**

- Replace the daily-close fallback with a three-tier cascade: streamed mid, then REST snapshot for legs the stream did not cover, then keep-and-recheck.
- `z_score_against` becomes the sole estimator on the exit path. `z_score_last` remains in use for entry z-scores in `statistical_arbitrage`.

**Session lifecycle**

- Add `trading_session_started`, emitted by pg_cron at 09:25 Eastern, and unschedule the five-minute evaluation heartbeat.
- Replace close detection with a one-shot timer armed at session start from Alpaca's reported close. Armed before the rebalance, so a pass that hangs cannot leave the session unable to close.
- `request_liquidation_if_close_is_near` becomes the pure predicate `close_is_near`; the timer owns the emit and the 15:45 pg_cron job backs it up.
- Derive the quote-stream window from `MarketSession` rather than a fixed 09:25-16:05, adding `MarketSession::open`, `contains_quote_stream_window`, and `time_until_quote_stream_window`.
- Add a one-second settle delay between dropping a subscription and dialling the next.

**Test infrastructure**

- Run the integration suite. Target selection was `--lib --bins`, which excluded every file under `tests/` — roughly 1,300 lines that compiled under clippy but whose assertions had never been evaluated, since the Rust port in 7e7a4853.
- Replace testcontainers with the devenv-managed PostgreSQL and a SeaweedFS `object-store` process. Drop both testcontainers dev-dependencies.
- Add `ensure-test-services`, run by `test-rust`.
- Make the sqlx cache check fail rather than exit 0 when no database is reachable, and order it ahead of `check-rust`.
- CI starts postgres and object-store and waits on both.

## Context

**What the probe measured.** Quotes stay fresh even on thin names — median under 100 seconds in the lowest volume decile — while last trades in deciles 7 through 10 were 3 to 14 days old. That inverted an earlier plan to move to bars: bars are basis-consistent with the daily-close baseline but do not exist for the symbols that trigger the fallback. Book width is the real problem: liquid names quote 1-15 bps, but thin ones ran 500-3,700 bps, and the midpoint of a 3,000 bps book sat over 1,000 bps from the last traded price. Those midpoints were being accepted as prices.

**The exit fallback was worse than it looked.** Daily bars sync at 05:00 UTC, so intraday the newest close is the *previous* trading day's — up to 65 hours stale on a Monday afternoon. The resulting z-score is constant for the session, so a pair whose quotes went quiet was closed at the first pass on that constant value. The signal reported the symbol going silent, not the spread moving. The two branches also used different estimators, so the same pair could be scored on different scales minutes apart depending only on whether quotes happened to be flowing.

**Production evidence for the entry reordering.** The last lines written before the service stopped on 2026-07-15:

```
"Candidate pairs selected","candidates":10,"required":10
ERROR "Pair sizing failed: Only 4 viable pairs available, need at least 10."
```

Ten candidates selected and sized; six dropped for tradability afterwards, leaving too few to meet the target, and no positions opened.

**Three defects the dead tests were hiding.** `test_data` asserted a nine-column parquet frame was ten columns wide — still encoding the bug that removing `inserted_at` fixed, while the same file asserted `inserted_at` was absent. `test_ensemble_events` used an eight-character ticker against a five-character limit. `tests/common` cached a `PgPool` in a static, but a pool is bound to the runtime that created it and every `#[tokio::test]` builds its own, so every acquire after the first test failed with `PoolTimedOut`. The old harness also stripped TimescaleDB because the vanilla container lacked it, meaning every assertion ran against a schema with no hypertables; the test database now has all three.

**Why SeaweedFS.** MinIO was the obvious choice and is marked insecure in this nixpkgs, with two of five advisories being unauthenticated object-write bypasses. Using it would have required adding it to `permittedInsecurePackages`. Garage is unflagged but needs a config file and a layout initialised before it serves. `weed server -s3` needs neither.

**Deliberately not addressed.** There is no liquidity filter to add: `inference/pipeline.rs` already restricts predictions to tickers averaging above $10 and 1M shares, which puts every candidate above roughly $11M daily dollar volume. An earlier plan to add a dollar-volume floor would have been a no-op. Tightening the universe means changing `MINIMUM_CLOSE_PRICE` / `MINIMUM_VOLUME`, which requires retraining, since the model must train on the population it serves.

**Measurement caveats.** The probe is one 44-symbol sample at one instant, and its deciles were ranked by share volume, which is a noisy liquidity proxy. The 25 bps spread bound and the 5-minute REST staleness window are therefore starting points, not tuned values. `MINIMUM_QUOTE_SIZE` at one round lot is the weakest of the three: observed quotes were commonly sized at exactly 100, so it barely filters, and raising it should follow a study of the size distribution rather than intuition. All three are single constants. Rejection counters are logged by cause at every gate — `Entry candidates screened`, `Snapshot quote pricing`, `Exit evaluation pricing` — so the first live session will show whether they cut too deep. There is no production history for any of this.

**Verification.** 1,229 library tests and 35 integration tests pass, the latter twice in succession to confirm idempotency against services that persist between runs. Coverage 80.3%, up from 79.3% against a 75% threshold. `cargo machete` reports no unused dependencies. Applying `schema.sql` to a local database was verified to unschedule `portfolio-evaluation-requested` and schedule `trading-session-started`; no `query!` macros changed, so the offline cache is unaffected.

**Not deployed.** The production VM has been down since 2026-07-15 — a `devenv up` supervisor spinning at 105% CPU with zero child processes and no logs for 13 days. That is unrelated to this branch and unresolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trading-session start events to coordinate daily portfolio activity.
  * Improved quote-stream scheduling using actual market hours, holidays, and early closes.
  * Added validation for quote spreads, sizes, timestamps, and freshness.
  * Enhanced portfolio rebalancing with validated live and REST market prices.

* **Bug Fixes**
  * Prevented inactive assets, stale quotes, invalid order books, and out-of-order updates from affecting decisions.
  * Improved liquidation timing by arming a session-based, one-time close timer.

* **Chores**
  * Improved integration test service setup and readiness checks for more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->