### PR TITLE
Speed up continuous integration caching

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -30,12 +30,14 @@ jobs:
       - name: Free disk space
         run: |
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+      # Deliberately no Nix binary cache action here. devenv pins nixpkgs to
+      # `cachix/devenv-nixpkgs/rolling` and configures `devenv.cachix.org` as a
+      # substituter, so that cache and `cache.nixos.org` already serve the whole
+      # shell closure. Caching Nix into the GitHub Actions cache on top of that
+      # uploaded every substituted path one at a time, costing many minutes in
+      # the post-job step while duplicating what the two public caches provide.
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-      - name: Configure Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
-        with:
-          use-flakehub: false
       - name: Install devenv
         run: nix profile install nixpkgs#devenv
       - name: Cache Rust dependencies

--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -3,6 +3,10 @@ name: Continuous integration
 run-name: Continuous integration
 on:
   pull_request:
+  # Only run on master pushes to provide a base-branch cache for pull requests.
+  push:
+    branches:
+      - master
 permissions:
   contents: read
   pull-requests: read
@@ -51,9 +55,7 @@ jobs:
           restore-keys: |
             llvm-cov-${{ runner.os }}-
       - name: Run base checks
-        run: >-
-          devenv --secretspec-provider env --secretspec-profile development
-          tasks run checks:base
+        run: devenv --secretspec-provider env --secretspec-profile development tasks run checks:base
       # The integration test targets need a database and an S3-compatible
       # object store. Only those two are started, not the fund services: those
       # would connect to Alpaca and are not what is under test here.
@@ -92,6 +94,4 @@ jobs:
         env:
           SQLX_OFFLINE: "true"
           CARGO_INCREMENTAL: "0"
-        run: >-
-          devenv --secretspec-provider env --secretspec-profile development
-          tasks run checks:rust
+        run: devenv --secretspec-provider env --secretspec-profile development tasks run checks:rust


### PR DESCRIPTION
# Overview

Two independent changes to `.github/workflows/continuous_integration.yaml` that together remove roughly 9-11 minutes from a typical run and 667s from every pull request's first run. Split into two commits so the Nix change can be reverted on its own.

## Changes

- Add a `push` trigger on master. GitHub scopes cache entries to the ref that wrote them, and pull request runs write to `refs/pull/N/merge`, which nothing else can read. Master never ran this workflow, so no base-branch cache existed for pull requests to restore from. The cache API confirmed it: the only ref with any entries was `refs/pull/1031/merge`.
- Remove the `Configure Nix cache` step. `Post Configure Nix cache` was the slowest part of a run at 527-672s, uploading store paths one at a time at a flat 1.8s each (368 paths in 671s). The bottleneck is per-path round trips to the cache API, not bandwidth.
- Reformat `Run base checks` and `Run Rust checks` from folded scalars to single-line commands. Both are 100 characters, under the repository's 120-character yamllint limit. `Start test services` is deliberately left as a folded scalar: as a single line it would be 127 characters and trip that limit.

## Context

**Why the Nix uploads were redundant.** `devenv.yaml` pins nixpkgs to `cachix/devenv-nixpkgs/rolling`, a fork Hydra never built, and devenv configures `devenv.cachix.org` to serve it. Between that and `cache.nixos.org` the whole shell closure is already available publicly. But `magic-nix-cache` tracks a single upstream cache, defaulting to `cache.nixos.org`, so every path substituted from Cachix looked novel and was re-uploaded despite never being built locally. Its `upstream-cache` input takes one URL, so pointing it at Cachix would only trade which half gets uploaded. Removing the step beats setting `use-gha-cache: false`, since with that and `use-flakehub` both disabled the action does nothing at all.

**Cache pressure.** The repository sat at 10.6GB against GitHub's 10GB limit across 3,497 entries, nearly all Nix blobs, with identical NARs stored repeatedly: one 304MB path three times, a 182MB path four times. `rust-cache` and `llvm-cov` are 4.1GB of genuinely useful cache that was exposed to eviction by that pressure.

## Result

The first run on this branch confirms the change, measured against three prior runs:

| Step | Before (warm caches) | Before (cold caches) | This branch |
|---|---|---|---|
| Install devenv | 42s | 28s | 22s |
| Run base checks | 79s | 158s | 137s |
| Run Rust checks | 284s | 951s | skipped |
| Post Configure Nix cache | 672s | 1s | **gone** |
| **Job total** | ~1250s | ~1300s | **203s** |

Neither Nix-dependent step regressed: `Install devenv` came in below its previous range, and `Run base checks` at 137s sits inside the historical 72-158s spread, below the 158s of the comparable run that also lacked warm Rust caches.

## Review notes

Neither change touches the checks themselves, so any regression shows up as wall-clock only, not as a false pass.

- **The Rust path is not yet exercised.** This pull request only edits YAML, so `dorny/paths-filter` skipped `Cache Rust dependencies`, `Cache llvm-cov artifacts`, and `Run Rust checks`. The Nix-dependent steps above are directly comparable, but the Rust steps are unverified on this branch and will first be exercised by the next pull request that touches Rust.
- `dorny/paths-filter` compares against the previous commit on push events, so a master push touching no Rust files skips the Rust steps and does not refresh those caches. The pool stays as fresh as the last Rust-touching merge.
- The trigger change only takes effect once it lands on master, so this pull request itself still starts cold.
- **No concurrency group was added**, though the new `push` trigger does make one theoretically applicable. Merge frequency on master is currently too low for concurrent runs to be a practical concern. Worth revisiting if that changes — but note that `cancel-in-progress: true` would need to stay scoped to pull requests, since a cancelled run never reaches its cache-save post step and cancelling master runs would defeat the base-branch seeding this pull request adds.

The existing 3,497 stale cache entries are not cleaned up here and will age out via LRU.
