### PR TITLE
Consolidate event dispatch and reshape EventType into families

### DIFF
--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -5,9 +5,12 @@
 //! offsets. All services must use these in place of local copies.
 
 use std::fmt;
+use std::future::Future;
 
+use sqlx::postgres::PgListener;
 use sqlx::PgPool;
-use tracing::info;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info};
 
 /// Lifecycle stage of an event family.
 ///
@@ -235,6 +238,140 @@ impl fmt::Display for EventType {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(self.as_str())
     }
+}
+
+// --- Notification parsing ---
+
+/// A parsed notification from the `events` channel.
+///
+/// Holding one is proof the payload was well-formed: valid JSON, a positive
+/// `event_id`, and an `event_type` this build recognises. Consumers used to
+/// re-derive those guarantees themselves, and two of them checked for an
+/// `event_id` of zero by hand because their parse helpers returned a sentinel.
+///
+/// The payload shape is fixed by the `notify_event` trigger in `schema.sql`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventNotification {
+    event_id: i64,
+    event_type: EventType,
+    payload: serde_json::Value,
+}
+
+impl EventNotification {
+    /// Parses a NOTIFY payload emitted by the `notify_event` trigger.
+    ///
+    /// Returns `None` when the payload is not valid JSON, is missing or has a
+    /// non-integer `event_id`, carries an `event_id` that is not positive, is
+    /// missing or has a non-string `event_type`, or names an `event_type` this
+    /// build does not know.
+    ///
+    /// An unknown `event_type` is expected rather than exceptional: the `events`
+    /// table retains rows written by earlier builds, including types that have
+    /// since been retired.
+    pub fn parse(payload: &str) -> Option<Self> {
+        let parsed: serde_json::Value = serde_json::from_str(payload).ok()?;
+        let event_id = parsed.get("event_id")?.as_i64()?;
+        if event_id <= 0 {
+            return None;
+        }
+        let event_type = EventType::parse(parsed.get("event_type")?.as_str()?)?;
+        let payload = parsed
+            .get("payload")
+            .cloned()
+            .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+        Some(Self {
+            event_id,
+            event_type,
+            payload,
+        })
+    }
+
+    /// The `events` row id this notification refers to. Always positive.
+    pub fn event_id(&self) -> i64 {
+        self.event_id
+    }
+
+    /// The event type, already resolved to a variant.
+    pub fn event_type(&self) -> EventType {
+        self.event_type
+    }
+
+    /// The event's JSONB payload, or an empty object when the row carried none.
+    pub fn payload(&self) -> &serde_json::Value {
+        &self.payload
+    }
+
+    /// Consumes the notification and returns the payload by value.
+    pub fn into_payload(self) -> serde_json::Value {
+        self.payload
+    }
+}
+
+/// Connects to the `events` channel and dispatches notifications until shutdown.
+///
+/// Replaces the connect / listen / catch-up / select / dispatch scaffolding that
+/// each consumer used to carry its own copy of. Returning `Err` hands control
+/// back to the caller's supervisor loop, which owns the reconnect backoff.
+///
+/// `on_connect` runs once per successful connection, before the first
+/// notification is read. It carries the consumer's startup catch-up, which
+/// deliberately differs between consumers — some replay every missed event,
+/// some collapse to the latest, and some intentionally skip catch-up entirely.
+/// It must run on every reconnect, not once per process, so that a Postgres blip
+/// does not silently skip the reconciliation and offset replay a consumer needs
+/// after any gap in delivery.
+///
+/// Notifications that fail to parse are skipped: a malformed payload is a bug
+/// worth a warning, but an unrecognised event type is routine, because the
+/// `events` table outlives the builds that wrote it.
+pub async fn run_event_listener<Connect, ConnectFuture, Handle, HandleFuture>(
+    pool: &PgPool,
+    shutdown_token: &CancellationToken,
+    consumer_label: &str,
+    on_connect: Connect,
+    handle: Handle,
+) -> Result<(), sqlx::Error>
+where
+    Connect: Fn() -> ConnectFuture,
+    ConnectFuture: Future<Output = Result<(), sqlx::Error>>,
+    Handle: Fn(EventNotification) -> HandleFuture,
+    HandleFuture: Future<Output = ()>,
+{
+    let mut listener = PgListener::connect_with(pool).await?;
+    listener.listen("events").await?;
+    info!(
+        consumer = consumer_label,
+        "Event consumer connected, listening on channel 'events'"
+    );
+
+    if shutdown_token.is_cancelled() {
+        return Ok(());
+    }
+
+    on_connect().await?;
+
+    loop {
+        let notification = tokio::select! {
+            result = listener.recv() => result?,
+            _ = shutdown_token.cancelled() => {
+                info!(consumer = consumer_label, "Shutdown signal received, draining");
+                break;
+            }
+        };
+
+        match EventNotification::parse(notification.payload()) {
+            Some(notification) => handle(notification).await,
+            None => {
+                debug!(
+                    consumer = consumer_label,
+                    payload = notification.payload(),
+                    "Skipping unparseable or unrecognised event notification"
+                );
+            }
+        }
+    }
+
+    Ok(())
 }
 
 // --- Consumer name constants ---
@@ -626,6 +763,93 @@ mod tests {
         for &(event_type, _) in ALL_EVENT_TYPES {
             assert_accounted_for(event_type);
         }
+    }
+
+    /// Builds a payload in the shape the `notify_event` trigger emits.
+    fn trigger_payload(event_type: &str, event_id: i64) -> String {
+        serde_json::json!({
+            "event_id": event_id,
+            "event_type": event_type,
+            "payload": {"date": "2026-07-30"},
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_event_notification_parses_a_well_formed_payload() {
+        let raw = trigger_payload("equity_predictions_requested", 42);
+        let notification =
+            EventNotification::parse(&raw).expect("well-formed payload should parse");
+        assert_eq!(notification.event_id(), 42);
+        assert_eq!(
+            notification.event_type(),
+            EventType::EquityPredictions(Outcome::Requested)
+        );
+        assert_eq!(notification.payload()["date"], "2026-07-30");
+    }
+
+    #[test]
+    fn test_event_notification_defaults_a_missing_payload_to_an_empty_object() {
+        let raw = serde_json::json!({
+            "event_id": 7,
+            "event_type": "equity_bars_sync_completed",
+        })
+        .to_string();
+        let notification = EventNotification::parse(&raw).expect("payload field is optional");
+        assert_eq!(
+            notification.event_type(),
+            EventType::EquityBarsSync(Outcome::Completed)
+        );
+        assert_eq!(notification.payload(), &serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_event_notification_rejects_invalid_json() {
+        assert!(EventNotification::parse("not-json").is_none());
+        assert!(EventNotification::parse("").is_none());
+        assert!(EventNotification::parse("{unclosed").is_none());
+    }
+
+    #[test]
+    fn test_event_notification_rejects_missing_or_malformed_fields() {
+        // Missing event_type.
+        let raw = serde_json::json!({"event_id": 1}).to_string();
+        assert!(EventNotification::parse(&raw).is_none());
+
+        // Missing event_id.
+        let raw = serde_json::json!({"event_type": "stress_test"}).to_string();
+        assert!(EventNotification::parse(&raw).is_none());
+
+        // Non-string event_type.
+        let raw = serde_json::json!({"event_id": 1, "event_type": 99}).to_string();
+        assert!(EventNotification::parse(&raw).is_none());
+
+        // Non-integer event_id.
+        let raw = serde_json::json!({"event_id": "not-a-number", "event_type": "stress_test"})
+            .to_string();
+        assert!(EventNotification::parse(&raw).is_none());
+    }
+
+    #[test]
+    fn test_event_notification_rejects_non_positive_event_id() {
+        // Two consumers used to check for a zero event_id by hand because their
+        // parse helper returned it as a sentinel. Rejecting it here is what lets
+        // event_id() promise a real row.
+        for event_id in [0, -1] {
+            let raw = trigger_payload("stress_test", event_id);
+            assert!(
+                EventNotification::parse(&raw).is_none(),
+                "event_id {event_id} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_event_notification_rejects_unknown_event_type() {
+        // Retired event types still present in older `events` rows must be
+        // skipped rather than crashing a consumer.
+        let raw = trigger_payload("equity_bars_export_requested", 5);
+        assert!(EventNotification::parse(&raw).is_none());
     }
 
     #[test]

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -10,13 +10,14 @@ use std::future::Future;
 use sqlx::postgres::PgListener;
 use sqlx::PgPool;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Lifecycle stage of an event family.
 ///
 /// Only [`Outcome::Requested`] ever drives behavior; the other three are the
-/// audit trail a family writes as it runs. See [`EventType::is_control`] for the
-/// two exceptions.
+/// audit trail a family writes as it runs. The single exception is
+/// [`EventType::EquityPredictions`]`(Completed)`, which starts a rebalance —
+/// [`EventType::is_control`] is the authoritative list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Outcome {
     /// The work has been asked for. Emitted by a pg_cron job, by a chain step,
@@ -257,29 +258,66 @@ pub struct EventNotification {
     payload: serde_json::Value,
 }
 
+/// Why a NOTIFY payload could not be turned into an [`EventNotification`].
+///
+/// The two cases carry different severities, which is the reason this is an enum
+/// rather than a bare `Option`. A malformed payload means the trigger or its
+/// caller is broken and nothing downstream will see the event. An unrecognised
+/// event type is routine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NotificationParseFailure {
+    /// The payload is not valid JSON, or `event_id` / `event_type` is absent,
+    /// the wrong JSON type, or (for `event_id`) not positive.
+    ///
+    /// A producer bug: the `notify_event` trigger always supplies all three
+    /// fields, so seeing this means something else is writing to the channel.
+    Malformed,
+    /// The payload is well-formed but names an event type this build does not
+    /// know.
+    ///
+    /// Expected rather than exceptional: the `events` table retains rows written
+    /// by earlier builds, including types that have since been retired.
+    UnknownEventType(String),
+}
+
+impl fmt::Display for NotificationParseFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Malformed => formatter.write_str("malformed notification payload"),
+            Self::UnknownEventType(event_type) => {
+                write!(formatter, "unknown event type '{event_type}'")
+            }
+        }
+    }
+}
+
 impl EventNotification {
     /// Parses a NOTIFY payload emitted by the `notify_event` trigger.
     ///
-    /// Returns `None` when the payload is not valid JSON, is missing or has a
-    /// non-integer `event_id`, carries an `event_id` that is not positive, is
-    /// missing or has a non-string `event_type`, or names an `event_type` this
-    /// build does not know.
-    ///
-    /// An unknown `event_type` is expected rather than exceptional: the `events`
-    /// table retains rows written by earlier builds, including types that have
-    /// since been retired.
-    pub fn parse(payload: &str) -> Option<Self> {
-        let parsed: serde_json::Value = serde_json::from_str(payload).ok()?;
-        let event_id = parsed.get("event_id")?.as_i64()?;
+    /// See [`NotificationParseFailure`] for the two ways this fails and why they
+    /// are distinguished.
+    pub fn parse(payload: &str) -> Result<Self, NotificationParseFailure> {
+        let parsed: serde_json::Value =
+            serde_json::from_str(payload).map_err(|_| NotificationParseFailure::Malformed)?;
+        let event_id = parsed
+            .get("event_id")
+            .and_then(serde_json::Value::as_i64)
+            .ok_or(NotificationParseFailure::Malformed)?;
         if event_id <= 0 {
-            return None;
+            return Err(NotificationParseFailure::Malformed);
         }
-        let event_type = EventType::parse(parsed.get("event_type")?.as_str()?)?;
+        let event_type_string = parsed
+            .get("event_type")
+            .and_then(serde_json::Value::as_str)
+            .ok_or(NotificationParseFailure::Malformed)?;
+        let event_type = EventType::parse(event_type_string).ok_or_else(|| {
+            NotificationParseFailure::UnknownEventType(event_type_string.to_string())
+        })?;
         let payload = parsed
             .get("payload")
             .cloned()
             .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
-        Some(Self {
+        Ok(Self {
             event_id,
             event_type,
             payload,
@@ -321,13 +359,22 @@ impl EventNotification {
 /// does not silently skip the reconciliation and offset replay a consumer needs
 /// after any gap in delivery.
 ///
-/// Notifications that fail to parse are skipped: a malformed payload is a bug
-/// worth a warning, but an unrecognised event type is routine, because the
-/// `events` table outlives the builds that wrote it.
+/// Cancellation is checked before `on_connect` and while waiting for the next
+/// notification, but not during either. Catch-up can submit orders — the
+/// portfolio consumer's runs a full rebalance — so abandoning it midway would
+/// leave the broker and the database disagreeing, which is the state startup
+/// reconciliation exists to repair. Waiting for it is the safer failure mode.
+///
+/// Notifications that fail to parse are skipped, at the severity their failure
+/// warrants. See [`NotificationParseFailure`].
 pub async fn run_event_listener<Connect, ConnectFuture, Handle, HandleFuture>(
     pool: &PgPool,
     shutdown_token: &CancellationToken,
-    consumer_label: &str,
+    // Names the service in connect, shutdown, and skipped-notification logs.
+    // Deliberately not a `CONSUMER_*` constant: those are offset-tracking keys,
+    // and a listener may own several of them, so reusing one would name only a
+    // fraction of what the log line covers.
+    service_label: &str,
     on_connect: Connect,
     handle: Handle,
 ) -> Result<(), sqlx::Error>
@@ -340,7 +387,7 @@ where
     let mut listener = PgListener::connect_with(pool).await?;
     listener.listen("events").await?;
     info!(
-        consumer = consumer_label,
+        service = service_label,
         "Event consumer connected, listening on channel 'events'"
     );
 
@@ -354,18 +401,24 @@ where
         let notification = tokio::select! {
             result = listener.recv() => result?,
             _ = shutdown_token.cancelled() => {
-                info!(consumer = consumer_label, "Shutdown signal received, draining");
+                info!(service = service_label, "Shutdown signal received, draining");
                 break;
             }
         };
 
         match EventNotification::parse(notification.payload()) {
-            Some(notification) => handle(notification).await,
-            None => {
-                debug!(
-                    consumer = consumer_label,
+            Ok(notification) => handle(notification).await,
+            Err(NotificationParseFailure::Malformed) => {
+                warn!(
+                    service = service_label,
                     payload = notification.payload(),
-                    "Skipping unparseable or unrecognised event notification"
+                    "Skipping malformed event notification"
+                );
+            }
+            Err(NotificationParseFailure::UnknownEventType(event_type)) => {
+                debug!(
+                    service = service_label,
+                    event_type, "Skipping event type this build does not know"
                 );
             }
         }
@@ -804,30 +857,40 @@ mod tests {
     }
 
     #[test]
-    fn test_event_notification_rejects_invalid_json() {
-        assert!(EventNotification::parse("not-json").is_none());
-        assert!(EventNotification::parse("").is_none());
-        assert!(EventNotification::parse("{unclosed").is_none());
+    fn test_event_notification_rejects_invalid_json_as_malformed() {
+        for raw in ["not-json", "", "{unclosed"] {
+            assert_eq!(
+                EventNotification::parse(raw),
+                Err(NotificationParseFailure::Malformed),
+                "{raw:?} should be rejected as malformed"
+            );
+        }
     }
 
     #[test]
     fn test_event_notification_rejects_missing_or_malformed_fields() {
-        // Missing event_type.
-        let raw = serde_json::json!({"event_id": 1}).to_string();
-        assert!(EventNotification::parse(&raw).is_none());
-
-        // Missing event_id.
-        let raw = serde_json::json!({"event_type": "stress_test"}).to_string();
-        assert!(EventNotification::parse(&raw).is_none());
-
-        // Non-string event_type.
-        let raw = serde_json::json!({"event_id": 1, "event_type": 99}).to_string();
-        assert!(EventNotification::parse(&raw).is_none());
-
-        // Non-integer event_id.
-        let raw = serde_json::json!({"event_id": "not-a-number", "event_type": "stress_test"})
-            .to_string();
-        assert!(EventNotification::parse(&raw).is_none());
+        let cases = [
+            ("missing event_type", serde_json::json!({"event_id": 1})),
+            (
+                "missing event_id",
+                serde_json::json!({"event_type": "stress_test"}),
+            ),
+            (
+                "non-string event_type",
+                serde_json::json!({"event_id": 1, "event_type": 99}),
+            ),
+            (
+                "non-integer event_id",
+                serde_json::json!({"event_id": "not-a-number", "event_type": "stress_test"}),
+            ),
+        ];
+        for (description, raw) in cases {
+            assert_eq!(
+                EventNotification::parse(&raw.to_string()),
+                Err(NotificationParseFailure::Malformed),
+                "{description} should be rejected as malformed"
+            );
+        }
     }
 
     #[test]
@@ -837,19 +900,25 @@ mod tests {
         // event_id() promise a real row.
         for event_id in [0, -1] {
             let raw = trigger_payload("stress_test", event_id);
-            assert!(
-                EventNotification::parse(&raw).is_none(),
+            assert_eq!(
+                EventNotification::parse(&raw),
+                Err(NotificationParseFailure::Malformed),
                 "event_id {event_id} should be rejected"
             );
         }
     }
 
     #[test]
-    fn test_event_notification_rejects_unknown_event_type() {
-        // Retired event types still present in older `events` rows must be
-        // skipped rather than crashing a consumer.
+    fn test_event_notification_reports_an_unknown_event_type_separately() {
+        // Retired event types still present in older `events` rows are routine,
+        // not a producer bug, and the two are logged at different severities.
         let raw = trigger_payload("equity_bars_export_requested", 5);
-        assert!(EventNotification::parse(&raw).is_none());
+        assert_eq!(
+            EventNotification::parse(&raw),
+            Err(NotificationParseFailure::UnknownEventType(
+                "equity_bars_export_requested".to_string()
+            ))
+        );
     }
 
     #[test]

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -9,77 +9,76 @@ use std::fmt;
 use sqlx::PgPool;
 use tracing::info;
 
+/// Lifecycle stage of an event family.
+///
+/// Only [`Outcome::Requested`] ever drives behavior; the other three are the
+/// audit trail a family writes as it runs. See [`EventType::is_control`] for the
+/// two exceptions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The work has been asked for. Emitted by a pg_cron job, by a chain step,
+    /// or by a consumer re-requesting work it found missing.
+    Requested,
+    /// The work has begun.
+    Started,
+    /// The work finished successfully.
+    Completed,
+    /// The work failed, or finished with a partial failure.
+    Errored,
+}
+
 /// All event types published on the `events` PostgreSQL NOTIFY channel.
 ///
 /// Each variant maps to a canonical snake_case string via [`EventType::as_str`].
 /// That string is stored in the `events` table `event_type` column and carried
 /// in NOTIFY payloads so consumers can match without an extra database round-trip.
+///
+/// Most variants are a family carrying an [`Outcome`], because the
+/// requested/started/completed/errored quadruplet is the shape nearly every
+/// event follows. The singletons are genuinely lone events, not families with
+/// three unemitted siblings.
+///
+/// Only a minority of these drive behavior. [`EventType::is_control`] is the
+/// authoritative list; everything else is written for the operator dashboard and
+/// the nightly export and is never dispatched on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EventType {
-    // --- Market data sync ---
-    /// pg_cron trigger: nightly equity bar sync requested.
-    EquityBarsSyncRequested,
-    /// data: equity bar sync has started.
-    EquityBarsSyncStarted,
-    /// data: equity bar sync completed successfully.
-    EquityBarsSyncCompleted,
-    /// data: equity bar sync encountered an error.
-    EquityBarsSyncErrored,
+    /// Nightly equity bar sync. `Requested` comes from pg_cron; the data service
+    /// emits the rest as it runs.
+    EquityBarsSync(Outcome),
 
-    // --- Nightly post-market chain: export → backup → purge ---
-    /// pg_cron trigger: nightly database export to S3 Parquet requested.
-    DatabaseExportRequested,
-    /// data: database export has started.
-    DatabaseExportStarted,
-    /// data: database export completed successfully.
-    DatabaseExportCompleted,
-    /// data: database export encountered an error.
-    DatabaseExportErrored,
+    /// Nightly database export to S3 Parquet, the first leg of the post-market
+    /// chain. `Requested` comes from pg_cron; export success chains to
+    /// [`EventType::DatabaseBackup`].
+    DatabaseExport(Outcome),
 
-    /// data: database backup requested (chained from export completion).
-    DatabaseBackupRequested,
-    /// data: database backup has started.
-    DatabaseBackupStarted,
-    /// data: database backup completed successfully.
-    DatabaseBackupCompleted,
-    /// data: database backup encountered an error.
-    DatabaseBackupErrored,
+    /// Nightly database backup, chained from export completion.
+    DatabaseBackup(Outcome),
 
-    /// data: database purge requested (chained from backup completion).
-    DatabasePurgeRequested,
-    /// data: database purge has started.
-    DatabasePurgeStarted,
-    /// data: database purge completed successfully, with every table purged.
-    DatabasePurgeCompleted,
-    /// data: database purge finished with one or more tables failing.
+    /// Nightly retention purge, chained from backup completion.
     ///
-    /// A failing table is skipped so the rest of the purge still runs, so this is a
-    /// partial outcome rather than an abort: the payload carries the failed table
-    /// names alongside the rows that were deleted.
-    DatabasePurgeErrored,
+    /// `Errored` is a partial outcome rather than an abort: a failing table is
+    /// skipped so the rest of the purge still runs, and the payload carries the
+    /// failed table names alongside the rows that were deleted.
+    DatabasePurge(Outcome),
 
-    // --- Prediction pipeline ---
-    /// pg_cron trigger: pre-market request for the day's equity predictions.
+    /// Daily equity prediction run.
     ///
     /// Predictions are derived from daily bars, so one run per session produces
-    /// every distinct value the day will have. The portfolio consumer re-emits
-    /// this event when a session begins with no predictions recorded, which
-    /// covers a failed or missed pre-market run.
-    EquityPredictionsRequested,
-    /// inference: equity prediction run has started.
-    EquityPredictionsStarted,
-    /// inference: equity prediction run completed successfully.
-    EquityPredictionsCompleted,
-    /// inference: equity prediction run encountered an error.
-    EquityPredictionsErrored,
-
-    // --- Trading session ---
-    /// pg_cron trigger: the trading session is about to begin.
+    /// every distinct value the day will have. `Requested` comes from pg_cron,
+    /// and the portfolio consumer re-emits it when a session begins with no
+    /// predictions recorded, which covers a failed or missed pre-market run.
     ///
-    /// Emitted once, shortly before the regular open. Starts the session: the
-    /// portfolio consumer reconciles against the broker, confirms the market
-    /// actually trades today, builds the initial portfolio, and arms the
-    /// liquidation timer from the real session close.
+    /// `Completed` is the one non-`Requested` control event: it is what drives
+    /// the portfolio rebalance once a fresh prediction set exists.
+    EquityPredictions(Outcome),
+
+    /// The trading session is about to begin. Control.
+    ///
+    /// Emitted once by pg_cron, shortly before the regular open. Starts the
+    /// session: the portfolio consumer reconciles against the broker, confirms
+    /// the market actually trades today, builds the initial portfolio, and arms
+    /// the liquidation timer from the real session close.
     ///
     /// This replaced a five-minute evaluation heartbeat that ran a full
     /// rebalance whether or not anything had changed. Intraday work is driven by
@@ -88,107 +87,147 @@ pub enum EventType {
     /// crosses a close threshold.
     TradingSessionStarted,
 
-    // --- Portfolio rebalance ---
-    /// Evaluate open positions for exits and idle capital for entries.
+    /// Evaluate open positions for exits and idle capital for entries. Control.
     ///
     /// Emitted by the live-quote evaluator on a threshold crossing. No longer
     /// emitted on a timer: a pass that finds nothing changed is pure cost, and
     /// the events that genuinely need one now emit it directly.
+    ///
+    /// A singleton rather than a `Requested` outcome of
+    /// [`EventType::PortfolioRebalance`] because it is a request to *decide*
+    /// whether to rebalance, which is not the same as the rebalance itself.
     PortfolioEvaluationRequested,
-    /// portfolio: rebalance has started.
-    PortfolioRebalanceStarted,
-    /// portfolio: rebalance completed successfully.
-    PortfolioRebalanceCompleted,
-    /// portfolio: rebalance encountered an error.
-    PortfolioRebalanceErrored,
 
-    // --- End-of-day liquidation ---
-    /// pg_cron trigger: close all open positions before market close.
-    PortfolioLiquidationRequested,
-    /// portfolio: liquidation has started.
-    PortfolioLiquidationStarted,
-    /// portfolio: liquidation completed successfully.
-    PortfolioLiquidationCompleted,
-    /// portfolio: liquidation encountered an error.
-    PortfolioLiquidationErrored,
+    /// A rebalance pass. Audit only.
+    ///
+    /// Nothing emits `Requested` — a pass is started by
+    /// [`EventType::PortfolioEvaluationRequested`],
+    /// [`EventType::TradingSessionStarted`], or
+    /// [`EventType::EquityPredictions`]`(Completed)`, never by a rebalance
+    /// request of its own. The combination is representable so the family keeps
+    /// the uniform shape, and round-trips correctly should an emitter ever
+    /// appear.
+    PortfolioRebalance(Outcome),
 
-    // --- Stress testing ---
+    /// End-of-day liquidation of all open positions.
+    ///
+    /// `Requested` has two emitters, deliberately: the in-process timer armed
+    /// from the real session close, and a pg_cron fail-safe on the wall clock.
+    /// Liquidation is idempotent, so both firing is harmless.
+    PortfolioLiquidation(Outcome),
+
     /// Dedicated variant for the event bus stress test binary.
     StressTest,
 }
 
 impl EventType {
     /// Returns the canonical snake_case string stored in the `events` table.
+    ///
+    /// These strings are a stable external interface: they sit in existing
+    /// `events` rows, in the nightly S3 exports, and in the dashboard's parsing
+    /// path. Changing one orphans stored data.
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::EquityBarsSyncRequested => "equity_bars_sync_requested",
-            Self::EquityBarsSyncStarted => "equity_bars_sync_started",
-            Self::EquityBarsSyncCompleted => "equity_bars_sync_completed",
-            Self::EquityBarsSyncErrored => "equity_bars_sync_errored",
-            Self::DatabaseExportRequested => "database_export_requested",
-            Self::DatabaseExportStarted => "database_export_started",
-            Self::DatabaseExportCompleted => "database_export_completed",
-            Self::DatabaseExportErrored => "database_export_errored",
-            Self::DatabaseBackupRequested => "database_backup_requested",
-            Self::DatabaseBackupStarted => "database_backup_started",
-            Self::DatabaseBackupCompleted => "database_backup_completed",
-            Self::DatabaseBackupErrored => "database_backup_errored",
-            Self::DatabasePurgeRequested => "database_purge_requested",
-            Self::DatabasePurgeStarted => "database_purge_started",
-            Self::DatabasePurgeCompleted => "database_purge_completed",
-            Self::DatabasePurgeErrored => "database_purge_errored",
-            Self::EquityPredictionsRequested => "equity_predictions_requested",
-            Self::EquityPredictionsStarted => "equity_predictions_started",
-            Self::EquityPredictionsCompleted => "equity_predictions_completed",
-            Self::EquityPredictionsErrored => "equity_predictions_errored",
+            Self::EquityBarsSync(Outcome::Requested) => "equity_bars_sync_requested",
+            Self::EquityBarsSync(Outcome::Started) => "equity_bars_sync_started",
+            Self::EquityBarsSync(Outcome::Completed) => "equity_bars_sync_completed",
+            Self::EquityBarsSync(Outcome::Errored) => "equity_bars_sync_errored",
+            Self::DatabaseExport(Outcome::Requested) => "database_export_requested",
+            Self::DatabaseExport(Outcome::Started) => "database_export_started",
+            Self::DatabaseExport(Outcome::Completed) => "database_export_completed",
+            Self::DatabaseExport(Outcome::Errored) => "database_export_errored",
+            Self::DatabaseBackup(Outcome::Requested) => "database_backup_requested",
+            Self::DatabaseBackup(Outcome::Started) => "database_backup_started",
+            Self::DatabaseBackup(Outcome::Completed) => "database_backup_completed",
+            Self::DatabaseBackup(Outcome::Errored) => "database_backup_errored",
+            Self::DatabasePurge(Outcome::Requested) => "database_purge_requested",
+            Self::DatabasePurge(Outcome::Started) => "database_purge_started",
+            Self::DatabasePurge(Outcome::Completed) => "database_purge_completed",
+            Self::DatabasePurge(Outcome::Errored) => "database_purge_errored",
+            Self::EquityPredictions(Outcome::Requested) => "equity_predictions_requested",
+            Self::EquityPredictions(Outcome::Started) => "equity_predictions_started",
+            Self::EquityPredictions(Outcome::Completed) => "equity_predictions_completed",
+            Self::EquityPredictions(Outcome::Errored) => "equity_predictions_errored",
             Self::TradingSessionStarted => "trading_session_started",
             Self::PortfolioEvaluationRequested => "portfolio_evaluation_requested",
-            Self::PortfolioRebalanceStarted => "portfolio_rebalance_started",
-            Self::PortfolioRebalanceCompleted => "portfolio_rebalance_completed",
-            Self::PortfolioRebalanceErrored => "portfolio_rebalance_errored",
-            Self::PortfolioLiquidationRequested => "portfolio_liquidation_requested",
-            Self::PortfolioLiquidationStarted => "portfolio_liquidation_started",
-            Self::PortfolioLiquidationCompleted => "portfolio_liquidation_completed",
-            Self::PortfolioLiquidationErrored => "portfolio_liquidation_errored",
+            Self::PortfolioRebalance(Outcome::Requested) => "portfolio_rebalance_requested",
+            Self::PortfolioRebalance(Outcome::Started) => "portfolio_rebalance_started",
+            Self::PortfolioRebalance(Outcome::Completed) => "portfolio_rebalance_completed",
+            Self::PortfolioRebalance(Outcome::Errored) => "portfolio_rebalance_errored",
+            Self::PortfolioLiquidation(Outcome::Requested) => "portfolio_liquidation_requested",
+            Self::PortfolioLiquidation(Outcome::Started) => "portfolio_liquidation_started",
+            Self::PortfolioLiquidation(Outcome::Completed) => "portfolio_liquidation_completed",
+            Self::PortfolioLiquidation(Outcome::Errored) => "portfolio_liquidation_errored",
             Self::StressTest => "stress_test",
         }
     }
 
     /// Parses a stored event type string. Returns `None` for unknown values.
+    ///
+    /// Unknown values are expected in practice: the `events` table retains rows
+    /// written by earlier builds, including event types that have since been
+    /// removed. Callers skip what they cannot parse rather than treating it as
+    /// an error.
     pub fn parse(value: &str) -> Option<Self> {
         match value {
-            "equity_bars_sync_requested" => Some(Self::EquityBarsSyncRequested),
-            "equity_bars_sync_started" => Some(Self::EquityBarsSyncStarted),
-            "equity_bars_sync_completed" => Some(Self::EquityBarsSyncCompleted),
-            "equity_bars_sync_errored" => Some(Self::EquityBarsSyncErrored),
-            "database_export_requested" => Some(Self::DatabaseExportRequested),
-            "database_export_started" => Some(Self::DatabaseExportStarted),
-            "database_export_completed" => Some(Self::DatabaseExportCompleted),
-            "database_export_errored" => Some(Self::DatabaseExportErrored),
-            "database_backup_requested" => Some(Self::DatabaseBackupRequested),
-            "database_backup_started" => Some(Self::DatabaseBackupStarted),
-            "database_backup_completed" => Some(Self::DatabaseBackupCompleted),
-            "database_backup_errored" => Some(Self::DatabaseBackupErrored),
-            "database_purge_requested" => Some(Self::DatabasePurgeRequested),
-            "database_purge_started" => Some(Self::DatabasePurgeStarted),
-            "database_purge_completed" => Some(Self::DatabasePurgeCompleted),
-            "database_purge_errored" => Some(Self::DatabasePurgeErrored),
-            "equity_predictions_requested" => Some(Self::EquityPredictionsRequested),
-            "equity_predictions_started" => Some(Self::EquityPredictionsStarted),
-            "equity_predictions_completed" => Some(Self::EquityPredictionsCompleted),
-            "equity_predictions_errored" => Some(Self::EquityPredictionsErrored),
+            "equity_bars_sync_requested" => Some(Self::EquityBarsSync(Outcome::Requested)),
+            "equity_bars_sync_started" => Some(Self::EquityBarsSync(Outcome::Started)),
+            "equity_bars_sync_completed" => Some(Self::EquityBarsSync(Outcome::Completed)),
+            "equity_bars_sync_errored" => Some(Self::EquityBarsSync(Outcome::Errored)),
+            "database_export_requested" => Some(Self::DatabaseExport(Outcome::Requested)),
+            "database_export_started" => Some(Self::DatabaseExport(Outcome::Started)),
+            "database_export_completed" => Some(Self::DatabaseExport(Outcome::Completed)),
+            "database_export_errored" => Some(Self::DatabaseExport(Outcome::Errored)),
+            "database_backup_requested" => Some(Self::DatabaseBackup(Outcome::Requested)),
+            "database_backup_started" => Some(Self::DatabaseBackup(Outcome::Started)),
+            "database_backup_completed" => Some(Self::DatabaseBackup(Outcome::Completed)),
+            "database_backup_errored" => Some(Self::DatabaseBackup(Outcome::Errored)),
+            "database_purge_requested" => Some(Self::DatabasePurge(Outcome::Requested)),
+            "database_purge_started" => Some(Self::DatabasePurge(Outcome::Started)),
+            "database_purge_completed" => Some(Self::DatabasePurge(Outcome::Completed)),
+            "database_purge_errored" => Some(Self::DatabasePurge(Outcome::Errored)),
+            "equity_predictions_requested" => Some(Self::EquityPredictions(Outcome::Requested)),
+            "equity_predictions_started" => Some(Self::EquityPredictions(Outcome::Started)),
+            "equity_predictions_completed" => Some(Self::EquityPredictions(Outcome::Completed)),
+            "equity_predictions_errored" => Some(Self::EquityPredictions(Outcome::Errored)),
             "trading_session_started" => Some(Self::TradingSessionStarted),
             "portfolio_evaluation_requested" => Some(Self::PortfolioEvaluationRequested),
-            "portfolio_rebalance_started" => Some(Self::PortfolioRebalanceStarted),
-            "portfolio_rebalance_completed" => Some(Self::PortfolioRebalanceCompleted),
-            "portfolio_rebalance_errored" => Some(Self::PortfolioRebalanceErrored),
-            "portfolio_liquidation_requested" => Some(Self::PortfolioLiquidationRequested),
-            "portfolio_liquidation_started" => Some(Self::PortfolioLiquidationStarted),
-            "portfolio_liquidation_completed" => Some(Self::PortfolioLiquidationCompleted),
-            "portfolio_liquidation_errored" => Some(Self::PortfolioLiquidationErrored),
+            "portfolio_rebalance_requested" => Some(Self::PortfolioRebalance(Outcome::Requested)),
+            "portfolio_rebalance_started" => Some(Self::PortfolioRebalance(Outcome::Started)),
+            "portfolio_rebalance_completed" => Some(Self::PortfolioRebalance(Outcome::Completed)),
+            "portfolio_rebalance_errored" => Some(Self::PortfolioRebalance(Outcome::Errored)),
+            "portfolio_liquidation_requested" => {
+                Some(Self::PortfolioLiquidation(Outcome::Requested))
+            }
+            "portfolio_liquidation_started" => Some(Self::PortfolioLiquidation(Outcome::Started)),
+            "portfolio_liquidation_completed" => {
+                Some(Self::PortfolioLiquidation(Outcome::Completed))
+            }
+            "portfolio_liquidation_errored" => Some(Self::PortfolioLiquidation(Outcome::Errored)),
             "stress_test" => Some(Self::StressTest),
             _ => None,
         }
+    }
+
+    /// Returns `true` when a consumer acts on this event.
+    ///
+    /// Everything else is an audit record: written for the operator dashboard
+    /// and the nightly export, never dispatched on. This list is the definition
+    /// — if a consumer starts handling an event, it belongs here, and if one
+    /// stops, it does not.
+    pub fn is_control(self) -> bool {
+        matches!(
+            self,
+            Self::EquityBarsSync(Outcome::Requested)
+                | Self::DatabaseExport(Outcome::Requested)
+                | Self::DatabaseBackup(Outcome::Requested)
+                | Self::DatabasePurge(Outcome::Requested)
+                | Self::EquityPredictions(Outcome::Requested)
+                | Self::EquityPredictions(Outcome::Completed)
+                | Self::TradingSessionStarted
+                | Self::PortfolioEvaluationRequested
+                | Self::PortfolioLiquidation(Outcome::Requested)
+        )
     }
 }
 
@@ -348,42 +387,161 @@ mod tests {
             .unwrap()
     }
 
+    /// Every variant paired with the exact string stored in the `events` table.
+    ///
+    /// This table is the contract with existing rows, the nightly S3 exports,
+    /// and the dashboard. A mismatch here means stored data has been orphaned.
+    const ALL_EVENT_TYPES: &[(EventType, &str)] = &[
+        (
+            EventType::EquityBarsSync(Outcome::Requested),
+            "equity_bars_sync_requested",
+        ),
+        (
+            EventType::EquityBarsSync(Outcome::Started),
+            "equity_bars_sync_started",
+        ),
+        (
+            EventType::EquityBarsSync(Outcome::Completed),
+            "equity_bars_sync_completed",
+        ),
+        (
+            EventType::EquityBarsSync(Outcome::Errored),
+            "equity_bars_sync_errored",
+        ),
+        (
+            EventType::DatabaseExport(Outcome::Requested),
+            "database_export_requested",
+        ),
+        (
+            EventType::DatabaseExport(Outcome::Started),
+            "database_export_started",
+        ),
+        (
+            EventType::DatabaseExport(Outcome::Completed),
+            "database_export_completed",
+        ),
+        (
+            EventType::DatabaseExport(Outcome::Errored),
+            "database_export_errored",
+        ),
+        (
+            EventType::DatabaseBackup(Outcome::Requested),
+            "database_backup_requested",
+        ),
+        (
+            EventType::DatabaseBackup(Outcome::Started),
+            "database_backup_started",
+        ),
+        (
+            EventType::DatabaseBackup(Outcome::Completed),
+            "database_backup_completed",
+        ),
+        (
+            EventType::DatabaseBackup(Outcome::Errored),
+            "database_backup_errored",
+        ),
+        (
+            EventType::DatabasePurge(Outcome::Requested),
+            "database_purge_requested",
+        ),
+        (
+            EventType::DatabasePurge(Outcome::Started),
+            "database_purge_started",
+        ),
+        (
+            EventType::DatabasePurge(Outcome::Completed),
+            "database_purge_completed",
+        ),
+        (
+            EventType::DatabasePurge(Outcome::Errored),
+            "database_purge_errored",
+        ),
+        (
+            EventType::EquityPredictions(Outcome::Requested),
+            "equity_predictions_requested",
+        ),
+        (
+            EventType::EquityPredictions(Outcome::Started),
+            "equity_predictions_started",
+        ),
+        (
+            EventType::EquityPredictions(Outcome::Completed),
+            "equity_predictions_completed",
+        ),
+        (
+            EventType::EquityPredictions(Outcome::Errored),
+            "equity_predictions_errored",
+        ),
+        (EventType::TradingSessionStarted, "trading_session_started"),
+        (
+            EventType::PortfolioEvaluationRequested,
+            "portfolio_evaluation_requested",
+        ),
+        (
+            EventType::PortfolioRebalance(Outcome::Requested),
+            "portfolio_rebalance_requested",
+        ),
+        (
+            EventType::PortfolioRebalance(Outcome::Started),
+            "portfolio_rebalance_started",
+        ),
+        (
+            EventType::PortfolioRebalance(Outcome::Completed),
+            "portfolio_rebalance_completed",
+        ),
+        (
+            EventType::PortfolioRebalance(Outcome::Errored),
+            "portfolio_rebalance_errored",
+        ),
+        (
+            EventType::PortfolioLiquidation(Outcome::Requested),
+            "portfolio_liquidation_requested",
+        ),
+        (
+            EventType::PortfolioLiquidation(Outcome::Started),
+            "portfolio_liquidation_started",
+        ),
+        (
+            EventType::PortfolioLiquidation(Outcome::Completed),
+            "portfolio_liquidation_completed",
+        ),
+        (
+            EventType::PortfolioLiquidation(Outcome::Errored),
+            "portfolio_liquidation_errored",
+        ),
+        (EventType::StressTest, "stress_test"),
+    ];
+
+    /// Every event a consumer acts on. The complement is audit-only.
+    const CONTROL_EVENT_TYPES: &[EventType] = &[
+        EventType::EquityBarsSync(Outcome::Requested),
+        EventType::DatabaseExport(Outcome::Requested),
+        EventType::DatabaseBackup(Outcome::Requested),
+        EventType::DatabasePurge(Outcome::Requested),
+        EventType::EquityPredictions(Outcome::Requested),
+        EventType::EquityPredictions(Outcome::Completed),
+        EventType::TradingSessionStarted,
+        EventType::PortfolioEvaluationRequested,
+        EventType::PortfolioLiquidation(Outcome::Requested),
+    ];
+
+    #[test]
+    fn test_event_type_maps_to_exact_stored_string() {
+        // Guards the strings themselves, not just their consistency: a rename
+        // that updated both as_str and parse would still orphan stored rows.
+        for &(event_type, expected) in ALL_EVENT_TYPES {
+            assert_eq!(
+                event_type.as_str(),
+                expected,
+                "wrong stored string for {:?}",
+                event_type
+            );
+        }
+    }
+
     #[test]
     fn test_event_type_parse_round_trips_all_variants() {
-        // Every as_str() output must parse back to the same variant.
-        let all: &[EventType] = &[
-            EventType::EquityBarsSyncRequested,
-            EventType::EquityBarsSyncStarted,
-            EventType::EquityBarsSyncCompleted,
-            EventType::EquityBarsSyncErrored,
-            EventType::DatabaseExportRequested,
-            EventType::DatabaseExportStarted,
-            EventType::DatabaseExportCompleted,
-            EventType::DatabaseExportErrored,
-            EventType::DatabaseBackupRequested,
-            EventType::DatabaseBackupStarted,
-            EventType::DatabaseBackupCompleted,
-            EventType::DatabaseBackupErrored,
-            EventType::DatabasePurgeRequested,
-            EventType::DatabasePurgeStarted,
-            EventType::DatabasePurgeCompleted,
-            EventType::DatabasePurgeErrored,
-            EventType::EquityPredictionsRequested,
-            EventType::EquityPredictionsStarted,
-            EventType::EquityPredictionsCompleted,
-            EventType::EquityPredictionsErrored,
-            EventType::TradingSessionStarted,
-            EventType::PortfolioEvaluationRequested,
-            EventType::PortfolioRebalanceStarted,
-            EventType::PortfolioRebalanceCompleted,
-            EventType::PortfolioRebalanceErrored,
-            EventType::PortfolioLiquidationRequested,
-            EventType::PortfolioLiquidationStarted,
-            EventType::PortfolioLiquidationCompleted,
-            EventType::PortfolioLiquidationErrored,
-            EventType::StressTest,
-        ];
-        for &event_type in all {
+        for &(event_type, _) in ALL_EVENT_TYPES {
             assert_eq!(
                 EventType::parse(event_type.as_str()),
                 Some(event_type),
@@ -394,53 +552,125 @@ mod tests {
     }
 
     #[test]
+    fn test_event_type_table_covers_every_variant() {
+        // The tests above only check the variants the table already lists, so a
+        // variant added to EventType but forgotten here would slip past them.
+        // Generate the full cross product instead of trusting a hand-written
+        // count: every family paired with every outcome, plus the singletons.
+        //
+        // Adding a *family* still needs a line here, which the exhaustive match
+        // below turns into a compile error rather than a silent gap.
+        let families: [fn(Outcome) -> EventType; 7] = [
+            EventType::EquityBarsSync,
+            EventType::DatabaseExport,
+            EventType::DatabaseBackup,
+            EventType::DatabasePurge,
+            EventType::EquityPredictions,
+            EventType::PortfolioRebalance,
+            EventType::PortfolioLiquidation,
+        ];
+        let outcomes = [
+            Outcome::Requested,
+            Outcome::Started,
+            Outcome::Completed,
+            Outcome::Errored,
+        ];
+        let singletons = [
+            EventType::TradingSessionStarted,
+            EventType::PortfolioEvaluationRequested,
+            EventType::StressTest,
+        ];
+
+        let mut expected = Vec::new();
+        for family in families {
+            for outcome in outcomes {
+                expected.push(family(outcome));
+            }
+        }
+        expected.extend_from_slice(&singletons);
+
+        for event_type in &expected {
+            assert!(
+                ALL_EVENT_TYPES
+                    .iter()
+                    .any(|(listed, _)| listed == event_type),
+                "ALL_EVENT_TYPES is missing {:?}",
+                event_type
+            );
+        }
+        assert_eq!(
+            ALL_EVENT_TYPES.len(),
+            expected.len(),
+            "ALL_EVENT_TYPES lists a variant the cross product does not produce"
+        );
+    }
+
+    #[test]
+    fn test_every_family_appears_in_the_coverage_cross_product() {
+        // Companion to the test above: an exhaustive match, so adding a variant
+        // to EventType fails to compile until the cross product learns about it.
+        fn assert_accounted_for(event_type: EventType) {
+            match event_type {
+                EventType::EquityBarsSync(_)
+                | EventType::DatabaseExport(_)
+                | EventType::DatabaseBackup(_)
+                | EventType::DatabasePurge(_)
+                | EventType::EquityPredictions(_)
+                | EventType::PortfolioRebalance(_)
+                | EventType::PortfolioLiquidation(_)
+                | EventType::TradingSessionStarted
+                | EventType::PortfolioEvaluationRequested
+                | EventType::StressTest => {}
+            }
+        }
+        for &(event_type, _) in ALL_EVENT_TYPES {
+            assert_accounted_for(event_type);
+        }
+    }
+
+    #[test]
+    fn test_event_type_strings_are_unique() {
+        // Two variants sharing a string would make parse lossy in one direction.
+        let mut seen = std::collections::HashSet::new();
+        for &(_, stored) in ALL_EVENT_TYPES {
+            assert!(seen.insert(stored), "duplicate stored string {stored}");
+        }
+    }
+
+    #[test]
     fn test_event_type_parse_rejects_unknown() {
         assert_eq!(EventType::parse("unknown_event"), None);
         assert_eq!(EventType::parse(""), None);
         assert_eq!(EventType::parse("EQUITY_BARS_SYNC_COMPLETED"), None);
+        // Retired event types still present in older `events` rows.
+        assert_eq!(EventType::parse("equity_bars_export_requested"), None);
+        assert_eq!(EventType::parse("trading_history_export_requested"), None);
     }
 
     #[test]
-    fn test_event_type_as_str_is_snake_case() {
-        assert_eq!(
-            EventType::EquityBarsSyncRequested.as_str(),
-            "equity_bars_sync_requested"
-        );
-        assert_eq!(
-            EventType::EquityPredictionsCompleted.as_str(),
-            "equity_predictions_completed"
-        );
-        assert_eq!(
-            EventType::PortfolioRebalanceCompleted.as_str(),
-            "portfolio_rebalance_completed"
-        );
-        assert_eq!(
-            EventType::PortfolioLiquidationCompleted.as_str(),
-            "portfolio_liquidation_completed"
-        );
-        assert_eq!(
-            EventType::PortfolioEvaluationRequested.as_str(),
-            "portfolio_evaluation_requested"
-        );
-        assert_eq!(
-            EventType::EquityPredictionsErrored.as_str(),
-            "equity_predictions_errored"
-        );
-        assert_eq!(
-            EventType::PortfolioLiquidationErrored.as_str(),
-            "portfolio_liquidation_errored"
-        );
+    fn test_is_control_is_true_for_exactly_the_control_events() {
+        for &event_type in CONTROL_EVENT_TYPES {
+            assert!(
+                event_type.is_control(),
+                "{:?} should be a control event",
+                event_type
+            );
+        }
+        for &(event_type, _) in ALL_EVENT_TYPES {
+            let expected = CONTROL_EVENT_TYPES.contains(&event_type);
+            assert_eq!(
+                event_type.is_control(),
+                expected,
+                "is_control disagrees with the control list for {:?}",
+                event_type
+            );
+        }
     }
 
     #[test]
     fn test_event_type_display_matches_as_str() {
-        for event_type in [
-            EventType::EquityBarsSyncCompleted,
-            EventType::EquityPredictionsRequested,
-            EventType::PortfolioRebalanceCompleted,
-            EventType::DatabaseBackupCompleted,
-        ] {
-            assert_eq!(event_type.to_string(), event_type.as_str());
+        for &(event_type, stored) in ALL_EVENT_TYPES {
+            assert_eq!(event_type.to_string(), stored);
         }
     }
 
@@ -449,6 +679,7 @@ mod tests {
         assert_eq!(CONSUMER_INFERENCE, "inference");
         assert_eq!(CONSUMER_PORTFOLIO, "portfolio");
         assert_eq!(CONSUMER_PORTFOLIO_LIQUIDATION, "portfolio-liquidation");
+        assert_eq!(CONSUMER_PORTFOLIO_SESSION, "portfolio-session");
         assert_eq!(CONSUMER_DATA_EQUITY_BARS_SYNC, "data-equity-bars-sync");
         assert_eq!(CONSUMER_DATA_DATABASE_EXPORT, "data-database-export");
         assert_eq!(CONSUMER_DATA_DATABASE_BACKUP, "data-database-backup");
@@ -460,7 +691,7 @@ mod tests {
         make_runtime().block_on(async {
             let result = emit_event(
                 &lazy_pool(),
-                EventType::EquityBarsSyncCompleted,
+                EventType::EquityBarsSync(Outcome::Completed),
                 &serde_json::json!({}),
             )
             .await;
@@ -489,173 +720,27 @@ mod tests {
     #[test]
     fn test_latest_event_after_compiles() {
         make_runtime().block_on(async {
-            assert!(
-                latest_event_after(&lazy_pool(), EventType::EquityPredictionsCompleted, 0)
-                    .await
-                    .is_err()
-            );
+            assert!(latest_event_after(
+                &lazy_pool(),
+                EventType::EquityPredictions(Outcome::Completed),
+                0
+            )
+            .await
+            .is_err());
         });
     }
 
     #[test]
     fn test_events_after_compiles() {
         make_runtime().block_on(async {
-            assert!(
-                events_after(&lazy_pool(), EventType::DatabaseExportRequested, 0)
-                    .await
-                    .is_err()
-            );
+            assert!(events_after(
+                &lazy_pool(),
+                EventType::DatabaseExport(Outcome::Requested),
+                0
+            )
+            .await
+            .is_err());
         });
-    }
-
-    #[test]
-    fn test_event_type_as_str_all_variants() {
-        // Exhaustively verify every variant maps to its expected snake_case string.
-        let cases: &[(EventType, &str)] = &[
-            (
-                EventType::EquityBarsSyncRequested,
-                "equity_bars_sync_requested",
-            ),
-            (EventType::EquityBarsSyncStarted, "equity_bars_sync_started"),
-            (
-                EventType::EquityBarsSyncCompleted,
-                "equity_bars_sync_completed",
-            ),
-            (EventType::EquityBarsSyncErrored, "equity_bars_sync_errored"),
-            (
-                EventType::DatabaseExportRequested,
-                "database_export_requested",
-            ),
-            (EventType::DatabaseExportStarted, "database_export_started"),
-            (
-                EventType::DatabaseExportCompleted,
-                "database_export_completed",
-            ),
-            (EventType::DatabaseExportErrored, "database_export_errored"),
-            (
-                EventType::DatabaseBackupRequested,
-                "database_backup_requested",
-            ),
-            (EventType::DatabaseBackupStarted, "database_backup_started"),
-            (
-                EventType::DatabaseBackupCompleted,
-                "database_backup_completed",
-            ),
-            (EventType::DatabaseBackupErrored, "database_backup_errored"),
-            (
-                EventType::DatabasePurgeRequested,
-                "database_purge_requested",
-            ),
-            (EventType::DatabasePurgeStarted, "database_purge_started"),
-            (
-                EventType::DatabasePurgeCompleted,
-                "database_purge_completed",
-            ),
-            (EventType::DatabasePurgeErrored, "database_purge_errored"),
-            (EventType::TradingSessionStarted, "trading_session_started"),
-            (
-                EventType::PortfolioEvaluationRequested,
-                "portfolio_evaluation_requested",
-            ),
-            (
-                EventType::EquityPredictionsRequested,
-                "equity_predictions_requested",
-            ),
-            (
-                EventType::EquityPredictionsStarted,
-                "equity_predictions_started",
-            ),
-            (
-                EventType::EquityPredictionsCompleted,
-                "equity_predictions_completed",
-            ),
-            (
-                EventType::EquityPredictionsErrored,
-                "equity_predictions_errored",
-            ),
-            (
-                EventType::PortfolioRebalanceStarted,
-                "portfolio_rebalance_started",
-            ),
-            (
-                EventType::PortfolioRebalanceCompleted,
-                "portfolio_rebalance_completed",
-            ),
-            (
-                EventType::PortfolioRebalanceErrored,
-                "portfolio_rebalance_errored",
-            ),
-            (
-                EventType::PortfolioLiquidationRequested,
-                "portfolio_liquidation_requested",
-            ),
-            (
-                EventType::PortfolioLiquidationStarted,
-                "portfolio_liquidation_started",
-            ),
-            (
-                EventType::PortfolioLiquidationCompleted,
-                "portfolio_liquidation_completed",
-            ),
-            (
-                EventType::PortfolioLiquidationErrored,
-                "portfolio_liquidation_errored",
-            ),
-            (EventType::StressTest, "stress_test"),
-        ];
-        for (event_type, expected) in cases {
-            assert_eq!(
-                event_type.as_str(),
-                *expected,
-                "as_str mismatch for {:?}",
-                event_type
-            );
-        }
-    }
-
-    #[test]
-    fn test_event_type_display_matches_as_str_all_variants() {
-        // Display must equal as_str() for every variant.
-        let all: &[EventType] = &[
-            EventType::EquityBarsSyncRequested,
-            EventType::EquityBarsSyncStarted,
-            EventType::EquityBarsSyncCompleted,
-            EventType::EquityBarsSyncErrored,
-            EventType::DatabaseExportRequested,
-            EventType::DatabaseExportStarted,
-            EventType::DatabaseExportCompleted,
-            EventType::DatabaseExportErrored,
-            EventType::DatabaseBackupRequested,
-            EventType::DatabaseBackupStarted,
-            EventType::DatabaseBackupCompleted,
-            EventType::DatabaseBackupErrored,
-            EventType::DatabasePurgeRequested,
-            EventType::DatabasePurgeStarted,
-            EventType::DatabasePurgeCompleted,
-            EventType::DatabasePurgeErrored,
-            EventType::EquityPredictionsRequested,
-            EventType::EquityPredictionsStarted,
-            EventType::EquityPredictionsCompleted,
-            EventType::EquityPredictionsErrored,
-            EventType::TradingSessionStarted,
-            EventType::PortfolioEvaluationRequested,
-            EventType::PortfolioRebalanceStarted,
-            EventType::PortfolioRebalanceCompleted,
-            EventType::PortfolioRebalanceErrored,
-            EventType::PortfolioLiquidationRequested,
-            EventType::PortfolioLiquidationStarted,
-            EventType::PortfolioLiquidationCompleted,
-            EventType::PortfolioLiquidationErrored,
-            EventType::StressTest,
-        ];
-        for event_type in all {
-            assert_eq!(
-                event_type.to_string(),
-                event_type.as_str(),
-                "Display != as_str for {:?}",
-                event_type
-            );
-        }
     }
 
     #[test]
@@ -666,7 +751,7 @@ mod tests {
         );
         assert_ne!(
             EventType::PortfolioEvaluationRequested,
-            EventType::EquityPredictionsStarted
+            EventType::EquityPredictions(Outcome::Started)
         );
         assert_ne!(
             EventType::TradingSessionStarted,
@@ -677,7 +762,7 @@ mod tests {
     #[test]
     fn test_event_type_copy() {
         // EventType derives Copy so it can be passed by value freely.
-        let original = EventType::PortfolioRebalanceStarted;
+        let original = EventType::PortfolioRebalance(Outcome::Started);
         let copied = original;
         assert_eq!(original, copied);
     }

--- a/src/dashboard/cache.rs
+++ b/src/dashboard/cache.rs
@@ -17,9 +17,9 @@ use rust_decimal::Decimal;
 use sqlx::postgres::PgListener;
 use sqlx::PgPool;
 use tokio::sync::RwLock;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
-use crate::common::events::{EventNotification, EventType};
+use crate::common::events::{EventNotification, EventType, NotificationParseFailure};
 use crate::domain::market::{PairID, Ticker};
 use crate::domain::trading::CloseReason;
 
@@ -285,12 +285,19 @@ pub fn spawn_event_listener_task(state: SharedState, pool: PgPool) {
             loop {
                 match listener.recv().await {
                     Ok(notification) => {
-                        let Some(parsed) = EventNotification::parse(notification.payload()) else {
-                            warn!(
-                                payload = notification.payload(),
-                                "Skipping unparseable or unrecognised event notification"
-                            );
-                            continue;
+                        let parsed = match EventNotification::parse(notification.payload()) {
+                            Ok(parsed) => parsed,
+                            Err(NotificationParseFailure::Malformed) => {
+                                warn!(
+                                    payload = notification.payload(),
+                                    "Skipping malformed event notification"
+                                );
+                                continue;
+                            }
+                            Err(NotificationParseFailure::UnknownEventType(event_type)) => {
+                                debug!(event_type, "Skipping event type this build does not know");
+                                continue;
+                            }
                         };
                         let entry = EventEntry {
                             event_id: parsed.event_id(),

--- a/src/dashboard/cache.rs
+++ b/src/dashboard/cache.rs
@@ -19,7 +19,7 @@ use sqlx::PgPool;
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
-use crate::common::events::EventType;
+use crate::common::events::{EventNotification, EventType};
 use crate::domain::market::{PairID, Ticker};
 use crate::domain::trading::CloseReason;
 
@@ -285,40 +285,17 @@ pub fn spawn_event_listener_task(state: SharedState, pool: PgPool) {
             loop {
                 match listener.recv().await {
                     Ok(notification) => {
-                        let parsed: serde_json::Value =
-                            match serde_json::from_str(notification.payload()) {
-                                Ok(value) => value,
-                                Err(error) => {
-                                    warn!(error = %error, "Invalid event notification payload");
-                                    continue;
-                                }
-                            };
-                        let Some(event_id) =
-                            parsed.get("event_id").and_then(serde_json::Value::as_i64)
-                        else {
-                            warn!("Event notification missing event_id field");
-                            continue;
-                        };
-                        let Some(event_type_str) =
-                            parsed.get("event_type").and_then(serde_json::Value::as_str)
-                        else {
-                            warn!("Event notification missing event_type field");
-                            continue;
-                        };
-                        let Some(event_type) = EventType::parse(event_type_str) else {
+                        let Some(parsed) = EventNotification::parse(notification.payload()) else {
                             warn!(
-                                event_type = event_type_str,
-                                "Unknown event type in notification, skipping"
+                                payload = notification.payload(),
+                                "Skipping unparseable or unrecognised event notification"
                             );
                             continue;
                         };
                         let entry = EventEntry {
-                            event_id,
-                            event_type,
-                            payload: parsed
-                                .get("payload")
-                                .cloned()
-                                .unwrap_or(serde_json::Value::Null),
+                            event_id: parsed.event_id(),
+                            event_type: parsed.event_type(),
+                            payload: parsed.into_payload(),
                             received_at: Utc::now(),
                         };
                         let mut guard = state.write().await;

--- a/src/dashboard/cache.rs
+++ b/src/dashboard/cache.rs
@@ -341,6 +341,7 @@ pub fn spawn_event_listener_task(state: SharedState, pool: PgPool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::events::Outcome;
 
     #[test]
     fn test_dashboard_state_default_is_empty() {
@@ -398,12 +399,15 @@ mod tests {
     fn test_event_entry_fields() {
         let entry = EventEntry {
             event_id: 42,
-            event_type: EventType::PortfolioRebalanceCompleted,
+            event_type: EventType::PortfolioRebalance(Outcome::Completed),
             payload: serde_json::json!({"session_id": "abc"}),
             received_at: Utc::now(),
         };
         assert_eq!(entry.event_id, 42);
-        assert_eq!(entry.event_type, EventType::PortfolioRebalanceCompleted);
+        assert_eq!(
+            entry.event_type,
+            EventType::PortfolioRebalance(Outcome::Completed)
+        );
         assert_eq!(entry.payload["session_id"], "abc");
     }
 

--- a/src/dashboard/html.rs
+++ b/src/dashboard/html.rs
@@ -517,7 +517,7 @@ tr:hover { background-color: rgba(255, 180, 0, 0.1); }
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::events::EventType;
+    use crate::common::events::{EventType, Outcome};
     use crate::dashboard::cache::{
         ClosedTrade, ClosedTradesSummary, DashboardState, EventEntry, ModelRunInformation,
         OpenPosition, PerformanceSnapshot, PeriodReturns, PredictionRow,
@@ -765,7 +765,7 @@ mod tests {
         let mut state = DashboardState::default();
         state.events.push_back(EventEntry {
             event_id: 1,
-            event_type: EventType::PortfolioRebalanceCompleted,
+            event_type: EventType::PortfolioRebalance(Outcome::Completed),
             payload: serde_json::json!({"session_id": "abc"}),
             received_at: Utc::now(),
         });
@@ -780,7 +780,7 @@ mod tests {
         for index in 0..20 {
             state.events.push_back(EventEntry {
                 event_id: index,
-                event_type: EventType::PortfolioRebalanceCompleted,
+                event_type: EventType::PortfolioRebalance(Outcome::Completed),
                 payload: serde_json::json!({"index": index}),
                 received_at: Utc::now(),
             });
@@ -917,7 +917,7 @@ mod tests {
         let mut state = DashboardState::default();
         state.events.push_back(EventEntry {
             event_id: 1,
-            event_type: EventType::PortfolioRebalanceCompleted,
+            event_type: EventType::PortfolioRebalance(Outcome::Completed),
             payload: serde_json::json!({"key": "<script>alert(1)</script>"}),
             received_at: Utc::now(),
         });

--- a/src/data/database.rs
+++ b/src/data/database.rs
@@ -2,7 +2,8 @@ use crate::domain::market::{EquityBar, EquityDetail, PairID, Ticker};
 use crate::domain::predictions::{EquityPrediction, ModelRun, ModelRunStatus};
 use crate::domain::trading::{
     AllocationAction, AllocationSide, EquityAllocation, EquityOrder, EquityPair, EquityPairStatus,
-    EquityPortfolioSnapshot, EquityRebalanceSession, RebalanceSessionStatus, SnapshotType,
+    EquityPortfolioSnapshot, EquityRebalanceSession, RebalanceSessionStatus, RebalanceTrigger,
+    SnapshotType,
 };
 use chrono::{DateTime, Days, NaiveDate, Utc};
 use sqlx::PgPool;
@@ -319,7 +320,11 @@ pub async fn query_equity_rebalance_sessions(
             Ok(EquityRebalanceSession::new(
                 row.id,
                 row.triggered_at,
-                row.trigger_reason,
+                RebalanceTrigger::parse(&row.trigger_reason).ok_or_else(|| {
+                    sqlx::Error::Decode(
+                        format!("Invalid rebalance trigger: {}", row.trigger_reason).into(),
+                    )
+                })?,
                 row.model_run_id,
                 row.completed_at,
                 status,

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -185,7 +185,7 @@ fn create_equity_rebalance_session_dataframe(
     df!(
         "id" => sessions.iter().map(|session| session.id().to_string()).collect::<Vec<String>>(),
         "triggered_at" => sessions.iter().map(|session| session.triggered_at().timestamp_millis()).collect::<Vec<i64>>(),
-        "trigger_reason" => sessions.iter().map(|session| session.trigger_reason()).collect::<Vec<&str>>(),
+        "trigger_reason" => sessions.iter().map(|session| session.trigger_reason().as_str()).collect::<Vec<&str>>(),
         "model_run_id" => sessions.iter().map(|session| session.model_run_id()).collect::<Vec<Option<&str>>>(),
         "completed_at" => sessions.iter().map(|session| session.completed_at().map(|timestamp| timestamp.timestamp_millis())).collect::<Vec<Option<i64>>>(),
         "status" => sessions.iter().map(|session| session.status().as_str()).collect::<Vec<&str>>(),
@@ -344,7 +344,7 @@ mod tests {
         vec![EquityRebalanceSession::new(
             "550e8400-e29b-41d4-a716-446655440001".parse().unwrap(),
             Utc::now(),
-            "portfolio_evaluation".to_string(),
+            crate::domain::trading::RebalanceTrigger::SessionStart,
             Some("run-abc123".to_string()),
             None,
             RebalanceSessionStatus::Completed,
@@ -656,7 +656,7 @@ mod tests {
         let sessions = vec![crate::domain::trading::EquityRebalanceSession::new(
             "550e8400-e29b-41d4-a716-446655440099".parse().unwrap(),
             chrono::Utc::now(),
-            "portfolio_evaluation".to_string(),
+            crate::domain::trading::RebalanceTrigger::SessionStart,
             None,
             None,
             crate::domain::trading::RebalanceSessionStatus::Completed,
@@ -1045,7 +1045,7 @@ mod tests {
         let sessions = vec![EquityRebalanceSession::new(
             "550e8400-e29b-41d4-a716-446655440088".parse().unwrap(),
             Utc::now(),
-            "manual".to_string(),
+            crate::domain::trading::RebalanceTrigger::Manual,
             None,
             None,
             RebalanceSessionStatus::Failed,

--- a/src/data/scheduler.rs
+++ b/src/data/scheduler.rs
@@ -416,7 +416,7 @@ async fn run_listener(
     run_event_listener(
         pool,
         shutdown_token,
-        CONSUMER_DATA_EQUITY_BARS_SYNC,
+        "data",
         || run_startup_catch_up(state, pool),
         |notification| async move {
             let event_id = notification.event_id();
@@ -438,10 +438,28 @@ async fn run_listener(
                     handle_database_purge(pool, event_id).await;
                 }
                 // Every consumer receives every event; the rest belong to other
-                // services or are audit records. The match exists so a new
-                // variant is a compile-time decision rather than a silent
-                // omission.
-                _ => {}
+                // services or are audit records. Listed rather than caught by a
+                // wildcard so that adding a family, or an `Outcome` to one of
+                // the families this consumer handles, fails the build here
+                // instead of being silently ignored.
+                EventType::EquityBarsSync(
+                    Outcome::Started | Outcome::Completed | Outcome::Errored,
+                )
+                | EventType::DatabaseExport(
+                    Outcome::Started | Outcome::Completed | Outcome::Errored,
+                )
+                | EventType::DatabaseBackup(
+                    Outcome::Started | Outcome::Completed | Outcome::Errored,
+                )
+                | EventType::DatabasePurge(
+                    Outcome::Started | Outcome::Completed | Outcome::Errored,
+                )
+                | EventType::EquityPredictions(_)
+                | EventType::PortfolioRebalance(_)
+                | EventType::PortfolioLiquidation(_)
+                | EventType::TradingSessionStarted
+                | EventType::PortfolioEvaluationRequested
+                | EventType::StressTest => {}
             }
         },
     )

--- a/src/data/scheduler.rs
+++ b/src/data/scheduler.rs
@@ -1,6 +1,6 @@
 use crate::common::events::{
     emit_event, events_after, get_consumer_offset, latest_event_after, update_consumer_offset,
-    EventType, CONSUMER_DATA_DATABASE_BACKUP, CONSUMER_DATA_DATABASE_EXPORT,
+    EventType, Outcome, CONSUMER_DATA_DATABASE_BACKUP, CONSUMER_DATA_DATABASE_EXPORT,
     CONSUMER_DATA_DATABASE_PURGE, CONSUMER_DATA_EQUITY_BARS_SYNC,
 };
 use crate::data::equity_bars::fetch_and_store_equity_bars;
@@ -432,8 +432,12 @@ async fn run_listener(
 
     // Catch up on any missed one-time actionable events (latest missed instance each).
     let sync_offset = get_consumer_offset(pool, CONSUMER_DATA_EQUITY_BARS_SYNC).await?;
-    if let Some(event_id) =
-        latest_event_after(pool, EventType::EquityBarsSyncRequested, sync_offset).await?
+    if let Some(event_id) = latest_event_after(
+        pool,
+        EventType::EquityBarsSync(Outcome::Requested),
+        sync_offset,
+    )
+    .await?
     {
         info!(event_id, "Catching up on missed equity_bars_sync_requested");
         handle_equity_bars_sync(state, pool, event_id).await;
@@ -443,24 +447,36 @@ async fn run_listener(
     // replayed in order. Skipping to the latest would permanently lose export dates
     // for any intermediate days the service was down.
     let export_offset = get_consumer_offset(pool, CONSUMER_DATA_DATABASE_EXPORT).await?;
-    for (event_id, payload) in
-        events_after(pool, EventType::DatabaseExportRequested, export_offset).await?
+    for (event_id, payload) in events_after(
+        pool,
+        EventType::DatabaseExport(Outcome::Requested),
+        export_offset,
+    )
+    .await?
     {
         info!(event_id, "Catching up on missed database_export_requested");
         handle_database_export(state, pool, event_id, &payload).await;
     }
 
     let backup_offset = get_consumer_offset(pool, CONSUMER_DATA_DATABASE_BACKUP).await?;
-    if let Some(event_id) =
-        latest_event_after(pool, EventType::DatabaseBackupRequested, backup_offset).await?
+    if let Some(event_id) = latest_event_after(
+        pool,
+        EventType::DatabaseBackup(Outcome::Requested),
+        backup_offset,
+    )
+    .await?
     {
         info!(event_id, "Catching up on missed database_backup_requested");
         handle_database_backup(state, pool, event_id).await;
     }
 
     let purge_offset = get_consumer_offset(pool, CONSUMER_DATA_DATABASE_PURGE).await?;
-    if let Some(event_id) =
-        latest_event_after(pool, EventType::DatabasePurgeRequested, purge_offset).await?
+    if let Some(event_id) = latest_event_after(
+        pool,
+        EventType::DatabasePurge(Outcome::Requested),
+        purge_offset,
+    )
+    .await?
     {
         info!(event_id, "Catching up on missed database_purge_requested");
         handle_database_purge(pool, event_id).await;
@@ -491,16 +507,16 @@ async fn run_listener(
         let empty_payload = serde_json::Value::Object(Default::default());
         let payload = parsed.get("payload").unwrap_or(&empty_payload);
 
-        if event_type == EventType::EquityBarsSyncRequested.as_str() {
+        if event_type == EventType::EquityBarsSync(Outcome::Requested).as_str() {
             info!(event_id, "Received equity_bars_sync_requested");
             handle_equity_bars_sync(state, pool, event_id).await;
-        } else if event_type == EventType::DatabaseExportRequested.as_str() {
+        } else if event_type == EventType::DatabaseExport(Outcome::Requested).as_str() {
             info!(event_id, "Received database_export_requested");
             handle_database_export(state, pool, event_id, payload).await;
-        } else if event_type == EventType::DatabaseBackupRequested.as_str() {
+        } else if event_type == EventType::DatabaseBackup(Outcome::Requested).as_str() {
             info!(event_id, "Received database_backup_requested");
             handle_database_backup(state, pool, event_id).await;
-        } else if event_type == EventType::DatabasePurgeRequested.as_str() {
+        } else if event_type == EventType::DatabasePurge(Outcome::Requested).as_str() {
             info!(event_id, "Received database_purge_requested");
             handle_database_purge(pool, event_id).await;
         }
@@ -512,7 +528,7 @@ async fn run_listener(
 async fn handle_equity_bars_sync(state: &State, pool: &sqlx::PgPool, event_id: i64) {
     if let Err(error) = emit_event(
         pool,
-        EventType::EquityBarsSyncStarted,
+        EventType::EquityBarsSync(Outcome::Started),
         &serde_json::json!({}),
     )
     .await
@@ -525,7 +541,7 @@ async fn handle_equity_bars_sync(state: &State, pool: &sqlx::PgPool, event_id: i
             info!(rows = bar_count, "Equity bar sync completed");
             if let Err(error) = emit_event(
                 pool,
-                EventType::EquityBarsSyncCompleted,
+                EventType::EquityBarsSync(Outcome::Completed),
                 &serde_json::json!({"bar_count": bar_count}),
             )
             .await
@@ -537,7 +553,7 @@ async fn handle_equity_bars_sync(state: &State, pool: &sqlx::PgPool, event_id: i
             info!("No equity bar data available for sync");
             if let Err(error) = emit_event(
                 pool,
-                EventType::EquityBarsSyncCompleted,
+                EventType::EquityBarsSync(Outcome::Completed),
                 &serde_json::json!({"bar_count": 0}),
             )
             .await
@@ -549,7 +565,7 @@ async fn handle_equity_bars_sync(state: &State, pool: &sqlx::PgPool, event_id: i
             error!(error = %error, "Equity bar sync errored");
             if let Err(emit_error) = emit_event(
                 pool,
-                EventType::EquityBarsSyncErrored,
+                EventType::EquityBarsSync(Outcome::Errored),
                 &serde_json::json!({"error": error}),
             )
             .await
@@ -616,7 +632,7 @@ async fn handle_database_export(
     let export_date = export_date_from_payload(payload);
     if let Err(error) = emit_event(
         pool,
-        EventType::DatabaseExportStarted,
+        EventType::DatabaseExport(Outcome::Started),
         &serde_json::json!({"date": export_date.to_string()}),
     )
     .await
@@ -629,7 +645,7 @@ async fn handle_database_export(
             info!(rows = count, "Database export completed");
             if let Err(error) = emit_event(
                 pool,
-                EventType::DatabaseExportCompleted,
+                EventType::DatabaseExport(Outcome::Completed),
                 &serde_json::json!({"count": count, "date": export_date.to_string()}),
             )
             .await
@@ -640,7 +656,7 @@ async fn handle_database_export(
             // Chain: export success → backup
             if let Err(error) = emit_event(
                 pool,
-                EventType::DatabaseBackupRequested,
+                EventType::DatabaseBackup(Outcome::Requested),
                 &serde_json::json!({}),
             )
             .await
@@ -652,7 +668,7 @@ async fn handle_database_export(
             error!(error = %error, "Database export errored");
             if let Err(emit_error) = emit_event(
                 pool,
-                EventType::DatabaseExportErrored,
+                EventType::DatabaseExport(Outcome::Errored),
                 &serde_json::json!({"error": error, "date": export_date.to_string()}),
             )
             .await
@@ -671,7 +687,7 @@ async fn handle_database_export(
 async fn handle_database_backup(state: &State, pool: &sqlx::PgPool, event_id: i64) {
     if let Err(error) = emit_event(
         pool,
-        EventType::DatabaseBackupStarted,
+        EventType::DatabaseBackup(Outcome::Started),
         &serde_json::json!({}),
     )
     .await
@@ -684,7 +700,7 @@ async fn handle_database_backup(state: &State, pool: &sqlx::PgPool, event_id: i6
             info!(bytes = byte_count, "Database backup completed");
             if let Err(error) = emit_event(
                 pool,
-                EventType::DatabaseBackupCompleted,
+                EventType::DatabaseBackup(Outcome::Completed),
                 &serde_json::json!({"byte_count": byte_count}),
             )
             .await
@@ -694,7 +710,7 @@ async fn handle_database_backup(state: &State, pool: &sqlx::PgPool, event_id: i6
             // Chain: backup success → purge
             if let Err(chain_error) = emit_event(
                 pool,
-                EventType::DatabasePurgeRequested,
+                EventType::DatabasePurge(Outcome::Requested),
                 &serde_json::json!({}),
             )
             .await
@@ -706,7 +722,7 @@ async fn handle_database_backup(state: &State, pool: &sqlx::PgPool, event_id: i6
             error!(error = %error, "Database backup errored");
             if let Err(emit_error) = emit_event(
                 pool,
-                EventType::DatabaseBackupErrored,
+                EventType::DatabaseBackup(Outcome::Errored),
                 &serde_json::json!({"error": error}),
             )
             .await
@@ -734,12 +750,12 @@ fn purge_outcome_event(
 ) -> (EventType, serde_json::Value) {
     if summary.failed_tables.is_empty() {
         (
-            EventType::DatabasePurgeCompleted,
+            EventType::DatabasePurge(Outcome::Completed),
             serde_json::json!({ "total_rows_deleted": total_rows_deleted }),
         )
     } else {
         (
-            EventType::DatabasePurgeErrored,
+            EventType::DatabasePurge(Outcome::Errored),
             serde_json::json!({
                 "total_rows_deleted": total_rows_deleted,
                 "failed_tables": summary.failed_tables,
@@ -751,7 +767,7 @@ fn purge_outcome_event(
 async fn handle_database_purge(pool: &sqlx::PgPool, event_id: i64) {
     if let Err(error) = emit_event(
         pool,
-        EventType::DatabasePurgeStarted,
+        EventType::DatabasePurge(Outcome::Started),
         &serde_json::json!({}),
     )
     .await
@@ -1450,7 +1466,9 @@ mod tests {
         let (event_type, payload) = purge_outcome_event(&summary, 42);
         assert_eq!(
             event_type,
-            crate::common::events::EventType::DatabasePurgeCompleted
+            crate::common::events::EventType::DatabasePurge(
+                crate::common::events::Outcome::Completed
+            )
         );
         assert_eq!(payload["total_rows_deleted"], 42);
         assert!(payload.get("failed_tables").is_none());
@@ -1468,7 +1486,9 @@ mod tests {
         let (event_type, payload) = purge_outcome_event(&summary, 42);
         assert_eq!(
             event_type,
-            crate::common::events::EventType::DatabasePurgeErrored
+            crate::common::events::EventType::DatabasePurge(
+                crate::common::events::Outcome::Errored
+            )
         );
         assert_eq!(payload["total_rows_deleted"], 42);
         assert_eq!(payload["failed_tables"][0], "equity_pairs");
@@ -1487,7 +1507,9 @@ mod tests {
         let (event_type, payload) = purge_outcome_event(&summary, 0);
         assert_eq!(
             event_type,
-            crate::common::events::EventType::DatabasePurgeErrored
+            crate::common::events::EventType::DatabasePurge(
+                crate::common::events::Outcome::Errored
+            )
         );
         assert_eq!(payload["failed_tables"].as_array().unwrap().len(), 3);
         assert_eq!(payload["total_rows_deleted"], 0);

--- a/src/data/scheduler.rs
+++ b/src/data/scheduler.rs
@@ -1,7 +1,7 @@
 use crate::common::events::{
-    emit_event, events_after, get_consumer_offset, latest_event_after, update_consumer_offset,
-    EventType, Outcome, CONSUMER_DATA_DATABASE_BACKUP, CONSUMER_DATA_DATABASE_EXPORT,
-    CONSUMER_DATA_DATABASE_PURGE, CONSUMER_DATA_EQUITY_BARS_SYNC,
+    emit_event, events_after, get_consumer_offset, latest_event_after, run_event_listener,
+    update_consumer_offset, EventType, Outcome, CONSUMER_DATA_DATABASE_BACKUP,
+    CONSUMER_DATA_DATABASE_EXPORT, CONSUMER_DATA_DATABASE_PURGE, CONSUMER_DATA_EQUITY_BARS_SYNC,
 };
 use crate::data::equity_bars::fetch_and_store_equity_bars;
 use crate::data::equity_details;
@@ -12,7 +12,6 @@ use crate::data::types::TradingDate;
 use aws_sdk_s3::primitives::ByteStream;
 use chrono::{DateTime, Datelike, NaiveDate, Utc};
 use chrono_tz::US::Eastern;
-use sqlx::postgres::PgListener;
 use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
@@ -414,20 +413,52 @@ async fn run_listener(
     pool: &sqlx::PgPool,
     shutdown_token: &CancellationToken,
 ) -> Result<(), sqlx::Error> {
-    let mut listener = PgListener::connect_with(pool).await?;
-    listener.listen("events").await?;
-    info!("Event consumer connected, listening on channel 'events'");
+    run_event_listener(
+        pool,
+        shutdown_token,
+        CONSUMER_DATA_EQUITY_BARS_SYNC,
+        || run_startup_catch_up(state, pool),
+        |notification| async move {
+            let event_id = notification.event_id();
+            match notification.event_type() {
+                EventType::EquityBarsSync(Outcome::Requested) => {
+                    info!(event_id, "Received equity_bars_sync_requested");
+                    handle_equity_bars_sync(state, pool, event_id).await;
+                }
+                EventType::DatabaseExport(Outcome::Requested) => {
+                    info!(event_id, "Received database_export_requested");
+                    handle_database_export(state, pool, event_id, notification.payload()).await;
+                }
+                EventType::DatabaseBackup(Outcome::Requested) => {
+                    info!(event_id, "Received database_backup_requested");
+                    handle_database_backup(state, pool, event_id).await;
+                }
+                EventType::DatabasePurge(Outcome::Requested) => {
+                    info!(event_id, "Received database_purge_requested");
+                    handle_database_purge(pool, event_id).await;
+                }
+                // Every consumer receives every event; the rest belong to other
+                // services or are audit records. The match exists so a new
+                // variant is a compile-time decision rather than a silent
+                // omission.
+                _ => {}
+            }
+        },
+    )
+    .await
+}
 
+/// Validates the schedule and replays the events this consumer missed.
+///
+/// Runs on every connection, not once per process: a reconnect means delivery
+/// had a gap, and the same replay that covers a restart covers that gap too.
+async fn run_startup_catch_up(state: &State, pool: &sqlx::PgPool) -> Result<(), sqlx::Error> {
     // Validate pg_cron jobs and event freshness on startup. Event freshness
     // is only meaningful when pg_cron is installed (otherwise no cron-triggered
     // events exist and every check would produce a false warning).
     let pg_cron_available = validate_cron_jobs(pool).await;
     if pg_cron_available {
         check_event_freshness(pool).await;
-    }
-
-    if shutdown_token.is_cancelled() {
-        return Ok(());
     }
 
     // Catch up on any missed one-time actionable events (latest missed instance each).
@@ -480,46 +511,6 @@ async fn run_listener(
     {
         info!(event_id, "Catching up on missed database_purge_requested");
         handle_database_purge(pool, event_id).await;
-    }
-
-    // Main event loop.
-    loop {
-        let notification = tokio::select! {
-            result = listener.recv() => result?,
-            _ = shutdown_token.cancelled() => {
-                info!("Shutdown signal received, draining");
-                break;
-            }
-        };
-        let parsed: serde_json::Value = match serde_json::from_str(notification.payload()) {
-            Ok(value) => value,
-            Err(_) => continue,
-        };
-
-        let event_type = parsed
-            .get("event_type")
-            .and_then(|value| value.as_str())
-            .unwrap_or("");
-        let event_id = parsed
-            .get("event_id")
-            .and_then(|value| value.as_i64())
-            .unwrap_or(0);
-        let empty_payload = serde_json::Value::Object(Default::default());
-        let payload = parsed.get("payload").unwrap_or(&empty_payload);
-
-        if event_type == EventType::EquityBarsSync(Outcome::Requested).as_str() {
-            info!(event_id, "Received equity_bars_sync_requested");
-            handle_equity_bars_sync(state, pool, event_id).await;
-        } else if event_type == EventType::DatabaseExport(Outcome::Requested).as_str() {
-            info!(event_id, "Received database_export_requested");
-            handle_database_export(state, pool, event_id, payload).await;
-        } else if event_type == EventType::DatabaseBackup(Outcome::Requested).as_str() {
-            info!(event_id, "Received database_backup_requested");
-            handle_database_backup(state, pool, event_id).await;
-        } else if event_type == EventType::DatabasePurge(Outcome::Requested).as_str() {
-            info!(event_id, "Received database_purge_requested");
-            handle_database_purge(pool, event_id).await;
-        }
     }
 
     Ok(())

--- a/src/domain/trading.rs
+++ b/src/domain/trading.rs
@@ -323,12 +323,73 @@ impl std::fmt::Display for CloseReason {
     }
 }
 
+/// What caused a rebalance pass to run.
+///
+/// Stored in `equity_rebalance_sessions.trigger_reason`, which is `TEXT` and was
+/// previously written with the same literal from every call site. A closed set
+/// makes the first question anyone asks of that table — why did this pass run —
+/// answerable from the data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RebalanceTrigger {
+    /// The trading session opened.
+    SessionStart,
+    /// A live quote moved a spread across a close threshold.
+    LiveCrossing,
+    /// A prediction run completed and produced a fresh set to act on.
+    PredictionRefresh,
+    /// A session-start pass opened nothing and the retry timer fired.
+    EntryRetry,
+    /// Requested out of band rather than by the system itself.
+    Manual,
+    /// Written by every pass before the trigger became a closed set.
+    ///
+    /// Nothing emits this. It exists so rows already in
+    /// `equity_rebalance_sessions` still round-trip, rather than being silently
+    /// relabelled as one of the real triggers.
+    Legacy,
+}
+
+impl RebalanceTrigger {
+    /// Returns the canonical string stored in `trigger_reason`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SessionStart => "session_start",
+            Self::LiveCrossing => "live_crossing",
+            Self::PredictionRefresh => "prediction_refresh",
+            Self::EntryRetry => "entry_retry",
+            Self::Manual => "manual",
+            Self::Legacy => "portfolio_evaluation",
+        }
+    }
+
+    /// Parses a stored `trigger_reason`. Returns `None` for unknown values,
+    /// which includes every row written before this became an enum.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "session_start" => Some(Self::SessionStart),
+            "live_crossing" => Some(Self::LiveCrossing),
+            "prediction_refresh" => Some(Self::PredictionRefresh),
+            "entry_retry" => Some(Self::EntryRetry),
+            "manual" => Some(Self::Manual),
+            "portfolio_evaluation" => Some(Self::Legacy),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for RebalanceTrigger {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
 /// Groups one full rebalance cycle from allocation through order submission.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EquityRebalanceSession {
     id: Uuid,
     triggered_at: DateTime<Utc>,
-    trigger_reason: String,
+    trigger_reason: RebalanceTrigger,
     /// References `model_runs.run_id`; nullable when the model run is unavailable.
     model_run_id: Option<String>,
     completed_at: Option<DateTime<Utc>>,
@@ -340,7 +401,7 @@ impl EquityRebalanceSession {
     pub fn new(
         id: Uuid,
         triggered_at: DateTime<Utc>,
-        trigger_reason: String,
+        trigger_reason: RebalanceTrigger,
         model_run_id: Option<String>,
         completed_at: Option<DateTime<Utc>>,
         status: RebalanceSessionStatus,
@@ -363,8 +424,8 @@ impl EquityRebalanceSession {
         self.triggered_at
     }
 
-    pub fn trigger_reason(&self) -> &str {
-        &self.trigger_reason
+    pub fn trigger_reason(&self) -> RebalanceTrigger {
+        self.trigger_reason
     }
 
     pub fn model_run_id(&self) -> Option<&str> {
@@ -983,6 +1044,57 @@ mod tests {
     use rust_decimal::Decimal;
     use uuid::Uuid;
 
+    /// Every trigger paired with the exact value stored in `trigger_reason`.
+    const ALL_REBALANCE_TRIGGERS: &[(RebalanceTrigger, &str)] = &[
+        (RebalanceTrigger::SessionStart, "session_start"),
+        (RebalanceTrigger::LiveCrossing, "live_crossing"),
+        (RebalanceTrigger::PredictionRefresh, "prediction_refresh"),
+        (RebalanceTrigger::EntryRetry, "entry_retry"),
+        (RebalanceTrigger::Manual, "manual"),
+        (RebalanceTrigger::Legacy, "portfolio_evaluation"),
+    ];
+
+    #[test]
+    fn test_rebalance_trigger_round_trips_every_variant() {
+        for &(trigger, stored) in ALL_REBALANCE_TRIGGERS {
+            assert_eq!(
+                trigger.as_str(),
+                stored,
+                "wrong stored value for {trigger:?}"
+            );
+            assert_eq!(
+                RebalanceTrigger::parse(stored),
+                Some(trigger),
+                "round-trip failed for {trigger:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rebalance_trigger_parses_the_pre_enum_value() {
+        // Rows written before this became a closed set all carry this literal.
+        // Mapping it to a real trigger would silently invent provenance that was
+        // never recorded, so it gets its own variant.
+        assert_eq!(
+            RebalanceTrigger::parse("portfolio_evaluation"),
+            Some(RebalanceTrigger::Legacy)
+        );
+    }
+
+    #[test]
+    fn test_rebalance_trigger_rejects_unknown_values() {
+        assert_eq!(RebalanceTrigger::parse("eod_snapshot_requested"), None);
+        assert_eq!(RebalanceTrigger::parse(""), None);
+        assert_eq!(RebalanceTrigger::parse("SESSION_START"), None);
+    }
+
+    #[test]
+    fn test_rebalance_trigger_display_matches_as_str() {
+        for &(trigger, stored) in ALL_REBALANCE_TRIGGERS {
+            assert_eq!(trigger.to_string(), stored);
+        }
+    }
+
     fn make_pair_id() -> PairID {
         PairID::new(Ticker::new("AAPL").unwrap(), Ticker::new("MSFT").unwrap())
     }
@@ -1161,12 +1273,12 @@ mod tests {
         let session = EquityRebalanceSession::new(
             Uuid::new_v4(),
             Utc::now(),
-            "portfolio_evaluation".to_string(),
+            RebalanceTrigger::SessionStart,
             Some("run-abc123".to_string()),
             None,
             RebalanceSessionStatus::Completed,
         );
-        assert_eq!(session.trigger_reason(), "portfolio_evaluation");
+        assert_eq!(session.trigger_reason(), RebalanceTrigger::SessionStart);
         assert_eq!(session.status(), &RebalanceSessionStatus::Completed);
         assert!(session.completed_at().is_none());
     }
@@ -1176,13 +1288,13 @@ mod tests {
         let session = EquityRebalanceSession::new(
             Uuid::new_v4(),
             Utc::now(),
-            "eod_snapshot_requested".to_string(),
+            RebalanceTrigger::LiveCrossing,
             None,
             Some(Utc::now()),
             RebalanceSessionStatus::Completed,
         );
         let cloned = session.clone();
-        assert_eq!(cloned.trigger_reason(), "eod_snapshot_requested");
+        assert_eq!(cloned.trigger_reason(), RebalanceTrigger::LiveCrossing);
     }
 
     #[test]
@@ -1283,7 +1395,7 @@ mod tests {
         EquityRebalanceSession::new(
             Uuid::new_v4(),
             Utc::now(),
-            "portfolio_evaluation".to_string(),
+            RebalanceTrigger::SessionStart,
             None,
             None,
             RebalanceSessionStatus::Completed,
@@ -1360,7 +1472,7 @@ mod tests {
         assert!(!sessions.is_empty());
         assert_eq!(
             sessions.as_slice()[0].trigger_reason(),
-            "portfolio_evaluation"
+            RebalanceTrigger::SessionStart
         );
     }
 
@@ -1407,7 +1519,7 @@ mod tests {
         let session = EquityRebalanceSession::new(
             id,
             now,
-            "portfolio_evaluation".to_string(),
+            RebalanceTrigger::SessionStart,
             Some("run-xyz".to_string()),
             Some(now),
             RebalanceSessionStatus::Failed,

--- a/src/domain/trading.rs
+++ b/src/domain/trading.rs
@@ -347,6 +347,11 @@ pub enum RebalanceTrigger {
     /// Nothing emits this. It exists so rows already in
     /// `equity_rebalance_sessions` still round-trip, rather than being silently
     /// relabelled as one of the real triggers.
+    ///
+    /// The explicit rename keeps the Serde form equal to [`Self::as_str`]. It is
+    /// the only variant where `rename_all = "snake_case"` would disagree, which
+    /// is exactly why it is easy to miss.
+    #[serde(rename = "portfolio_evaluation")]
     Legacy,
 }
 
@@ -363,8 +368,11 @@ impl RebalanceTrigger {
         }
     }
 
-    /// Parses a stored `trigger_reason`. Returns `None` for unknown values,
-    /// which includes every row written before this became an enum.
+    /// Parses a stored `trigger_reason`.
+    ///
+    /// Rows written before this became a closed set carry `"portfolio_evaluation"`
+    /// and map to [`RebalanceTrigger::Legacy`]. `None` means a value no build has
+    /// ever written.
     pub fn parse(value: &str) -> Option<Self> {
         match value {
             "session_start" => Some(Self::SessionStart),
@@ -1067,6 +1075,19 @@ mod tests {
                 Some(trigger),
                 "round-trip failed for {trigger:?}"
             );
+
+            // The Serde form must equal as_str, or a value written through one
+            // path fails to read back through the other. `Legacy` is the only
+            // variant where the derived snake_case name would disagree, which is
+            // exactly why testing only as_str/parse would miss it.
+            let serialized = serde_json::to_string(&trigger).unwrap();
+            assert_eq!(
+                serialized,
+                format!("\"{stored}\""),
+                "serde form diverges from as_str for {trigger:?}"
+            );
+            let deserialized: RebalanceTrigger = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(deserialized, trigger);
         }
     }
 

--- a/src/inference/consumer.rs
+++ b/src/inference/consumer.rs
@@ -78,7 +78,7 @@ async fn run_consumer(
     run_event_listener(
         pool,
         shutdown_token,
-        CONSUMER_INFERENCE,
+        "inference",
         || async {
             // Catch up on an equity_predictions_requested that arrived while we
             // were down.
@@ -105,11 +105,23 @@ async fn run_consumer(
                     info!(event_id, "Received equity_predictions_requested");
                     handle_equity_predictions_requested(state, pool, event_id).await;
                 }
-                // Every consumer receives every event, so the catch-all is
-                // mostly other services' traffic. Inference acts on nothing
-                // else; the match exists so a new variant is a compile-time
-                // decision rather than a silent omission.
-                _ => {}
+                // Every consumer receives every event, so most of this is other
+                // services' traffic. Inference acts on nothing else. Listed
+                // rather than caught by a wildcard so that adding a family, or
+                // an `Outcome` to the family this consumer does handle, fails
+                // the build here instead of being silently ignored.
+                EventType::EquityPredictions(
+                    Outcome::Started | Outcome::Completed | Outcome::Errored,
+                )
+                | EventType::EquityBarsSync(_)
+                | EventType::DatabaseExport(_)
+                | EventType::DatabaseBackup(_)
+                | EventType::DatabasePurge(_)
+                | EventType::PortfolioRebalance(_)
+                | EventType::PortfolioLiquidation(_)
+                | EventType::TradingSessionStarted
+                | EventType::PortfolioEvaluationRequested
+                | EventType::StressTest => {}
             }
         },
     )

--- a/src/inference/consumer.rs
+++ b/src/inference/consumer.rs
@@ -16,7 +16,7 @@ use tracing::{error, info, warn};
 
 use crate::common::events::{
     emit_event, get_consumer_offset, latest_event_after, update_consumer_offset, EventType,
-    CONSUMER_INFERENCE,
+    Outcome, CONSUMER_INFERENCE,
 };
 use crate::inference::pipeline::run_predictions;
 use crate::inference::state::AppState;
@@ -86,8 +86,12 @@ async fn run_consumer(
 
     // Catch up on an equity_predictions_requested that arrived while we were down.
     let offset = get_consumer_offset(pool, CONSUMER_INFERENCE).await?;
-    if let Some(event_id) =
-        latest_event_after(pool, EventType::EquityPredictionsRequested, offset).await?
+    if let Some(event_id) = latest_event_after(
+        pool,
+        EventType::EquityPredictions(Outcome::Requested),
+        offset,
+    )
+    .await?
     {
         info!(
             event_id,
@@ -107,7 +111,7 @@ async fn run_consumer(
         let payload = notification.payload();
 
         if parse_event_type(payload).as_deref()
-            != Some(EventType::EquityPredictionsRequested.as_str())
+            != Some(EventType::EquityPredictions(Outcome::Requested).as_str())
         {
             continue;
         }
@@ -153,7 +157,7 @@ pub(crate) fn parse_event_id(payload: &str) -> i64 {
 async fn handle_equity_predictions_requested(state: &AppState, pool: &PgPool, event_id: i64) {
     if let Err(error) = emit_event(
         pool,
-        EventType::EquityPredictionsStarted,
+        EventType::EquityPredictions(Outcome::Started),
         &serde_json::json!({}),
     )
     .await
@@ -176,12 +180,12 @@ async fn handle_equity_predictions_requested(state: &AppState, pool: &PgPool, ev
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::events::EventType;
+    use crate::common::events::{EventType, Outcome};
 
     #[test]
     fn test_parse_event_type_equity_predictions_requested() {
         let payload = serde_json::json!({
-            "event_type": EventType::EquityPredictionsRequested.as_str(),
+            "event_type": EventType::EquityPredictions(Outcome::Requested).as_str(),
             "event_id": 42,
         })
         .to_string();

--- a/src/inference/consumer.rs
+++ b/src/inference/consumer.rs
@@ -7,7 +7,6 @@
 
 use std::time::Duration;
 
-use sqlx::postgres::PgListener;
 use sqlx::PgPool;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
@@ -15,8 +14,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::common::events::{
-    emit_event, get_consumer_offset, latest_event_after, update_consumer_offset, EventType,
-    Outcome, CONSUMER_INFERENCE,
+    emit_event, get_consumer_offset, latest_event_after, run_event_listener,
+    update_consumer_offset, EventType, Outcome, CONSUMER_INFERENCE,
 };
 use crate::inference::pipeline::run_predictions;
 use crate::inference::state::AppState;
@@ -76,76 +75,45 @@ async fn run_consumer(
     pool: &PgPool,
     shutdown_token: &CancellationToken,
 ) -> Result<(), sqlx::Error> {
-    let mut listener = PgListener::connect_with(pool).await?;
-    listener.listen("events").await?;
-    info!("Event consumer connected, listening on channel 'events'");
-
-    if shutdown_token.is_cancelled() {
-        return Ok(());
-    }
-
-    // Catch up on an equity_predictions_requested that arrived while we were down.
-    let offset = get_consumer_offset(pool, CONSUMER_INFERENCE).await?;
-    if let Some(event_id) = latest_event_after(
+    run_event_listener(
         pool,
-        EventType::EquityPredictions(Outcome::Requested),
-        offset,
-    )
-    .await?
-    {
-        info!(
-            event_id,
-            "Catching up on missed equity_predictions_requested"
-        );
-        handle_equity_predictions_requested(state, pool, event_id).await;
-    }
-
-    loop {
-        let notification = tokio::select! {
-            result = listener.recv() => result?,
-            _ = shutdown_token.cancelled() => {
-                info!("Shutdown signal received, draining");
-                break;
+        shutdown_token,
+        CONSUMER_INFERENCE,
+        || async {
+            // Catch up on an equity_predictions_requested that arrived while we
+            // were down.
+            let offset = get_consumer_offset(pool, CONSUMER_INFERENCE).await?;
+            if let Some(event_id) = latest_event_after(
+                pool,
+                EventType::EquityPredictions(Outcome::Requested),
+                offset,
+            )
+            .await?
+            {
+                info!(
+                    event_id,
+                    "Catching up on missed equity_predictions_requested"
+                );
+                handle_equity_predictions_requested(state, pool, event_id).await;
             }
-        };
-        let payload = notification.payload();
-
-        if parse_event_type(payload).as_deref()
-            != Some(EventType::EquityPredictions(Outcome::Requested).as_str())
-        {
-            continue;
-        }
-
-        let event_id = parse_event_id(payload);
-        if event_id == 0 {
-            warn!("Skipping equity_predictions_requested with invalid event_id");
-            continue;
-        }
-        info!(event_id, "Received equity_predictions_requested");
-        handle_equity_predictions_requested(state, pool, event_id).await;
-    }
-
-    Ok(())
-}
-
-/// Parse an event notification payload and return the event type string if
-/// present. Returns `None` when the payload is not valid JSON or does not
-/// carry an `event_type` field.
-pub(crate) fn parse_event_type(payload: &str) -> Option<String> {
-    let parsed: serde_json::Value = serde_json::from_str(payload).ok()?;
-    parsed
-        .get("event_type")
-        .and_then(|value| value.as_str())
-        .map(String::from)
-}
-
-/// Extract the `event_id` integer from a notification payload, returning 0
-/// when the field is absent or not an integer.
-pub(crate) fn parse_event_id(payload: &str) -> i64 {
-    serde_json::from_str::<serde_json::Value>(payload)
-        .ok()
-        .and_then(|parsed| parsed.get("event_id").and_then(|value| value.as_i64()))
-        .unwrap_or(0)
+            Ok(())
+        },
+        |notification| async move {
+            let event_id = notification.event_id();
+            match notification.event_type() {
+                EventType::EquityPredictions(Outcome::Requested) => {
+                    info!(event_id, "Received equity_predictions_requested");
+                    handle_equity_predictions_requested(state, pool, event_id).await;
+                }
+                // Every consumer receives every event, so the catch-all is
+                // mostly other services' traffic. Inference acts on nothing
+                // else; the match exists so a new variant is a compile-time
+                // decision rather than a silent omission.
+                _ => {}
+            }
+        },
+    )
+    .await
 }
 
 /// Run a prediction pass and advance the consumer offset.
@@ -180,76 +148,6 @@ async fn handle_equity_predictions_requested(state: &AppState, pool: &PgPool, ev
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::events::{EventType, Outcome};
-
-    #[test]
-    fn test_parse_event_type_equity_predictions_requested() {
-        let payload = serde_json::json!({
-            "event_type": EventType::EquityPredictions(Outcome::Requested).as_str(),
-            "event_id": 42,
-        })
-        .to_string();
-        let result = parse_event_type(&payload);
-        assert_eq!(result.as_deref(), Some("equity_predictions_requested"));
-    }
-
-    #[test]
-    fn test_parse_event_type_other_event() {
-        let payload = serde_json::json!({
-            "event_type": "equity_bars_sync_completed",
-            "event_id": 7,
-        })
-        .to_string();
-        let result = parse_event_type(&payload);
-        assert_eq!(result.as_deref(), Some("equity_bars_sync_completed"));
-    }
-
-    #[test]
-    fn test_parse_event_type_missing_field() {
-        let payload = serde_json::json!({"event_id": 1}).to_string();
-        assert!(parse_event_type(&payload).is_none());
-    }
-
-    #[test]
-    fn test_parse_event_type_invalid_json() {
-        assert!(parse_event_type("not-json").is_none());
-        assert!(parse_event_type("").is_none());
-        assert!(parse_event_type("{unclosed").is_none());
-    }
-
-    #[test]
-    fn test_parse_event_type_non_string_value() {
-        // event_type with a numeric value must return None (not a string).
-        let payload = serde_json::json!({"event_type": 99}).to_string();
-        assert!(parse_event_type(&payload).is_none());
-    }
-
-    #[test]
-    fn test_parse_event_id_present() {
-        let payload = serde_json::json!({
-            "event_type": "equity_predictions_requested",
-            "event_id": 123,
-        })
-        .to_string();
-        assert_eq!(parse_event_id(&payload), 123);
-    }
-
-    #[test]
-    fn test_parse_event_id_missing_defaults_to_zero() {
-        let payload = serde_json::json!({"event_type": "equity_predictions_requested"}).to_string();
-        assert_eq!(parse_event_id(&payload), 0);
-    }
-
-    #[test]
-    fn test_parse_event_id_invalid_json_defaults_to_zero() {
-        assert_eq!(parse_event_id("bad json"), 0);
-    }
-
-    #[test]
-    fn test_parse_event_id_non_integer_defaults_to_zero() {
-        let payload = serde_json::json!({"event_id": "not-a-number"}).to_string();
-        assert_eq!(parse_event_id(&payload), 0);
-    }
 
     #[tokio::test]
     async fn test_spawn_event_consumer_no_pool_does_not_panic() {

--- a/src/inference/pipeline.rs
+++ b/src/inference/pipeline.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
+use crate::common::events::Outcome;
 use crate::inference::artifact;
 use crate::inference::database;
 use crate::inference::predict;
@@ -98,7 +99,7 @@ pub async fn run_predictions(state: &AppState) -> Result<PredictionRun, Pipeline
         error!(stage = error.stage(), error = %error.message(), "Prediction pipeline failed");
         if let Err(emit_error) = crate::common::events::emit_event(
             pool,
-            crate::common::events::EventType::EquityPredictionsErrored,
+            crate::common::events::EventType::EquityPredictions(Outcome::Errored),
             &serde_json::json!({
                 "correlation_id": correlation_id.to_string(),
                 "reason": error.stage(),
@@ -166,7 +167,7 @@ async fn run_pipeline_and_persist(
         info!(rows = rows, "Predictions inserted into PostgreSQL");
         if let Err(e) = crate::common::events::emit_event(
             pool,
-            crate::common::events::EventType::EquityPredictionsCompleted,
+            crate::common::events::EventType::EquityPredictions(Outcome::Completed),
             &serde_json::json!({"correlation_id": correlation_id.to_string()}),
         )
         .await

--- a/src/portfolio/consumer.rs
+++ b/src/portfolio/consumer.rs
@@ -108,7 +108,7 @@ async fn run_consumer(
     run_event_listener(
         pool,
         shutdown_token,
-        CONSUMER_PORTFOLIO,
+        "portfolio",
         || run_startup_catch_up(state, pool, shutdown_token),
         |notification| async move {
             let event_id = notification.event_id();
@@ -136,10 +136,20 @@ async fn run_consumer(
                     handle_portfolio_liquidation(state, pool, event_id).await;
                 }
                 // Every consumer receives every event; the rest belong to other
-                // services or are audit records. The match exists so a new
-                // variant is a compile-time decision rather than a silent
-                // omission.
-                _ => {}
+                // services or are audit records. Listed rather than caught by a
+                // wildcard so that adding a family, or an `Outcome` to a family
+                // this consumer partly handles, fails the build here instead of
+                // being silently ignored.
+                EventType::EquityPredictions(Outcome::Requested | Outcome::Started)
+                | EventType::PortfolioLiquidation(
+                    Outcome::Started | Outcome::Completed | Outcome::Errored,
+                )
+                | EventType::EquityBarsSync(_)
+                | EventType::DatabaseExport(_)
+                | EventType::DatabaseBackup(_)
+                | EventType::DatabasePurge(_)
+                | EventType::PortfolioRebalance(_)
+                | EventType::StressTest => {}
             }
         },
     )
@@ -622,10 +632,10 @@ async fn run_rebalance_pass(
     match run_rebalance(state, trigger).await {
         Ok(outcome) => {
             info!(
-                session_id = %outcome.session_id,
-                pairs_opened = outcome.pairs_opened,
-                pairs_closed = outcome.pairs_closed,
-                pairs_kept = outcome.pairs_kept,
+                session_id = %outcome.session_id(),
+                pairs_opened = outcome.pairs_opened(),
+                pairs_closed = outcome.pairs_closed(),
+                pairs_kept = outcome.pairs_kept(),
                 "Rebalance completed from event"
             );
             return Some(outcome);
@@ -690,7 +700,7 @@ fn report_trigger_disagreement(payload: &serde_json::Value, outcome: &RebalanceO
         return;
     };
     let agreed = outcome
-        .close_signals
+        .close_signals()
         .iter()
         .any(|(pair_id, _)| pair_id.as_str() == flagged_pair);
     if agreed {
@@ -699,8 +709,8 @@ fn report_trigger_disagreement(payload: &serde_json::Value, outcome: &RebalanceO
     warn!(
         pair_id = flagged_pair,
         trigger_z_score = payload.get("z_score").and_then(|value| value.as_f64()),
-        pairs_closed = outcome.pairs_closed,
-        close_signals = outcome.close_signals.len(),
+        pairs_closed = outcome.pairs_closed(),
+        close_signals = outcome.close_signals().len(),
         "Live evaluator flagged a pair the rebalance pass did not close"
     );
 }
@@ -781,22 +791,23 @@ mod tests {
 
     /// Builds an outcome whose exit evaluation signalled the given pairs.
     fn outcome_closing(pairs: &[&str]) -> RebalanceOutcome {
-        RebalanceOutcome {
-            session_id: uuid::Uuid::new_v4(),
-            pairs_opened: 0,
-            pairs_closed: pairs.len(),
-            pairs_kept: 0,
-            net_asset_value: 1_000_000.0,
-            close_signals: pairs
-                .iter()
-                .map(|pair| {
-                    (
-                        PairID::parse(pair).expect("test pair id should be valid"),
-                        CloseReason::StopLoss,
-                    )
-                })
-                .collect(),
-        }
+        let close_signals = pairs
+            .iter()
+            .map(|pair| {
+                (
+                    PairID::parse(pair).expect("test pair id should be valid"),
+                    CloseReason::StopLoss,
+                )
+            })
+            .collect::<Vec<_>>();
+        RebalanceOutcome::new(
+            uuid::Uuid::new_v4(),
+            0,
+            close_signals.len(),
+            0,
+            1_000_000.0,
+            close_signals,
+        )
     }
 
     #[test]

--- a/src/portfolio/consumer.rs
+++ b/src/portfolio/consumer.rs
@@ -29,7 +29,6 @@
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use sqlx::postgres::PgListener;
 use sqlx::PgPool;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
@@ -37,8 +36,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::common::events::{
-    emit_event, get_consumer_offset, latest_event_after, update_consumer_offset, EventType,
-    Outcome, CONSUMER_PORTFOLIO, CONSUMER_PORTFOLIO_LIQUIDATION, CONSUMER_PORTFOLIO_SESSION,
+    emit_event, get_consumer_offset, latest_event_after, run_event_listener,
+    update_consumer_offset, EventType, Outcome, CONSUMER_PORTFOLIO, CONSUMER_PORTFOLIO_LIQUIDATION,
+    CONSUMER_PORTFOLIO_SESSION,
 };
 use crate::common::market_hours::MarketSession;
 use crate::portfolio::database::{fetch_open_pairs, predictions_exist_for_today};
@@ -102,14 +102,56 @@ async fn run_consumer(
     pool: &PgPool,
     shutdown_token: &CancellationToken,
 ) -> Result<(), sqlx::Error> {
-    let mut listener = PgListener::connect_with(pool).await?;
-    listener.listen("events").await?;
-    info!("Event consumer connected, listening on channel 'events'");
+    run_event_listener(
+        pool,
+        shutdown_token,
+        CONSUMER_PORTFOLIO,
+        || run_startup_catch_up(state, pool, shutdown_token),
+        |notification| async move {
+            let event_id = notification.event_id();
+            match notification.event_type() {
+                EventType::TradingSessionStarted => {
+                    info!(event_id, "Received trading_session_started");
+                    handle_trading_session_started(state, pool, event_id, shutdown_token).await;
+                }
+                EventType::PortfolioEvaluationRequested => {
+                    handle_portfolio_evaluation(state, pool).await;
+                }
+                EventType::EquityPredictions(Outcome::Completed) => {
+                    info!(event_id, "Received equity_predictions_completed");
+                    handle_equity_predictions_completed(state, pool, event_id).await;
+                }
+                EventType::EquityPredictions(Outcome::Errored) => {
+                    // Nothing to unwind: the request timestamp is a retry
+                    // backoff, not a lock, so the next due evaluation
+                    // re-requests on its own. An explicit arm because this is a
+                    // considered decision, not an oversight.
+                    info!(event_id, "Received equity_predictions_errored");
+                }
+                EventType::PortfolioLiquidation(Outcome::Requested) => {
+                    info!(event_id, "Received portfolio_liquidation_requested");
+                    handle_portfolio_liquidation(state, pool, event_id).await;
+                }
+                // Every consumer receives every event; the rest belong to other
+                // services or are audit records. The match exists so a new
+                // variant is a compile-time decision rather than a silent
+                // omission.
+                _ => {}
+            }
+        },
+    )
+    .await
+}
 
-    if shutdown_token.is_cancelled() {
-        return Ok(());
-    }
-
+/// Replays the events this consumer missed while it was down.
+///
+/// Runs on every connection, not once per process: a reconnect means delivery
+/// had a gap, and the same replay that covers a restart covers that gap too.
+async fn run_startup_catch_up(
+    state: &AppState,
+    pool: &PgPool,
+    shutdown_token: &CancellationToken,
+) -> Result<(), sqlx::Error> {
     // Run startup reconciliation to resolve any DB-Alpaca drift accumulated
     // while the service was down.
     match reconciliation::reconcile(pool, state.alpaca_client()).await {
@@ -213,46 +255,6 @@ async fn run_consumer(
             {
                 warn!(error = %error, "Failed to update liquidation consumer offset");
             }
-        }
-    }
-
-    loop {
-        let notification = tokio::select! {
-            result = listener.recv() => result?,
-            _ = shutdown_token.cancelled() => {
-                info!("Shutdown signal received, draining");
-                break;
-            }
-        };
-        let parsed: serde_json::Value = match serde_json::from_str(notification.payload()) {
-            Ok(value) => value,
-            Err(_) => continue,
-        };
-
-        let event_type = parsed
-            .get("event_type")
-            .and_then(|value| value.as_str())
-            .unwrap_or("");
-        let event_id = parsed
-            .get("event_id")
-            .and_then(|value| value.as_i64())
-            .unwrap_or(0);
-
-        if event_type == EventType::TradingSessionStarted.as_str() {
-            info!(event_id, "Received trading_session_started");
-            handle_trading_session_started(state, pool, event_id, shutdown_token).await;
-        } else if event_type == EventType::PortfolioEvaluationRequested.as_str() {
-            handle_portfolio_evaluation(state, pool).await;
-        } else if event_type == EventType::EquityPredictions(Outcome::Completed).as_str() {
-            info!(event_id, "Received equity_predictions_completed");
-            handle_equity_predictions_completed(state, pool, event_id).await;
-        } else if event_type == EventType::EquityPredictions(Outcome::Errored).as_str() {
-            // Nothing to unwind: the request timestamp is a retry backoff, not a
-            // lock, so the next due evaluation re-requests on its own.
-            info!(event_id, "Received equity_predictions_errored");
-        } else if event_type == EventType::PortfolioLiquidation(Outcome::Requested).as_str() {
-            info!(event_id, "Received portfolio_liquidation_requested");
-            handle_portfolio_liquidation(state, pool, event_id).await;
         }
     }
 

--- a/src/portfolio/consumer.rs
+++ b/src/portfolio/consumer.rs
@@ -41,8 +41,11 @@ use crate::common::events::{
     CONSUMER_PORTFOLIO_SESSION,
 };
 use crate::common::market_hours::MarketSession;
+use crate::domain::trading::RebalanceTrigger;
 use crate::portfolio::database::{fetch_open_pairs, predictions_exist_for_today};
-use crate::portfolio::rebalance::{run_end_of_day_liquidation, run_rebalance, RebalanceError};
+use crate::portfolio::rebalance::{
+    run_end_of_day_liquidation, run_rebalance, RebalanceError, RebalanceOutcome,
+};
 use crate::portfolio::reconciliation;
 use crate::portfolio::state::AppState;
 
@@ -115,7 +118,7 @@ async fn run_consumer(
                     handle_trading_session_started(state, pool, event_id, shutdown_token).await;
                 }
                 EventType::PortfolioEvaluationRequested => {
-                    handle_portfolio_evaluation(state, pool).await;
+                    handle_portfolio_evaluation(state, pool, notification.payload()).await;
                 }
                 EventType::EquityPredictions(Outcome::Completed) => {
                     info!(event_id, "Received equity_predictions_completed");
@@ -306,7 +309,7 @@ async fn handle_trading_session_started(
         record_session_offset(pool, event_id).await;
         return;
     }
-    run_rebalance_pass(state, pool).await;
+    run_rebalance_pass(state, pool, RebalanceTrigger::SessionStart).await;
     state.finish_rebalance();
 
     // A pass that opened nothing is the case the retired heartbeat used to
@@ -486,7 +489,8 @@ fn spawn_liquidation_timer(
 ///
 /// No consumer offset tracking, because a stale evaluation tick carries no
 /// meaningful signal.
-async fn handle_portfolio_evaluation(state: &AppState, pool: &PgPool) {
+async fn handle_portfolio_evaluation(state: &AppState, pool: &PgPool, payload: &serde_json::Value) {
+    let trigger = evaluation_trigger_from(payload);
     let session = match state.alpaca_client().fetch_market_session().await {
         Ok(session) => session,
         Err(error) => {
@@ -516,8 +520,14 @@ async fn handle_portfolio_evaluation(state: &AppState, pool: &PgPool) {
         return;
     }
 
-    run_rebalance_pass(state, pool).await;
+    let outcome = run_rebalance_pass(state, pool, trigger).await;
     state.finish_rebalance();
+
+    if trigger == RebalanceTrigger::LiveCrossing {
+        if let Some(outcome) = outcome {
+            report_trigger_disagreement(payload, &outcome);
+        }
+    }
 }
 
 /// Returns `true` when the session close is within [`LIQUIDATION_LEAD_TIME_MINUTES`].
@@ -573,11 +583,32 @@ async fn ensure_predictions_requested(state: &AppState, pool: &PgPool) {
     }
 }
 
+/// Maps an evaluation request's payload to the trigger that produced it.
+///
+/// The emitters already set `reason`; this reads it back so the rebalance
+/// session records which of them ran. An unrecognised or absent reason means the
+/// request came from somewhere other than the two in-process emitters.
+fn evaluation_trigger_from(payload: &serde_json::Value) -> RebalanceTrigger {
+    match payload.get("reason").and_then(|value| value.as_str()) {
+        Some("live_threshold_crossing") => RebalanceTrigger::LiveCrossing,
+        Some("entry_retry") => RebalanceTrigger::EntryRetry,
+        _ => RebalanceTrigger::Manual,
+    }
+}
+
 /// Runs a rebalance pass, emitting the start event and translating the outcome
 /// into log lines and, where warranted, a `portfolio_rebalance_errored` event.
 ///
 /// Callers own the in-progress flag; this function neither claims nor releases it.
-async fn run_rebalance_pass(state: &AppState, pool: &PgPool) {
+///
+/// Returns the outcome on success so a caller can compare the pass against
+/// whatever triggered it; `None` means the pass was skipped or failed, which the
+/// arms below have already logged.
+async fn run_rebalance_pass(
+    state: &AppState,
+    pool: &PgPool,
+    trigger: RebalanceTrigger,
+) -> Option<RebalanceOutcome> {
     if let Err(error) = emit_event(
         pool,
         EventType::PortfolioRebalance(Outcome::Started),
@@ -588,7 +619,7 @@ async fn run_rebalance_pass(state: &AppState, pool: &PgPool) {
         warn!(error = %error, "Failed to emit portfolio_rebalance_started");
     }
 
-    match run_rebalance(state).await {
+    match run_rebalance(state, trigger).await {
         Ok(outcome) => {
             info!(
                 session_id = %outcome.session_id,
@@ -597,6 +628,7 @@ async fn run_rebalance_pass(state: &AppState, pool: &PgPool) {
                 pairs_kept = outcome.pairs_kept,
                 "Rebalance completed from event"
             );
+            return Some(outcome);
         }
         Err(RebalanceError::StalePredictions) => {
             warn!("Rebalance skipped: stale or absent predictions");
@@ -642,6 +674,35 @@ async fn run_rebalance_pass(state: &AppState, pool: &PgPool) {
             }
         }
     }
+    None
+}
+
+/// Reports when the live evaluator flagged a pair the authoritative pass then
+/// declined to close.
+///
+/// These two paths already produced a livelock once by measuring the same
+/// spread differently, which is why they share `close_reason_for` and
+/// `z_score_against`. A systematic divergence recurring is the failure worth
+/// hearing about, so it is logged rather than left to be inferred from a pass
+/// that quietly did nothing.
+fn report_trigger_disagreement(payload: &serde_json::Value, outcome: &RebalanceOutcome) {
+    let Some(flagged_pair) = payload.get("pair_id").and_then(|value| value.as_str()) else {
+        return;
+    };
+    let agreed = outcome
+        .close_signals
+        .iter()
+        .any(|(pair_id, _)| pair_id.as_str() == flagged_pair);
+    if agreed {
+        return;
+    }
+    warn!(
+        pair_id = flagged_pair,
+        trigger_z_score = payload.get("z_score").and_then(|value| value.as_f64()),
+        pairs_closed = outcome.pairs_closed,
+        close_signals = outcome.close_signals.len(),
+        "Live evaluator flagged a pair the rebalance pass did not close"
+    );
 }
 
 /// Runs a rebalance pass in response to a completed prediction run.
@@ -650,7 +711,7 @@ async fn run_rebalance_pass(state: &AppState, pool: &PgPool) {
 /// change, so it is acted on immediately rather than waiting for the next tick.
 async fn handle_equity_predictions_completed(state: &AppState, pool: &PgPool, event_id: i64) {
     if state.try_begin_rebalance() {
-        run_rebalance_pass(state, pool).await;
+        run_rebalance_pass(state, pool, RebalanceTrigger::PredictionRefresh).await;
         state.finish_rebalance();
     } else {
         info!("Skipping prediction-driven rebalance: a pass is already running");
@@ -709,10 +770,96 @@ async fn handle_portfolio_liquidation(state: &AppState, pool: &PgPool, event_id:
 #[cfg(test)]
 mod tests {
     use super::{
-        CONSUMER_PORTFOLIO, CONSUMER_PORTFOLIO_LIQUIDATION, CONSUMER_PORTFOLIO_SESSION,
-        ENTRY_RETRY_BACKOFF_MINUTES, LIQUIDATION_LEAD_TIME_MINUTES,
+        evaluation_trigger_from, report_trigger_disagreement, CONSUMER_PORTFOLIO,
+        CONSUMER_PORTFOLIO_LIQUIDATION, CONSUMER_PORTFOLIO_SESSION, ENTRY_RETRY_BACKOFF_MINUTES,
+        LIQUIDATION_LEAD_TIME_MINUTES,
     };
     use crate::common::events::{EventType, Outcome};
+    use crate::domain::market::PairID;
+    use crate::domain::trading::{CloseReason, RebalanceTrigger};
+    use crate::portfolio::rebalance::RebalanceOutcome;
+
+    /// Builds an outcome whose exit evaluation signalled the given pairs.
+    fn outcome_closing(pairs: &[&str]) -> RebalanceOutcome {
+        RebalanceOutcome {
+            session_id: uuid::Uuid::new_v4(),
+            pairs_opened: 0,
+            pairs_closed: pairs.len(),
+            pairs_kept: 0,
+            net_asset_value: 1_000_000.0,
+            close_signals: pairs
+                .iter()
+                .map(|pair| {
+                    (
+                        PairID::parse(pair).expect("test pair id should be valid"),
+                        CloseReason::StopLoss,
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn test_evaluation_trigger_reads_the_emitters_reason() {
+        assert_eq!(
+            evaluation_trigger_from(&serde_json::json!({"reason": "live_threshold_crossing"})),
+            RebalanceTrigger::LiveCrossing
+        );
+        assert_eq!(
+            evaluation_trigger_from(&serde_json::json!({"reason": "entry_retry", "attempt": 1})),
+            RebalanceTrigger::EntryRetry
+        );
+    }
+
+    #[test]
+    fn test_evaluation_trigger_falls_back_to_manual() {
+        // Anything not emitted by the two in-process emitters came from outside.
+        assert_eq!(
+            evaluation_trigger_from(&serde_json::json!({})),
+            RebalanceTrigger::Manual
+        );
+        assert_eq!(
+            evaluation_trigger_from(&serde_json::json!({"reason": "something_else"})),
+            RebalanceTrigger::Manual
+        );
+        assert_eq!(
+            evaluation_trigger_from(&serde_json::json!({"reason": 7})),
+            RebalanceTrigger::Manual
+        );
+    }
+
+    #[test]
+    fn test_trigger_disagreement_is_silent_when_the_pass_agrees() {
+        let payload = serde_json::json!({
+            "reason": "live_threshold_crossing",
+            "pair_id": "AAPL-MSFT",
+            "z_score": 4.2,
+        });
+        // Nothing to assert beyond not panicking: the pass closed the flagged
+        // pair, so the divergence path must not be taken.
+        report_trigger_disagreement(&payload, &outcome_closing(&["AAPL-MSFT"]));
+    }
+
+    #[test]
+    fn test_trigger_disagreement_handles_a_declined_pair() {
+        let payload = serde_json::json!({
+            "reason": "live_threshold_crossing",
+            "pair_id": "AAPL-MSFT",
+            "z_score": 4.2,
+        });
+        report_trigger_disagreement(&payload, &outcome_closing(&["KO-PEP"]));
+        report_trigger_disagreement(&payload, &outcome_closing(&[]));
+    }
+
+    #[test]
+    fn test_trigger_disagreement_ignores_a_request_without_a_pair() {
+        // Entry retries and manual requests carry no pair, so there is nothing
+        // to disagree about.
+        report_trigger_disagreement(
+            &serde_json::json!({"reason": "entry_retry"}),
+            &outcome_closing(&[]),
+        );
+    }
 
     #[test]
     fn test_consumer_names_are_stable() {
@@ -891,7 +1038,7 @@ mod tests {
         };
         let state = make_test_state(mock);
 
-        handle_portfolio_evaluation(&state, state.pool()).await;
+        handle_portfolio_evaluation(&state, state.pool(), &serde_json::json!({})).await;
 
         // The pass returned before claiming the rebalance slot.
         assert!(!state.rebalance_in_progress());
@@ -908,7 +1055,7 @@ mod tests {
         // The dummy pool makes every query fail, so the pass errors out. The
         // slot must still be released or the service would wedge after one
         // transient database failure.
-        handle_portfolio_evaluation(&state, state.pool()).await;
+        handle_portfolio_evaluation(&state, state.pool(), &serde_json::json!({})).await;
 
         assert!(!state.rebalance_in_progress());
     }
@@ -923,7 +1070,7 @@ mod tests {
 
         assert!(state.try_begin_rebalance());
 
-        handle_portfolio_evaluation(&state, state.pool()).await;
+        handle_portfolio_evaluation(&state, state.pool(), &serde_json::json!({})).await;
 
         // Still held by the simulated in-flight pass, not cleared by the skip.
         assert!(state.rebalance_in_progress());

--- a/src/portfolio/consumer.rs
+++ b/src/portfolio/consumer.rs
@@ -38,7 +38,7 @@ use tracing::{error, info, warn};
 
 use crate::common::events::{
     emit_event, get_consumer_offset, latest_event_after, update_consumer_offset, EventType,
-    CONSUMER_PORTFOLIO, CONSUMER_PORTFOLIO_LIQUIDATION, CONSUMER_PORTFOLIO_SESSION,
+    Outcome, CONSUMER_PORTFOLIO, CONSUMER_PORTFOLIO_LIQUIDATION, CONSUMER_PORTFOLIO_SESSION,
 };
 use crate::common::market_hours::MarketSession;
 use crate::portfolio::database::{fetch_open_pairs, predictions_exist_for_today};
@@ -133,7 +133,7 @@ async fn run_consumer(
     let predictions_offset = get_consumer_offset(pool, CONSUMER_PORTFOLIO).await?;
     if let Some(event_id) = latest_event_after(
         pool,
-        EventType::EquityPredictionsCompleted,
+        EventType::EquityPredictions(Outcome::Completed),
         predictions_offset,
     )
     .await?
@@ -185,7 +185,7 @@ async fn run_consumer(
     let liquidation_offset = get_consumer_offset(pool, CONSUMER_PORTFOLIO_LIQUIDATION).await?;
     if let Some(event_id) = latest_event_after(
         pool,
-        EventType::PortfolioLiquidationRequested,
+        EventType::PortfolioLiquidation(Outcome::Requested),
         liquidation_offset,
     )
     .await?
@@ -243,14 +243,14 @@ async fn run_consumer(
             handle_trading_session_started(state, pool, event_id, shutdown_token).await;
         } else if event_type == EventType::PortfolioEvaluationRequested.as_str() {
             handle_portfolio_evaluation(state, pool).await;
-        } else if event_type == EventType::EquityPredictionsCompleted.as_str() {
+        } else if event_type == EventType::EquityPredictions(Outcome::Completed).as_str() {
             info!(event_id, "Received equity_predictions_completed");
             handle_equity_predictions_completed(state, pool, event_id).await;
-        } else if event_type == EventType::EquityPredictionsErrored.as_str() {
+        } else if event_type == EventType::EquityPredictions(Outcome::Errored).as_str() {
             // Nothing to unwind: the request timestamp is a retry backoff, not a
             // lock, so the next due evaluation re-requests on its own.
             info!(event_id, "Received equity_predictions_errored");
-        } else if event_type == EventType::PortfolioLiquidationRequested.as_str() {
+        } else if event_type == EventType::PortfolioLiquidation(Outcome::Requested).as_str() {
             info!(event_id, "Received portfolio_liquidation_requested");
             handle_portfolio_liquidation(state, pool, event_id).await;
         }
@@ -454,7 +454,7 @@ fn spawn_liquidation_timer(
         info!(session_close = %close, "Liquidation timer fired; requesting liquidation");
         if let Err(error) = emit_event(
             &pool,
-            EventType::PortfolioLiquidationRequested,
+            EventType::PortfolioLiquidation(Outcome::Requested),
             &serde_json::json!({"reason": "session_close_approaching"}),
         )
         .await
@@ -558,7 +558,7 @@ async fn ensure_predictions_requested(state: &AppState, pool: &PgPool) {
     info!("No predictions recorded for today; requesting a run");
     if let Err(error) = emit_event(
         pool,
-        EventType::EquityPredictionsRequested,
+        EventType::EquityPredictions(Outcome::Requested),
         &serde_json::json!({"reason": "missing_for_session"}),
     )
     .await
@@ -578,7 +578,7 @@ async fn ensure_predictions_requested(state: &AppState, pool: &PgPool) {
 async fn run_rebalance_pass(state: &AppState, pool: &PgPool) {
     if let Err(error) = emit_event(
         pool,
-        EventType::PortfolioRebalanceStarted,
+        EventType::PortfolioRebalance(Outcome::Started),
         &serde_json::json!({}),
     )
     .await
@@ -600,7 +600,7 @@ async fn run_rebalance_pass(state: &AppState, pool: &PgPool) {
             warn!("Rebalance skipped: stale or absent predictions");
             if let Err(error) = emit_event(
                 pool,
-                EventType::PortfolioRebalanceErrored,
+                EventType::PortfolioRebalance(Outcome::Errored),
                 &serde_json::json!({"reason": "stale_predictions"}),
             )
             .await
@@ -619,7 +619,7 @@ async fn run_rebalance_pass(state: &AppState, pool: &PgPool) {
             );
             if let Err(error) = emit_event(
                 pool,
-                EventType::PortfolioRebalanceErrored,
+                EventType::PortfolioRebalance(Outcome::Errored),
                 &serde_json::json!({"reason": "drawdown_breached"}),
             )
             .await
@@ -631,7 +631,7 @@ async fn run_rebalance_pass(state: &AppState, pool: &PgPool) {
             error!(error = %error, "Rebalance errored");
             if let Err(emit_error) = emit_event(
                 pool,
-                EventType::PortfolioRebalanceErrored,
+                EventType::PortfolioRebalance(Outcome::Errored),
                 &serde_json::json!({"reason": error.to_string()}),
             )
             .await
@@ -662,7 +662,7 @@ async fn handle_equity_predictions_completed(state: &AppState, pool: &PgPool, ev
 async fn handle_portfolio_liquidation(state: &AppState, pool: &PgPool, event_id: i64) {
     if let Err(error) = emit_event(
         pool,
-        EventType::PortfolioLiquidationStarted,
+        EventType::PortfolioLiquidation(Outcome::Started),
         &serde_json::json!({}),
     )
     .await
@@ -676,7 +676,7 @@ async fn handle_portfolio_liquidation(state: &AppState, pool: &PgPool, event_id:
             error!(error = %error, "Portfolio liquidation errored: Alpaca execution error");
             if let Err(emit_error) = emit_event(
                 pool,
-                EventType::PortfolioLiquidationErrored,
+                EventType::PortfolioLiquidation(Outcome::Errored),
                 &serde_json::json!({"reason": error.to_string()}),
             )
             .await
@@ -688,7 +688,7 @@ async fn handle_portfolio_liquidation(state: &AppState, pool: &PgPool, event_id:
             error!(error = %error, "Portfolio liquidation errored");
             if let Err(emit_error) = emit_event(
                 pool,
-                EventType::PortfolioLiquidationErrored,
+                EventType::PortfolioLiquidation(Outcome::Errored),
                 &serde_json::json!({"reason": error.to_string()}),
             )
             .await
@@ -710,7 +710,7 @@ mod tests {
         CONSUMER_PORTFOLIO, CONSUMER_PORTFOLIO_LIQUIDATION, CONSUMER_PORTFOLIO_SESSION,
         ENTRY_RETRY_BACKOFF_MINUTES, LIQUIDATION_LEAD_TIME_MINUTES,
     };
-    use crate::common::events::EventType;
+    use crate::common::events::{EventType, Outcome};
 
     #[test]
     fn test_consumer_names_are_stable() {
@@ -722,15 +722,15 @@ mod tests {
     #[test]
     fn test_event_type_strings_are_stable() {
         assert_eq!(
-            EventType::EquityPredictionsCompleted.as_str(),
+            EventType::EquityPredictions(Outcome::Completed).as_str(),
             "equity_predictions_completed"
         );
         assert_eq!(
-            EventType::EquityPredictionsErrored.as_str(),
+            EventType::EquityPredictions(Outcome::Errored).as_str(),
             "equity_predictions_errored"
         );
         assert_eq!(
-            EventType::PortfolioLiquidationRequested.as_str(),
+            EventType::PortfolioLiquidation(Outcome::Requested).as_str(),
             "portfolio_liquidation_requested"
         );
         assert_eq!(

--- a/src/portfolio/database.rs
+++ b/src/portfolio/database.rs
@@ -411,7 +411,7 @@ pub async fn insert_rebalance_session<'e>(
          VALUES ($1, $2, $3, $4, $5, $6)",
         session.id(),
         session.triggered_at(),
-        session.trigger_reason(),
+        session.trigger_reason().as_str(),
         session.model_run_id(),
         session.completed_at(),
         session.status().as_str()
@@ -980,11 +980,13 @@ mod tests {
     #[test]
     fn test_insert_rebalance_session_compiles() {
         make_runtime().block_on(async {
-            use crate::domain::trading::{EquityRebalanceSession, RebalanceSessionStatus};
+            use crate::domain::trading::{
+                EquityRebalanceSession, RebalanceSessionStatus, RebalanceTrigger,
+            };
             let session = EquityRebalanceSession::new(
                 Uuid::new_v4(),
                 Utc::now(),
-                "portfolio_evaluation".to_string(),
+                RebalanceTrigger::SessionStart,
                 None,
                 None,
                 RebalanceSessionStatus::Completed,

--- a/src/portfolio/live_evaluator.rs
+++ b/src/portfolio/live_evaluator.rs
@@ -284,7 +284,16 @@ async fn run_live_evaluator(
         match emit_event(
             &pool,
             EventType::PortfolioEvaluationRequested,
-            &serde_json::json!({"reason": "live_threshold_crossing"}),
+            // The flagged pair travels with the request so the authoritative
+            // pass can say whether it agreed. Observability only: by the time
+            // the pass reads this z-score, reconciliation, a positions fetch,
+            // and a historical price load have all happened, so it reprices
+            // rather than trusting the number.
+            &serde_json::json!({
+                "reason": "live_threshold_crossing",
+                "pair_id": crossed[0].0.as_str(),
+                "z_score": crossed[0].1,
+            }),
         )
         .await
         {

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -32,7 +32,7 @@ use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use crate::common::events::{emit_event, EventType};
+use crate::common::events::{emit_event, EventType, Outcome};
 use crate::common::market_hours::MarketSession;
 use crate::domain::freshness::StalenessWindow;
 use crate::domain::market::{BookQualityLimits, PairID, Ticker, UsableQuote};
@@ -445,7 +445,7 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
 
     emit_event(
         &mut *transaction,
-        EventType::PortfolioRebalanceCompleted,
+        EventType::PortfolioRebalance(Outcome::Completed),
         &serde_json::json!({
             "session_id": session_id.to_string(),
             "pairs_opened": pairs_opened,
@@ -626,7 +626,7 @@ pub async fn run_end_of_day_liquidation(state: &AppState) -> Result<usize, Rebal
 
         emit_event(
             pool,
-            EventType::PortfolioLiquidationCompleted,
+            EventType::PortfolioLiquidation(Outcome::Completed),
             &serde_json::json!({"pairs_closed": 0}),
         )
         .await?;
@@ -657,7 +657,7 @@ pub async fn run_end_of_day_liquidation(state: &AppState) -> Result<usize, Rebal
 
     emit_event(
         pool,
-        EventType::PortfolioLiquidationCompleted,
+        EventType::PortfolioLiquidation(Outcome::Completed),
         &serde_json::json!({ "pairs_closed": pairs_closed }),
     )
     .await?;

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -40,7 +40,7 @@ use crate::domain::orders::{FilledPair, Order, Pending};
 use crate::domain::portfolio::{Portfolio, PortfolioError};
 use crate::domain::trading::{
     AllocationAction, AllocationSide, CloseReason, EquityAllocation, EquityOrder, EquityPair,
-    EquityPairStatus, EquityRebalanceSession, RebalanceSessionStatus,
+    EquityPairStatus, EquityRebalanceSession, RebalanceSessionStatus, RebalanceTrigger,
 };
 use crate::portfolio::alpaca::{AccountInfo, TradableAssets, Trading};
 use crate::portfolio::beta::compute_market_betas;
@@ -76,6 +76,12 @@ pub struct RebalanceOutcome {
     pub pairs_closed: usize,
     pub pairs_kept: usize,
     pub net_asset_value: f64,
+    /// Pairs the exit evaluation signalled to close, with the reason.
+    ///
+    /// Carried so a caller can tell whether the pass agreed with whatever
+    /// flagged it. Distinct from `pairs_closed`, which counts the closes that
+    /// the broker then accepted.
+    pub close_signals: Vec<(PairID, CloseReason)>,
 }
 
 /// Error returned when `run_rebalance` cannot complete the cycle.
@@ -160,7 +166,10 @@ impl From<PortfolioError> for RebalanceError {
 ///
 /// Returns `RebalanceOutcome` on success or a `RebalanceError` describing
 /// why the cycle was skipped or failed.
-pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, RebalanceError> {
+pub async fn run_rebalance(
+    state: &AppState,
+    trigger: RebalanceTrigger,
+) -> Result<RebalanceOutcome, RebalanceError> {
     let pool = state.pool();
     let alpaca = state.alpaca_client();
 
@@ -233,6 +242,7 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
 
     // Phase 4: exit evaluation — always runs when open pairs exist.
     let mut pairs_closed: usize = 0;
+    let mut close_signal_summary: Vec<(PairID, CloseReason)> = Vec::new();
     if !open_pairs.is_empty() {
         // Tier 1: streamed mids, already filtered by the sixty-second guard.
         let mut exit_mid_prices = state.live_prices().fresh_mid_prices(Utc::now()).await;
@@ -268,6 +278,10 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
             "Exit evaluation pricing"
         );
         let close_signals = evaluate_open_pairs(&open_pairs, &historical_prices, &exit_mid_prices);
+        close_signal_summary = close_signals
+            .iter()
+            .map(|signal| (signal.open_pair.pair_id().clone(), signal.reason.clone()))
+            .collect();
         pairs_closed = close_triggered_pairs(alpaca, pool, &close_signals).await?;
         let pairs_kept_after_exits = open_pairs.len() - pairs_closed;
         info!(
@@ -415,7 +429,7 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
     let rebalance_session = EquityRebalanceSession::new(
         session_id,
         now,
-        "portfolio_evaluation".to_string(),
+        trigger,
         None,
         None,
         RebalanceSessionStatus::Completed,
@@ -473,6 +487,7 @@ pub async fn run_rebalance(state: &AppState) -> Result<RebalanceOutcome, Rebalan
         pairs_closed,
         pairs_kept,
         net_asset_value,
+        close_signals: close_signal_summary,
     })
 }
 
@@ -2073,6 +2088,7 @@ mod tests {
             pairs_closed: 2,
             pairs_kept: 8,
             net_asset_value: 500_000.0,
+            close_signals: Vec::new(),
         };
         assert_eq!(outcome.pairs_opened, 3);
         assert_eq!(outcome.pairs_closed, 2);

--- a/src/portfolio/rebalance.rs
+++ b/src/portfolio/rebalance.rs
@@ -71,17 +71,74 @@ use crate::portfolio::statistical_arbitrage::{
 /// Outcome of a completed rebalance cycle.
 #[derive(Debug)]
 pub struct RebalanceOutcome {
-    pub session_id: Uuid,
-    pub pairs_opened: usize,
-    pub pairs_closed: usize,
-    pub pairs_kept: usize,
-    pub net_asset_value: f64,
+    session_id: Uuid,
+    pairs_opened: usize,
+    pairs_closed: usize,
+    pairs_kept: usize,
+    net_asset_value: f64,
+    close_signals: Vec<(PairID, CloseReason)>,
+}
+
+impl RebalanceOutcome {
+    /// Constructs an outcome from a completed rebalance cycle.
+    ///
+    /// `close_signals` are the pairs the exit evaluation signalled to close,
+    /// with their reasons; `pairs_closed` counts the subset the broker then
+    /// accepted. A pass cannot close more pairs than it signalled, so the two
+    /// disagreeing means a caller has mixed up which quantity it holds.
+    pub fn new(
+        session_id: Uuid,
+        pairs_opened: usize,
+        pairs_closed: usize,
+        pairs_kept: usize,
+        net_asset_value: f64,
+        close_signals: Vec<(PairID, CloseReason)>,
+    ) -> Self {
+        debug_assert!(
+            pairs_closed <= close_signals.len(),
+            "closed {pairs_closed} pairs from {} close signals",
+            close_signals.len()
+        );
+        Self {
+            session_id,
+            pairs_opened,
+            pairs_closed,
+            pairs_kept,
+            net_asset_value,
+            close_signals,
+        }
+    }
+
+    pub fn session_id(&self) -> Uuid {
+        self.session_id
+    }
+
+    pub fn pairs_opened(&self) -> usize {
+        self.pairs_opened
+    }
+
+    /// Pairs the broker accepted a close for. Never exceeds
+    /// [`Self::close_signals`]`.len()`.
+    pub fn pairs_closed(&self) -> usize {
+        self.pairs_closed
+    }
+
+    pub fn pairs_kept(&self) -> usize {
+        self.pairs_kept
+    }
+
+    pub fn net_asset_value(&self) -> f64 {
+        self.net_asset_value
+    }
+
     /// Pairs the exit evaluation signalled to close, with the reason.
     ///
     /// Carried so a caller can tell whether the pass agreed with whatever
-    /// flagged it. Distinct from `pairs_closed`, which counts the closes that
-    /// the broker then accepted.
-    pub close_signals: Vec<(PairID, CloseReason)>,
+    /// flagged it, which is a different question from whether the close then
+    /// succeeded.
+    pub fn close_signals(&self) -> &[(PairID, CloseReason)] {
+        &self.close_signals
+    }
 }
 
 /// Error returned when `run_rebalance` cannot complete the cycle.
@@ -481,14 +538,14 @@ pub async fn run_rebalance(
         "Rebalance cycle completed"
     );
 
-    Ok(RebalanceOutcome {
+    Ok(RebalanceOutcome::new(
         session_id,
         pairs_opened,
         pairs_closed,
         pairs_kept,
         net_asset_value,
-        close_signals: close_signal_summary,
-    })
+        close_signal_summary,
+    ))
 }
 
 /// Reasons entry evaluation can be skipped without aborting the full cycle.
@@ -2082,18 +2139,20 @@ mod tests {
 
     #[test]
     fn test_rebalance_outcome_fields() {
-        let outcome = RebalanceOutcome {
-            session_id: Uuid::new_v4(),
-            pairs_opened: 3,
-            pairs_closed: 2,
-            pairs_kept: 8,
-            net_asset_value: 500_000.0,
-            close_signals: Vec::new(),
-        };
-        assert_eq!(outcome.pairs_opened, 3);
-        assert_eq!(outcome.pairs_closed, 2);
-        assert_eq!(outcome.pairs_kept, 8);
-        assert_eq!(outcome.net_asset_value, 500_000.0);
+        // Two closes need two signals behind them; the constructor asserts it.
+        let signals = vec![
+            (
+                PairID::parse("AAPL-MSFT").unwrap(),
+                CloseReason::ProfitTaken,
+            ),
+            (PairID::parse("KO-PEP").unwrap(), CloseReason::StopLoss),
+        ];
+        let outcome = RebalanceOutcome::new(Uuid::new_v4(), 3, 2, 8, 500_000.0, signals);
+        assert_eq!(outcome.pairs_opened(), 3);
+        assert_eq!(outcome.pairs_closed(), 2);
+        assert_eq!(outcome.pairs_kept(), 8);
+        assert_eq!(outcome.net_asset_value(), 500_000.0);
+        assert_eq!(outcome.close_signals().len(), 2);
     }
 
     // --- evaluate_open_pairs tests ---

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -233,38 +233,58 @@ fn database_url_base() -> String {
 /// schema being shipped. The devenv Postgres carries the extension, so the real
 /// one applies.
 fn filter_schema_for_test(schema: &str) -> String {
+    let mut kept: Vec<&str> = Vec::new();
+    // `DO` blocks are buffered rather than dropped on sight: the idiom is shared
+    // between pg_cron scheduling, which the test database cannot run, and plain
+    // DDL such as the `events_notify` trigger, which it very much needs. Dropping
+    // every block took the trigger with it, leaving NOTIFY silent here and the
+    // LISTEN loops untestable.
+    let mut do_block: Vec<&str> = Vec::new();
     let mut inside_do_block = false;
     let mut inside_cron_function = false;
-    schema
-        .lines()
-        .filter(|line| {
-            let trimmed = line.trim().to_lowercase();
 
-            if trimmed.starts_with("do $do$") {
-                inside_do_block = true;
-            }
-            if inside_do_block {
-                if trimmed.starts_with("$do$;") {
-                    inside_do_block = false;
+    for line in schema.lines() {
+        let trimmed = line.trim().to_lowercase();
+
+        if inside_do_block {
+            do_block.push(line);
+            if trimmed.starts_with("$do$;") {
+                inside_do_block = false;
+                let mentions_cron = do_block
+                    .iter()
+                    .any(|blocked| blocked.to_lowercase().contains("cron."));
+                if !mentions_cron {
+                    kept.append(&mut do_block);
                 }
-                return false;
+                do_block.clear();
             }
+            continue;
+        }
+        if trimmed.starts_with("do $do$") {
+            inside_do_block = true;
+            do_block.push(line);
+            continue;
+        }
 
-            if trimmed.starts_with("create or replace function cron.") {
-                inside_cron_function = true;
+        if trimmed.starts_with("create or replace function cron.") {
+            inside_cron_function = true;
+        }
+        if inside_cron_function {
+            if trimmed == "$$;" {
+                inside_cron_function = false;
             }
-            if inside_cron_function {
-                if trimmed == "$$;" {
-                    inside_cron_function = false;
-                }
-                return false;
-            }
+            continue;
+        }
 
-            !trimmed.starts_with("create extension if not exists pg_cron")
-                && !trimmed.starts_with("select cron.schedule")
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
+        if trimmed.starts_with("create extension if not exists pg_cron")
+            || trimmed.starts_with("select cron.schedule")
+        {
+            continue;
+        }
+        kept.push(line);
+    }
+
+    kept.join("\n")
 }
 
 /// Returns a connection pool to the shared test database.

--- a/tests/test_ensemble_events.rs
+++ b/tests/test_ensemble_events.rs
@@ -8,7 +8,7 @@
 mod common;
 
 use fund::common::events::{
-    emit_event, get_consumer_offset, latest_event_after, update_consumer_offset, EventType,
+    emit_event, get_consumer_offset, latest_event_after, update_consumer_offset, EventType, Outcome,
 };
 use fund::inference::database::{insert_predictions, upsert_model_run, ModelRunRecord};
 use serial_test::serial;
@@ -43,22 +43,26 @@ async fn test_consumer_offset_round_trip() {
 async fn test_latest_event_after_matches_only_requested_type() {
     let pool = common::get_pg_pool().await;
 
-    let before = latest_event_after(&pool, EventType::EquityPredictionsRequested, 0)
+    let before = latest_event_after(&pool, EventType::EquityPredictions(Outcome::Requested), 0)
         .await
         .unwrap()
         .unwrap_or(0);
 
     emit_event(
         &pool,
-        EventType::EquityPredictionsRequested,
+        EventType::EquityPredictions(Outcome::Requested),
         &serde_json::json!({}),
     )
     .await
     .unwrap();
 
-    let found = latest_event_after(&pool, EventType::EquityPredictionsRequested, before)
-        .await
-        .unwrap();
+    let found = latest_event_after(
+        &pool,
+        EventType::EquityPredictions(Outcome::Requested),
+        before,
+    )
+    .await
+    .unwrap();
     assert!(found.is_some());
     let requested_id = found.unwrap();
     assert!(requested_id > before);
@@ -72,9 +76,13 @@ async fn test_latest_event_after_matches_only_requested_type() {
     .await
     .unwrap();
     assert_eq!(
-        latest_event_after(&pool, EventType::EquityPredictionsRequested, requested_id)
-            .await
-            .unwrap(),
+        latest_event_after(
+            &pool,
+            EventType::EquityPredictions(Outcome::Requested),
+            requested_id
+        )
+        .await
+        .unwrap(),
         None
     );
 }

--- a/tests/test_ensemble_events.rs
+++ b/tests/test_ensemble_events.rs
@@ -7,11 +7,18 @@
 
 mod common;
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
 use fund::common::events::{
-    emit_event, get_consumer_offset, latest_event_after, update_consumer_offset, EventType, Outcome,
+    emit_event, get_consumer_offset, latest_event_after, run_event_listener,
+    update_consumer_offset, EventNotification, EventType, Outcome,
 };
 use fund::inference::database::{insert_predictions, upsert_model_run, ModelRunRecord};
 use serial_test::serial;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 #[tokio::test]
@@ -165,4 +172,214 @@ async fn test_insert_predictions_writes_rows() {
             .await
             .unwrap();
     assert_eq!(count, 1);
+}
+
+// --- Shared LISTEN loop ---
+//
+// These exercise `run_event_listener` against the real NOTIFY channel, because
+// the behaviour worth pinning down — that a notification reaches the handler,
+// that catch-up runs per connection, and that cancellation is prompt without
+// truncating in-flight work — only exists end to end.
+//
+// Every test tags its events with a unique marker in the payload and ignores
+// anything else, since the channel is shared with whatever else is running.
+
+/// Emits a `stress_test` event carrying a unique marker.
+async fn emit_marked_event(pool: &sqlx::PgPool, marker: &str) {
+    emit_event(
+        pool,
+        EventType::StressTest,
+        &serde_json::json!({"marker": marker}),
+    )
+    .await
+    .unwrap();
+}
+
+/// Returns true when a notification carries the given marker.
+fn has_marker(notification: &EventNotification, marker: &str) -> bool {
+    notification
+        .payload()
+        .get("marker")
+        .and_then(|value| value.as_str())
+        == Some(marker)
+}
+
+#[tokio::test]
+#[serial]
+async fn test_run_event_listener_dispatches_notifications_to_the_handler() {
+    let pool = common::get_pg_pool().await;
+    let marker = Uuid::new_v4().to_string();
+    let token = CancellationToken::new();
+    let seen: Arc<Mutex<Vec<i64>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let listener = tokio::spawn({
+        let (pool, token, seen, marker) =
+            (pool.clone(), token.clone(), seen.clone(), marker.clone());
+        async move {
+            run_event_listener(
+                &pool,
+                &token,
+                "test-dispatch",
+                || async { Ok(()) },
+                |notification| {
+                    let seen = seen.clone();
+                    let marker = marker.clone();
+                    async move {
+                        if has_marker(&notification, &marker) {
+                            seen.lock().await.push(notification.event_id());
+                        }
+                    }
+                },
+            )
+            .await
+        }
+    });
+
+    // The listener needs to be subscribed before the event is emitted; NOTIFY
+    // does not replay to a connection that was not listening at the time.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    emit_marked_event(&pool, &marker).await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while seen.lock().await.is_empty() && tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    token.cancel();
+    listener.await.unwrap().unwrap();
+
+    let received = seen.lock().await;
+    assert_eq!(
+        received.len(),
+        1,
+        "handler should have received exactly the marked event"
+    );
+    assert!(received[0] > 0, "event_id should be a real row id");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_run_event_listener_runs_catch_up_before_dispatching() {
+    let pool = common::get_pg_pool().await;
+    let token = CancellationToken::new();
+    let catch_up_runs = Arc::new(AtomicUsize::new(0));
+
+    let listener = tokio::spawn({
+        let (pool, token, catch_up_runs) = (pool.clone(), token.clone(), catch_up_runs.clone());
+        async move {
+            run_event_listener(
+                &pool,
+                &token,
+                "test-catch-up",
+                || {
+                    let catch_up_runs = catch_up_runs.clone();
+                    async move {
+                        catch_up_runs.fetch_add(1, Ordering::SeqCst);
+                        Ok(())
+                    }
+                },
+                |_| async {},
+            )
+            .await
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    token.cancel();
+    listener.await.unwrap().unwrap();
+
+    assert_eq!(
+        catch_up_runs.load(Ordering::SeqCst),
+        1,
+        "catch-up should run exactly once per connection"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_run_event_listener_exits_promptly_when_cancelled_while_idle() {
+    let pool = common::get_pg_pool().await;
+    let token = CancellationToken::new();
+
+    let listener = tokio::spawn({
+        let (pool, token) = (pool.clone(), token.clone());
+        async move {
+            run_event_listener(
+                &pool,
+                &token,
+                "test-idle-cancel",
+                || async { Ok(()) },
+                |_| async {},
+            )
+            .await
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let cancelled_at = tokio::time::Instant::now();
+    token.cancel();
+    listener.await.unwrap().unwrap();
+
+    assert!(
+        cancelled_at.elapsed() < Duration::from_secs(2),
+        "an idle listener should exit on cancellation without waiting for a notification"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_run_event_listener_finishes_an_in_flight_handler_before_exiting() {
+    let pool = common::get_pg_pool().await;
+    let marker = Uuid::new_v4().to_string();
+    let token = CancellationToken::new();
+    let handler_started = Arc::new(AtomicUsize::new(0));
+    let handler_finished = Arc::new(AtomicUsize::new(0));
+
+    let listener = tokio::spawn({
+        let (pool, token, marker) = (pool.clone(), token.clone(), marker.clone());
+        let (started, finished) = (handler_started.clone(), handler_finished.clone());
+        async move {
+            run_event_listener(
+                &pool,
+                &token,
+                "test-in-flight",
+                || async { Ok(()) },
+                |notification| {
+                    let (started, finished) = (started.clone(), finished.clone());
+                    let marker = marker.clone();
+                    async move {
+                        if !has_marker(&notification, &marker) {
+                            return;
+                        }
+                        started.fetch_add(1, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_millis(800)).await;
+                        finished.fetch_add(1, Ordering::SeqCst);
+                    }
+                },
+            )
+            .await
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    emit_marked_event(&pool, &marker).await;
+
+    // Cancel while the handler is mid-sleep.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while handler_started.load(Ordering::SeqCst) == 0 && tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        handler_started.load(Ordering::SeqCst),
+        1,
+        "handler should have started before cancellation"
+    );
+    token.cancel();
+
+    listener.await.unwrap().unwrap();
+    assert_eq!(
+        handler_finished.load(Ordering::SeqCst),
+        1,
+        "an in-flight handler must run to completion rather than being dropped"
+    );
 }

--- a/tests/test_ensemble_events.rs
+++ b/tests/test_ensemble_events.rs
@@ -184,6 +184,13 @@ async fn test_insert_predictions_writes_rows() {
 // Every test tags its events with a unique marker in the payload and ignores
 // anything else, since the channel is shared with whatever else is running.
 
+/// How long a cancelled listener is given to return before the test fails.
+///
+/// Without this the four tests below would hang rather than fail if
+/// `run_event_listener` stopped returning on cancellation, which turns a clear
+/// regression into a silent CI timeout.
+const LISTENER_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Emits a `stress_test` event carrying a unique marker.
 async fn emit_marked_event(pool: &sqlx::PgPool, marker: &str) {
     emit_event(
@@ -246,7 +253,11 @@ async fn test_run_event_listener_dispatches_notifications_to_the_handler() {
     }
 
     token.cancel();
-    listener.await.unwrap().unwrap();
+    tokio::time::timeout(LISTENER_EXIT_TIMEOUT, listener)
+        .await
+        .expect("listener did not exit after cancellation")
+        .unwrap()
+        .unwrap();
 
     let received = seen.lock().await;
     assert_eq!(
@@ -286,7 +297,11 @@ async fn test_run_event_listener_runs_catch_up_before_dispatching() {
 
     tokio::time::sleep(Duration::from_millis(300)).await;
     token.cancel();
-    listener.await.unwrap().unwrap();
+    tokio::time::timeout(LISTENER_EXIT_TIMEOUT, listener)
+        .await
+        .expect("listener did not exit after cancellation")
+        .unwrap()
+        .unwrap();
 
     assert_eq!(
         catch_up_runs.load(Ordering::SeqCst),
@@ -318,7 +333,11 @@ async fn test_run_event_listener_exits_promptly_when_cancelled_while_idle() {
     tokio::time::sleep(Duration::from_millis(300)).await;
     let cancelled_at = tokio::time::Instant::now();
     token.cancel();
-    listener.await.unwrap().unwrap();
+    tokio::time::timeout(LISTENER_EXIT_TIMEOUT, listener)
+        .await
+        .expect("listener did not exit after cancellation")
+        .unwrap()
+        .unwrap();
 
     assert!(
         cancelled_at.elapsed() < Duration::from_secs(2),
@@ -376,7 +395,11 @@ async fn test_run_event_listener_finishes_an_in_flight_handler_before_exiting() 
     );
     token.cancel();
 
-    listener.await.unwrap().unwrap();
+    tokio::time::timeout(LISTENER_EXIT_TIMEOUT, listener)
+        .await
+        .expect("listener did not exit after cancellation")
+        .unwrap()
+        .unwrap();
     assert_eq!(
         handler_finished.load(Ordering::SeqCst),
         1,


### PR DESCRIPTION
# Overview

Combines PRs 2 and 3 of the event flow cleanup. They are the same surface: PR 2 would have
converted four string-comparison chains into exhaustive matches, and PR 3 would then have rewritten
every one of those arms into the option C shape. Landing them together means each dispatch site's
match arms are written once, in their final form, rather than written and then immediately revised.

## Changes

- Collapse 29 flat `EventType` variants into 10: seven families carrying an `Outcome`
  (`Requested`/`Started`/`Completed`/`Errored`) plus three singletons.
- Add `EventType::is_control`, one auditable list of the nine events a consumer acts on. Everything
  else is an audit record for the dashboard and the nightly export.
- Add `EventNotification`, which owns its payload and can only be built by a validating parse.
  Holding one is proof the payload was well-formed, so the two consumers that checked for an
  `event_id` of zero by hand no longer need to.
- Add `run_event_listener`, replacing the connect / listen / catch-up / select / dispatch
  scaffolding the three application consumers each carried a copy of. Catch-up stays a
  per-connection callback because the strategies genuinely differ.
- Convert every dispatch site to an exhaustive `match` on `EventType`.
- Make `equity_rebalance_sessions.trigger_reason` a `RebalanceTrigger` enum, threaded from the four
  real call paths.
- Carry the flagged pair and observed z-score on evaluation requests, and report at `warn` when the
  authoritative pass declines to close that pair.
- Fix `filter_schema_for_test`, which stripped the `events_notify` trigger along with pg_cron
  scheduling, so NOTIFY has never fired in the test database.

## Context

**No behavior changes on the dispatch path.** The same handlers run on the same events in the same
order, and every stored event string is byte-identical. Those strings sit in existing `events` rows,
in the nightly S3 exports, and in the dashboard's parsing path, so they are a stable external
interface rather than an implementation detail; three tests guard them — an exact literal table, a
parse round-trip, and a cross-product check that fails when a variant is added without a table entry.

**Why the dashboard keeps its own loop.** It is shaped differently from the three application
consumers: owned `Arc` state rather than borrowed `&AppState`, no cancellation token and so no
shutdown drain, a 5s reconnect backoff against their 30s. Folding it in would have meant either
changing its behavior or parameterising the helper for a single caller. The split turns out to be
principled rather than a carve-out — the shared loop serves the consumers that act on control
events, and the dashboard is the one that records all of them.

**The test-harness fix is what makes any of this verifiable.** `filter_schema_for_test` dropped
every `DO $do$` block to remove pg_cron scheduling, but the `events_notify` trigger is created
inside one too. The test database has therefore never had the trigger, NOTIFY has never fired
there, and no test has ever exercised delivery — which is how four hand-rolled parsers drifted
apart unnoticed. The filter now buffers each block and keeps the ones that do not mention cron,
and four new tests exercise real delivery: a notification reaches the handler, catch-up runs once
per connection, an idle listener exits promptly on cancellation, and an in-flight handler runs to
completion rather than being dropped.

**Two variants exist without emitters, deliberately.** `PortfolioRebalance(Requested)` is
representable so the family keeps a uniform shape; it round-trips correctly and is documented as
unreachable. `RebalanceTrigger::Legacy` round-trips the pre-enum `"portfolio_evaluation"` literal,
because mapping those rows onto a real trigger would invent provenance that was never recorded and
erroring on them would break exports of any database carrying history. No schema change is needed:
`trigger_reason` stays `TEXT`, only the values written change.

**Disagreement reporting is observability only.** The carried z-score is stale by the time the pass
reads it — reconciliation, a positions fetch, and a historical price load all happen in between —
so the pass reprices rather than trusting it. These two code paths produced a livelock once by
measuring the same spread differently, which is why they share `close_reason_for` and
`z_score_against`; a systematic divergence recurring is the failure most worth hearing about, and
until now an evaluation that flagged a pair and a pass that quietly did nothing looked identical
from outside.

Verified with `devenv tasks run checks:rust`: 1,317 tests pass, coverage 80.65%, and
`cargo sqlx prepare --check` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer lifecycle event tracking with standardized requested, started, completed, and errored outcomes.
  - Added structured rebalance trigger types, including session start, live crossing, prediction refresh, retries, and manual runs.
  - Rebalance results now include close signals with associated pairs and reasons.
  - Portfolio evaluation notifications now include the crossed pair and live score.

- **Reliability**
  - Improved event listening, reconnect recovery, notification validation, and graceful shutdown handling.
  - Invalid rebalance trigger values are now rejected instead of silently accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->