### PR TITLE
Trim documentation across `src/`, move TiDE-only modules, correct `devenv` comments

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -324,8 +324,29 @@ in {
       [ -n "$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "${objectStoreEndpoint}" 2>/dev/null | grep -v '^000$')" ]
     }
 
+    # Probe the endpoint the suite actually connects to, not pg_isready's default.
+    # tests/common/mod.rs reads TEST_DATABASE_URL_BASE and falls back to
+    # localhost:5432, so the probe derives host and port from the same value. A
+    # bare `pg_isready` is a proxy for that, and the two can disagree — a data
+    # directory carries its port in postgresql.conf, so a profile whose directory
+    # was initialised while 5432 was taken keeps the shifted port afterwards. The
+    # proxy then loops for a minute against a port nothing is listening on and
+    # reports "did not start", which is the one thing that had not happened.
+    test_base="''${TEST_DATABASE_URL_BASE:-postgresql://localhost:5432}"
+    test_authority="''${test_base#*//}"
+    test_authority="''${test_authority%%/*}"
+    test_host="''${test_authority%%:*}"
+    test_port="''${test_authority#*:}"
+    if [ "$test_port" = "$test_host" ]; then
+      test_port=5432
+    fi
+
+    postgres_up() {
+      pg_isready -q -h "$test_host" -p "$test_port" 2>/dev/null
+    }
+
     needed=""
-    pg_isready -q 2>/dev/null || needed="postgres"
+    postgres_up || needed="postgres"
     object_store_up || needed="$needed object-store"
 
     if [ -z "$needed" ]; then
@@ -338,7 +359,7 @@ in {
     for _ in $(seq 1 60); do
       pg_ok=false
       store_ok=false
-      pg_isready -q 2>/dev/null && pg_ok=true
+      postgres_up && pg_ok=true
       object_store_up && store_ok=true
       if [ "$pg_ok" = true ] && [ "$store_ok" = true ]; then
         exit 0
@@ -347,9 +368,11 @@ in {
     done
 
     echo "Test services did not start within 60s"
-    echo "  postgres:     $(pg_isready -q 2>/dev/null && echo ready || echo down)"
+    echo "  postgres:     $test_host:$test_port ($(postgres_up && echo ready || echo down))"
     echo "  object-store: ${objectStoreEndpoint}"
     echo "Start them with 'devenv --profile test up postgres object-store --detach'."
+    echo "If postgres is listening on another port, that port is recorded in the"
+    echo "profile's postgresql.conf; remove the state directory to reinitialise it."
     exit 1
   '';
 
@@ -700,7 +723,7 @@ in {
           echo "  Optional: SEED_END_DATE=YYYY-MM-DD (defaults to today, US/Eastern)"
           echo ""
           echo "  Seeds ticker metadata and daily bars into PostgreSQL. The screen needs 60"
-          echo "  sessions of aligned closes and the model 70, so allow at least six months."
+          echo "  sessions of aligned closes and the model 40, so allow at least six months."
           exit 1
         fi
 
@@ -725,8 +748,14 @@ in {
     # recovering from a breaking schema change.
     "database:reset".exec = "reset-database";
 
-    # Dumps the live database and uploads it to S3. Also runs automatically via
-    # pg_cron at 22:00 UTC on weekdays after all nightly exports complete.
+    # Dumps the live database with pg_dump and uploads it to S3. Manual only:
+    # nothing schedules it. pg_cron runs SQL inside the database and cannot shell
+    # out to pg_dump, so this cannot become a cron job as written.
+    #
+    # Not the same thing as the nightly export, which the market data sync does
+    # chain automatically. That writes per-table parquet under exports/ for
+    # querying; this writes a pg_restore-able dump under database/backups/. Only
+    # this one restores equity_pairs, which nothing else can reconstruct.
     "database:backup".exec = "backup-database";
 
     # Applies the schema to the fund database. Safe to re-run (all DDL is

--- a/devenv.nix
+++ b/devenv.nix
@@ -332,14 +332,34 @@ in {
     # was initialised while 5432 was taken keeps the shifted port afterwards. The
     # proxy then loops for a minute against a port nothing is listening on and
     # reports "did not start", which is the one thing that had not happened.
+    # Stripped in this order because each step can otherwise hide the next: a query string can
+    # contain a slash, userinfo can contain a colon, and an IPv6 host contains several. Splitting
+    # the authority on its first colon without removing userinfo first reads
+    # `user:password@host:5433` as host `user`, and pg_isready then waits out its timeout against a
+    # host that does not exist.
     test_base="''${TEST_DATABASE_URL_BASE:-postgresql://localhost:5432}"
     test_authority="''${test_base#*//}"
+    test_authority="''${test_authority%%\?*}"
     test_authority="''${test_authority%%/*}"
-    test_host="''${test_authority%%:*}"
-    test_port="''${test_authority#*:}"
-    if [ "$test_port" = "$test_host" ]; then
-      test_port=5432
-    fi
+    test_authority="''${test_authority##*@}"
+    case "$test_authority" in
+      \[*\]*)
+        # Bracketed IPv6. libpq wants the bare address, so the brackets come off.
+        test_host="''${test_authority#\[}"
+        test_host="''${test_host%%\]*}"
+        test_port="''${test_authority##*\]}"
+        test_port="''${test_port#:}"
+        ;;
+      *:*)
+        test_host="''${test_authority%%:*}"
+        test_port="''${test_authority##*:}"
+        ;;
+      *)
+        test_host="$test_authority"
+        test_port=""
+        ;;
+    esac
+    [ -z "$test_port" ] && test_port=5432
 
     postgres_up() {
       pg_isready -q -h "$test_host" -p "$test_port" 2>/dev/null

--- a/src/bin/fund.rs
+++ b/src/bin/fund.rs
@@ -31,22 +31,17 @@ const LISTENER_RECONNECT_DELAY: Duration = Duration::from_secs(5);
 
 /// How long to wait for running handlers after shutdown is requested.
 ///
-/// The handlers that matter here are the ones with side effects part-applied: a liquidation between
-/// two broker orders, an export between S3 and the purge, or any handler that has not yet written
-/// its terminal event. Dropping one of those mid-sequence leaves a `_requested` row with no outcome
-/// while the process logs a clean stop.
+/// What matters is a handler with side effects part-applied: a liquidation between two broker
+/// orders, an export between S3 and the purge, or one that has not yet written its terminal event.
+/// Dropping one leaves a `_requested` row with no outcome while the process logs a clean stop.
 ///
-/// Derived from the work rather than picked as a round number. The longest thing this can be waiting
-/// on is one pair being opened, which is two legs at
+/// Derived from the work. The longest wait is one pair opening, two legs at
 /// [`fund::portfolio::execute::FILL_TIMEOUT`] each — sixty seconds. Seventy-five leaves margin for
-/// the terminal event write, and stays well inside the 120 seconds process-compose allows before it
-/// escalates.
+/// the terminal event write and stays inside the 120 process-compose allows before escalating.
 ///
-/// That bound only holds because the evaluation pass stops *starting* pairs once shutdown is
-/// requested; see `entries_abandoned` in [`fund::portfolio::evaluate`]. Without that check the pass
-/// would work through every approved candidate sequentially and no fixed timeout would cover it —
-/// the previous sixty seconds was exactly one pair's worst case with nothing left over, while its
-/// own comment claimed it was "longer than any handler should take".
+/// The bound holds only because the evaluation pass stops *starting* pairs once shutdown is
+/// requested; see `entries_abandoned` in [`fund::portfolio::evaluate`]. Without that the pass works
+/// through every approved candidate and no fixed timeout covers it.
 const HANDLER_DRAIN_TIMEOUT: Duration = Duration::from_secs(75);
 
 #[tokio::main]
@@ -137,23 +132,17 @@ async fn listen(
         info!("Listening for events");
 
         // Recovery runs *after* subscribing and *before* the first `recv`, on every connection
-        // rather than once at startup. Both halves of that matter.
+        // rather than once at startup.
         //
         // After subscribing, because PostgreSQL delivers a NOTIFY only to sessions already
-        // listening — it is never persisted. Scanning first and subscribing second leaves a window
-        // in which a request is written, notified to nobody, and then missed by the scan that
-        // already ran. The row sits at `_requested` with no terminal outcome and nothing looks
-        // again until the next restart; for a liquidation that means positions held overnight.
+        // listening and never persists it. Scanning first leaves a window where a request is
+        // written, notified to nobody, and missed by the scan that already ran — the row sits at
+        // `_requested` until the next restart, which for a liquidation means positions held
+        // overnight. The same window reopens on every reconnect, and that one recurs unattended.
         //
-        // On every connection, because the same window reopens on every reconnect — and that one
-        // recurs unattended. Anything notified while the connection was down was addressed to a
-        // session that no longer exists.
-        //
-        // Subscribing first cannot double-dispatch. The subscription is passive: notifications
-        // queue on the connection until `recv` is called, which does not happen until this returns.
-        // A request that recovery replays and the queue also carries arrives twice, and `claim` --
-        // a mutex-guarded set insert -- admits exactly one of them. Re-scanning on every reconnect
-        // is likewise cheap and safe: the query is bounded to today's Eastern date, and
+        // Subscribing first cannot double-dispatch: the subscription is passive, so notifications
+        // queue until `recv` is called. A request both replayed and queued arrives twice, and
+        // `claim` admits one. Re-scanning is bounded to today's Eastern date, and
         // `Command::PortfolioEvaluation` is `Recovery::Skip`, so a reconnect cannot replay a pass
         // whose inputs have gone stale.
         handlers::recover(Arc::clone(&state)).await;
@@ -161,16 +150,11 @@ async fn listen(
             tokio::select! {
                 () = shutdown.cancelled() => return,
                 // `try_recv`, not `recv`. `recv` loops over `try_recv` internally and returns only
-                // notifications, so a dropped connection is invisible to the caller — sqlx
-                // reconnects, re-subscribes, and carries on, and its own documentation is explicit
-                // that "any received while the connection was lost will not be returned". A
-                // reconnect handled that transparently is a silent hole: the request row exists,
-                // nothing dispatched it, and no log line was ever written. Measured, not assumed —
-                // terminating the listener's backend and inserting a request in the gap left it at
-                // `_requested` with no terminal outcome and not one line in the log.
-                //
-                // `try_recv` surfaces that boundary as `Ok(None)`, which is the only place the
-                // rescan can be hung.
+                // notifications, so a dropped connection is invisible to the caller: sqlx
+                // reconnects and carries on, and its documentation is explicit that anything
+                // received while the connection was lost is not returned. That is a silent hole —
+                // the request row exists, nothing dispatched it, no log line. `try_recv` surfaces
+                // the boundary as `Ok(None)`, the only place the rescan can be hung.
                 received = listener.try_recv() => match received {
                     Ok(Some(notification)) => {
                         // Reap anything already finished so the set does not grow across a session.
@@ -178,19 +162,15 @@ async fn listen(
                         dispatch(&state, handlers_in_flight, notification.payload()).await
                     }
                     Ok(None) => {
-                        // sqlx has already reconnected and re-subscribed by the time this returns,
-                        // so there is nothing to rebuild — only the gap to close. Anything notified
-                        // while the connection was down is gone, and the table is the only record
-                        // that it happened.
+                        // sqlx has already reconnected and re-subscribed; only the gap needs
+                        // closing. The table is the only record that anything notified during the
+                        // drop happened.
                         //
-                        // This makes delivery at-least-once rather than exactly-once: a request
-                        // notified just before the drop can still be sitting in sqlx's buffer, so
-                        // the rescan replays it and the buffered notification then dispatches it
-                        // again. Observed, 2ms apart. That is the accepted shape of this design —
-                        // every `Recovery::Replay` command is idempotent because replay *is* the
-                        // recovery mechanism, and the only cost is a duplicate `_completed` row in
-                        // the audit trail. Suppressing it would mean a round trip per dispatch to
-                        // ask a question the in-flight claim exists to avoid asking.
+                        // Delivery is therefore at-least-once: a request notified just before the
+                        // drop can still be in sqlx's buffer, so the rescan replays it and the
+                        // buffer dispatches it again. Every `Recovery::Replay` command is
+                        // idempotent because replay *is* the recovery mechanism, and the cost is a
+                        // duplicate `_completed` row.
                         warn!("Listener connection was re-established; rescanning for missed requests");
                         handlers::recover(Arc::clone(&state)).await;
                     }

--- a/src/bin/seed_equity_bars.rs
+++ b/src/bin/seed_equity_bars.rs
@@ -1,20 +1,16 @@
 //! Backfills daily bars into an empty database over an arbitrary date range.
 //!
-//! Bootstrap tooling. The running service's `market_data_sync` closes a three-session gap, which is
-//! the right window for a database that is already populated and the wrong one for a database that
-//! is not: the screen needs sixty sessions of aligned closes and the model seventy, so a fresh
-//! deployment cannot trade until something has fetched several months at once.
+//! Bootstrap tooling. The service's `market_data_sync` closes a three-session gap, which is right
+//! for a populated database and wrong for an empty one: the screen needs sixty sessions of aligned
+//! closes and the model forty, so a fresh deployment cannot trade until something has fetched
+//! several months at once.
 //!
 //! Usage: `seed_equity_bars <start YYYY-MM-DD> [end YYYY-MM-DD]`
 //! The end date defaults to today (US/Eastern) when omitted.
 //!
-//! The previous version took `--source <massive|s3>` and `--target <s3|postgresql|all>`. The
-//! targets are gone with the topology that justified them — the trainer archives its own S3 parquet
-//! rather than reading what a seed run left behind — and the source is gone because there is only
-//! one correct answer. Massive's grouped endpoint takes a **date**, not a symbol list, and that is
-//! what makes a backfill honest: asking Alpaca means asking for its *current* tradable set, so
-//! every symbol delisted since the start date would be silently missing from its own history and
-//! the model would train on a universe that survived by construction.
+//! Massive is the only source, because its grouped endpoint takes a **date** rather than a symbol
+//! list. Asking Alpaca means asking for its *current* tradable set, so every symbol delisted since
+//! the start date would be missing from its own history.
 
 use chrono::{Duration, NaiveDate, Utc};
 use tracing::{error, info, warn};

--- a/src/bin/seed_equity_details.rs
+++ b/src/bin/seed_equity_details.rs
@@ -7,9 +7,8 @@
 //!
 //! Usage: `seed_equity_details`
 //!
-//! There are no arguments. The previous version took `--target <s3|postgresql|all>`, from a data
-//! topology that no longer exists — the trainer reads the same embedded CSV directly rather than a
-//! copy of it in a bucket, so there is no second target left to choose between.
+//! There are no arguments. The trainer reads the same embedded CSV directly rather than a copy in
+//! a bucket, so PostgreSQL is the only target.
 
 use fund::common::database::connect_pool;
 use fund::common::observability::init_tracing;

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -1,17 +1,14 @@
 //! The trainer: fetch, archive, train, publish. Runs on its own machine with no database.
 //!
-//! Four stages, and the first one is new. The trainer used to read a dataset the application's
-//! nightly export had written, which coupled two machines through a bucket and made a failed export
-//! cost the next day's model. It now fetches its own bars from Massive and writes its own parquet,
-//! so the only thing crossing the boundary between the two VMs is the finished artifact.
+//! It fetches its own bars from Massive and writes its own parquet rather than reading the
+//! application's nightly export, so the only thing crossing between the two VMs is the finished
+//! artifact and a failed export cannot cost the next day's model.
 //!
-//! Both sides fetch through [`fund::data::bars`] and build frames through
-//! [`fund::data::bars::bars_to_dataframe`]. That shared path is the point: if the trainer's frames
-//! and the application's ever diverged, the model would train on columns the inference path does
-//! not produce, and it would surface as bad predictions rather than as a build error.
+//! Frames are built through [`fund::data::bars::bars_to_dataframe`], shared with the application:
+//! if the two diverged, the model would train on columns the inference path does not produce.
 //!
-//! Nothing here writes to a database, reads one, or talks to Alpaca. Massive answers by date, so
-//! there is no symbol list to build and therefore no broker to ask for one.
+//! Nothing here touches a database or Alpaca — Massive answers by date, so there is no symbol list
+//! to build and no broker to ask for one.
 
 use std::io::Cursor;
 
@@ -29,16 +26,16 @@ use fund::common::types::{MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
 use fund::data::bars;
 use fund::data::calendar::{eastern_date, is_weekend};
 use fund::data::details;
-use fund::models::artifact::{
+use fund::models::tide::artifact::{
     candidate_folders_descending, list_run_folders, package_dir_to_tar_gz, upload_artifact,
 };
-use fund::models::predict::consolidate_data;
 use fund::models::tide::config::ModelParameters;
 use fund::models::tide::data::input_feature_size;
 use fund::models::tide::drift::{check_drift, DriftStatus};
 use fund::models::tide::evaluate::evaluate;
 use fund::models::tide::fit::{filter_training_bars, fit, write_artifact_json};
 use fund::models::tide::model::TideModel;
+use fund::models::tide::predict::consolidate_data;
 use fund::models::tide::train::{train, TrainBackend, TrainConfig};
 
 const INPUT_LENGTH: usize = 35;
@@ -57,13 +54,9 @@ const DETAILS_ARCHIVE_KEY: &str = "data/equity/details/details.csv";
 
 /// Sessions the fetch stage re-requests each night.
 ///
-/// Three rather than one, for the same reason the application's sync uses three: a night the
-/// trainer did not run leaves a hole in the archive that nothing else fills.
-///
-/// The merge below is what makes the overlap cheap. It matters less than it did -- the grouped
-/// endpoint returns whatever traded on the date, so a delisted symbol's bars come back for the days
-/// it was still trading rather than vanishing with the current tradable set -- but a plain overwrite
-/// would still discard anything the API omits from a later response, and the merge costs nothing.
+/// Three rather than one: a night the trainer did not run leaves a hole nothing else fills. The
+/// merge below makes the overlap cheap, and guards against a later response omitting rows an
+/// earlier one had.
 const FETCH_LOOKBACK_SESSIONS: i64 = 3;
 
 /// Calendar days of archive the training window spans by default.
@@ -359,16 +352,11 @@ fn training_config() -> Result<TrainConfig, Box<dyn std::error::Error>> {
 
 /// Fetches the most recent sessions' bars from Massive and writes them to the archive.
 ///
-/// Returns the number of rows written. There is no universe here and no symbol list: the grouped
-/// endpoint is asked for a date and answers with every stock that traded on it. That is what the
-/// trainer wants — `filter_training_bars` applies the price and volume thresholds to the rows
-/// themselves further down, so pre-filtering here would only decide which names the model is
-/// allowed to have ever seen.
-///
-/// It also means the trainer needs no Alpaca credentials at all. It used to call
-/// `fetch_tradable_assets` purely to build that symbol list, which had the side effect of pinning
-/// the archive to whatever Alpaca lists *today* — the survivorship problem the merge below exists
-/// to limit. Asking for a date removes the cause rather than the symptom.
+/// Returns rows written. No universe and no symbol list: the endpoint is asked for a date and
+/// answers with every stock that traded. `filter_training_bars` applies the thresholds further
+/// down, so pre-filtering here would only decide which names the model may ever have seen — and
+/// building a list from `fetch_tradable_assets` would pin the archive to whatever Alpaca lists
+/// *today*, which is the survivorship problem.
 async fn fetch_and_archive(
     s3_client: &aws_sdk_s3::Client,
     bucket: &str,
@@ -537,9 +525,9 @@ async fn load_archived_bars(
 
 /// CRPS from the most recent prior runs' `run_metadata.json`, newest first.
 ///
-/// Read from the standalone metadata object rather than from inside the artifact tarball, which is
-/// what the deleted `model_runs` lineage table used to make possible. Failures degrade to an empty
-/// history: a drift baseline that cannot be read is not a reason to fail a training run.
+/// Read from the standalone metadata object rather than from inside the artifact tarball, so a
+/// baseline can be built without downloading every prior run. Failures degrade to an empty history:
+/// a drift baseline that cannot be read is not a reason to fail a training run.
 async fn fetch_prior_crps(
     s3_client: &aws_sdk_s3::Client,
     bucket: &str,

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -526,8 +526,9 @@ async fn load_archived_bars(
 /// CRPS from the most recent prior runs' `run_metadata.json`, newest first.
 ///
 /// Read from the standalone metadata object rather than from inside the artifact tarball, so a
-/// baseline can be built without downloading every prior run. Failures degrade to an empty history:
-/// a drift baseline that cannot be read is not a reason to fail a training run.
+/// baseline can be built without downloading every prior run. An unreadable run is skipped and the
+/// rest are kept; only an unlistable prefix yields nothing. Either way a drift baseline that cannot
+/// be read is not a reason to fail a training run.
 async fn fetch_prior_crps(
     s3_client: &aws_sdk_s3::Client,
     bucket: &str,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,15 +1,9 @@
 //! Shared vocabulary and service infrastructure.
 //!
-//! [`types`] holds the domain vocabulary every other module speaks — tickers, bars, quotes,
-//! predictions, and the validated financial primitives. [`events`] is the coordination mechanism:
-//! six commands, three outcomes, and the scan that recovers work missed while the process was down.
-//! The remainder is bootstrap shared by every entry point.
-//!
-//! Two market data providers, split by question rather than by preference. [`alpaca`] is the venue,
-//! so it answers everything about our account and about the current moment: the clock, the calendar,
-//! the tradable set, intraday snapshots, orders, positions, balances. [`massive`] answers one
-//! question — what did the whole market do on this date — because its grouped endpoint takes no
-//! symbol list, which is what keeps historical bars free of survivorship bias.
+//! Two market data providers, split by question rather than preference. [`alpaca`] is the venue,
+//! so it answers everything about our account and the current moment. [`massive`] answers only what
+//! the whole market did on a given date — its grouped endpoint takes no symbol list, which is what
+//! keeps historical bars free of survivorship bias.
 
 pub mod alpaca;
 pub mod aws;

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -4,9 +4,11 @@
 //! clock, calendar, assets, orders, positions — and the market data API what things *cost*. They
 //! share authentication and an error type and nothing else, which is why one file holds both.
 //!
-//! Deliberately thin, since Alpaca is the source of truth for fills and balances. Ambiguity — a
-//! snapshot with no quote, a calendar day with no duration — is surfaced rather than defaulted,
-//! because a missing value and a zero one are indistinguishable after the fact.
+//! Deliberately thin, since Alpaca is the source of truth for fills and balances. Deserialization
+//! surfaces ambiguity rather than defaulting it — a snapshot with no quote, a calendar day with no
+//! duration — because a missing value and a zero one are indistinguishable after the fact. What to
+//! do about a missing value is left to the consumer: [`Snapshot::reference_price`], for one,
+//! deliberately falls back to the last trade.
 
 use std::collections::HashSet;
 use std::num::NonZeroU32;

--- a/src/common/alpaca.rs
+++ b/src/common/alpaca.rs
@@ -1,16 +1,12 @@
 //! The Alpaca integration: credentials, the trading API, and the market data API.
 //!
-//! Alpaca is two services behind one set of credentials. The trading API at `api.alpaca.markets`
-//! answers what the market *is* — the clock, the published calendar, the asset universe, and in due
-//! course orders and positions. The market data API at `data.alpaca.markets` answers what things
-//! *cost* — snapshots and bars. They share authentication, an error type, and nothing else, which
-//! is why one file holds both rather than a module per host.
+//! Two services behind one set of credentials: the trading API answers what the market *is* — the
+//! clock, calendar, assets, orders, positions — and the market data API what things *cost*. They
+//! share authentication and an error type and nothing else, which is why one file holds both.
 //!
-//! Alpaca is the source of truth for fills, balances, buying power, and positions, so this module
-//! is deliberately thin: it deserializes what Alpaca reports and hands it on. Where a response is
-//! ambiguous — a snapshot with no quote, a calendar day with no duration — the ambiguity is
-//! surfaced rather than defaulted, because a missing value and a zero one are indistinguishable
-//! after the fact.
+//! Deliberately thin, since Alpaca is the source of truth for fills and balances. Ambiguity — a
+//! snapshot with no quote, a calendar day with no duration — is surfaced rather than defaulted,
+//! because a missing value and a zero one are indistinguishable after the fact.
 
 use std::collections::HashSet;
 use std::num::NonZeroU32;
@@ -1212,24 +1208,21 @@ struct ActivityResponse {
 
 /// Symbols requested per snapshot call.
 ///
-/// The endpoint imposes no documented symbol ceiling and has been measured accepting 2,000 symbols
-/// in a 9,424-character URL. This cap is therefore not the API's limit but a bound on request-line
-/// length, which intermediaries do restrict.
+/// Not the API's limit — the endpoint has been measured accepting 2,000 symbols in a
+/// 9,424-character URL — but a bound on request-line length, which intermediaries do restrict.
 ///
-/// Chunking also limits the blast radius of a single failed request, but only because
-/// [`MarketDataClient::fetch_snapshots`] keeps the chunks that succeeded. Propagating the first
-/// error instead would make a smaller cap strictly worse, by giving one failure more chunks to take
-/// down with it.
+/// Chunking also limits the blast radius of one failed request, but only because
+/// [`MarketDataClient::fetch_snapshots`] keeps the chunks that succeeded.
 const SNAPSHOT_SYMBOLS_PER_REQUEST: usize = 1_000;
 
 /// Which consolidated tape the market data API serves from.
 ///
-/// `iex` covers a few percent of consolidated volume, so quoted spreads are wide and often stale
-/// outside the largest names -- computing a pair spread from it introduces noise that looks exactly
-/// like signal. `sip` is the full consolidated tape and requires a paid subscription.
+/// `iex` covers a few percent of consolidated volume, so spreads are wide and often stale outside
+/// the largest names — noise that looks exactly like signal. `sip` is the full tape and needs a
+/// paid subscription.
 ///
-/// An enum rather than a string so an unrecognized value is rejected at the edge, where it can be
-/// reported, instead of reaching Alpaca as an unhelpful 400 on every request of the session.
+/// An enum so an unrecognized value is rejected at the edge rather than reaching Alpaca as a 400 on
+/// every request of the session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DataFeed {
     Iex,

--- a/src/common/crypto.rs
+++ b/src/common/crypto.rs
@@ -1,18 +1,12 @@
 //! Process-wide TLS crypto provider selection.
 //!
-//! Rustls 0.23 reaches the platform transitively through several dependencies
-//! (sqlx with `tls-rustls`, the AWS SDK, `tokio-tungstenite`), and the
-//! dependency graph enables *both* the `aws-lc-rs` and `ring` crypto providers.
-//! When more than one provider is linked, Rustls cannot pick a process default
-//! on its own and panics on the first TLS handshake with "Could not
-//! automatically determine the process-level CryptoProvider". Because each S3,
-//! Massive, or Alpaca request runs on its own Tokio worker thread, the panic
-//! silently kills individual worker threads mid-request, truncating large
-//! syncs (for example, a day of equity bars) to a partial result.
+//! The dependency graph pulls in Rustls transitively and enables *both* the `aws-lc-rs` and `ring`
+//! providers. With more than one linked, Rustls cannot pick a process default and panics on the
+//! first TLS handshake. Each request runs on its own Tokio worker thread, so that panic silently
+//! kills threads mid-request and truncates large syncs to a partial result.
 //!
-//! Selecting a provider explicitly at startup removes the ambiguity for the
-//! whole process. Every service binary calls [`install_default_crypto_provider`]
-//! as the first statement in `main`, before any TLS client is constructed.
+//! Every service binary calls [`install_default_crypto_provider`] as the first statement in `main`,
+//! before any TLS client is constructed.
 
 use rustls::crypto::aws_lc_rs;
 

--- a/src/common/crypto.rs
+++ b/src/common/crypto.rs
@@ -1,9 +1,9 @@
 //! Process-wide TLS crypto provider selection.
 //!
 //! The dependency graph pulls in Rustls transitively and enables *both* the `aws-lc-rs` and `ring`
-//! providers. With more than one linked, Rustls cannot pick a process default and panics on the
-//! first TLS handshake. Each request runs on its own Tokio worker thread, so that panic silently
-//! kills threads mid-request and truncates large syncs to a partial result.
+//! providers. With more than one linked, Rustls cannot pick a process default, and the first client
+//! configuration that needs one panics. Requests run as spawned tasks, so the panic surfaces as a
+//! failed task rather than a crash — a large sync comes back truncated instead of erroring.
 //!
 //! Every service binary calls [`install_default_crypto_provider`] as the first statement in `main`,
 //! before any TLS client is constructed.

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -5,12 +5,10 @@
 //! `<command>_errored` with a payload describing what happened. That is the entire coordination
 //! mechanism — there is no queue, no offset table, and no in-memory scheduling.
 //!
-//! There is deliberately no `started` outcome. It existed to say a handler had picked up the work,
-//! nothing read it, and the structured logs already answer the question.
+//! There is deliberately no `started` outcome — nothing would read it that the logs do not answer.
 //!
-//! The `events` table doubles as the restart recovery mechanism. A `_requested` row with no
-//! matching terminal outcome is work that was issued and never finished, which is exactly what a
-//! process that died mid-handler leaves behind. See [`recover_missed_commands`].
+//! The table doubles as the restart recovery mechanism: a `_requested` row with no terminal outcome
+//! is work issued and never finished. See [`recover_missed_commands`].
 
 use serde_json::Value;
 use sqlx::PgPool;
@@ -246,17 +244,14 @@ pub async fn emit_errored(pool: &PgPool, command: Command, error: &str) -> Resul
 /// Finds commands requested during the current Eastern trading date that never reached a terminal
 /// outcome, and which should be re-run.
 ///
-/// This is what replaces a consumer offset table. A `_requested` row with no later `_completed` or
-/// `_errored` row is, by construction, work that was issued and never finished — which is what a
-/// process killed mid-handler leaves behind, and also what a process that was simply not running
-/// when cron fired leaves behind. Both want the same response.
+/// This replaces a consumer offset table. A `_requested` row with no terminal outcome is work
+/// issued and never finished — what a process killed mid-handler leaves behind, and equally what a
+/// process not running when cron fired leaves behind. Both want the same response.
 ///
-/// Commands whose [`Command::recovery`] is [`Recovery::Skip`] are found and then dropped, so the
-/// caller receives only work worth doing.
+/// [`Recovery::Skip`] commands are found and dropped, so the caller receives only work worth doing.
 ///
-/// The Eastern date rather than the UTC date because that is the boundary the trading day actually
-/// has. The additional two-day bound on `created_at` keeps the hypertable from scanning every
-/// chunk to answer a question about today.
+/// The Eastern date because that is the boundary the trading day has; the two-day bound on
+/// `created_at` keeps the hypertable from scanning every chunk.
 pub async fn recover_missed_commands(pool: &PgPool) -> Result<Vec<Command>, EventError> {
     let rows = sqlx::query!(
         r#"

--- a/src/common/events.rs
+++ b/src/common/events.rs
@@ -250,8 +250,8 @@ pub async fn emit_errored(pool: &PgPool, command: Command, error: &str) -> Resul
 ///
 /// [`Recovery::Skip`] commands are found and dropped, so the caller receives only work worth doing.
 ///
-/// The Eastern date because that is the boundary the trading day has; the two-day bound on
-/// `created_at` keeps the hypertable from scanning every chunk.
+/// The window is the Eastern date because that is the boundary the trading day has, and the
+/// additional two-day bound on `created_at` keeps the hypertable from scanning every chunk.
 pub async fn recover_missed_commands(pool: &PgPool) -> Result<Vec<Command>, EventError> {
     let rows = sqlx::query!(
         r#"

--- a/src/common/massive.rs
+++ b/src/common/massive.rs
@@ -1,29 +1,21 @@
 //! Massive market data client: whole-market daily bars, one request per session.
 //!
-//! Deliberately narrow. Massive answers exactly one question here — what did every US stock do on
-//! this date — and Alpaca answers everything else: the clock, the calendar, the tradable set,
-//! intraday snapshots, orders, positions, and balances.
+//! Deliberately narrow: Massive answers only what every US stock did on a date, and Alpaca answers
+//! everything about our account and the current moment. Three properties of the grouped endpoint
+//! make that split load-bearing rather than aesthetic.
 //!
-//! The split is by question rather than by preference. Alpaca is the venue, so it is authoritative
-//! for facts about our account and about the current moment. Massive is a market data vendor, so it
-//! is better at describing what the whole market did on a past date. Two properties of the grouped
-//! endpoint make that difference load-bearing rather than aesthetic:
+//! **It takes no symbol list.** A backfill through Alpaca's bars endpoint can only pass Alpaca's
+//! *current* tradable set, so every symbol delisted since the start date is absent from its own
+//! history and the model trains on a universe that survived by construction.
 //!
-//! **It takes no symbol list.** Alpaca's bars endpoint requires one, and the only list available to
-//! a backfill is Alpaca's *current* tradable set — so every symbol delisted since the start date is
-//! silently absent from its own history, and the model trains on a universe that survived by
-//! construction. Asking for a date instead of a list removes that failure mode entirely.
+//! **It returns the whole market, which keeps the universe open.** `load_liquidity` reads averages
+//! out of `equity_bars`, so a sync that refreshed only the tickers already in the universe could
+//! never admit a name that became liquid — it would ratchet closed `LIQUIDITY_LOOKBACK_DAYS` after
+//! the last seed and shrink from there.
 //!
-//! **It returns the whole market, which is what keeps the universe open.** `load_liquidity` reads
-//! averages out of `equity_bars`, so if the nightly sync only refreshed the tickers already in the
-//! universe, the universe could never admit a name that became liquid — it would ratchet closed
-//! `LIQUIDITY_LOOKBACK_DAYS` after the last seed and shrink from there. Storing every symbol that
-//! traded is what makes the liquidity screen an actual re-selection each day.
-//!
-//! It is also the consolidated tape, with no feed tiers. Alpaca's `iex` feed carries a few percent
-//! of consolidated volume, which is survivable for quotes and not for bars: `volume` and `vw` are
-//! computed over that few percent, and the liquidity thresholds are calibrated against the real
-//! numbers.
+//! **It is the consolidated tape, with no feed tiers.** Alpaca's `iex` feed carries a few percent
+//! of consolidated volume — survivable for quotes, not for bars, since `volume` and `vw` would be
+//! computed over that few percent while the liquidity thresholds assume the real numbers.
 
 use chrono::{DateTime, NaiveDate};
 use serde::Deserialize;

--- a/src/common/observability.rs
+++ b/src/common/observability.rs
@@ -15,9 +15,10 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 /// level; `None` follows stdout. An uncreatable log directory disables file logging rather than
 /// failing.
 ///
-/// The returned `WorkerGuard` MUST be held for the process lifetime — dropping it tears down the
-/// non-blocking writer and buffered lines are lost. `None` when file logging is off. Uses
-/// `try_init`, so repeated calls across tests are a no-op rather than a panic.
+/// `Some` means *this call* installed the file layer, and the `WorkerGuard` MUST then be held for
+/// the process lifetime — dropping it tears down the non-blocking writer and buffered lines are
+/// lost. `None` means it did not, either because file logging is off or because `try_init` found a
+/// subscriber already installed, which is what makes repeated calls across tests a no-op.
 pub fn init_tracing(
     log_file: &str,
     file_filter: Option<&str>,
@@ -85,8 +86,9 @@ pub fn init_tracing(
 
 /// Initialize structured JSON tracing to a file only, with no stdout output.
 ///
-/// Identical to [`init_tracing`] without the stdout layer; used by the dashboard. An unwritable log
-/// directory disables tracing rather than falling back to stdout.
+/// Like [`init_tracing`] but file-only and with no `file_filter` — the file layer always follows
+/// `RUST_LOG`. Used by the dashboard. An unwritable log directory installs nothing at all rather
+/// than falling back to stdout.
 pub fn init_tracing_file_only(log_file: &str, service: &str) -> Option<WorkerGuard> {
     let fund_profile = env::var("FUND_PROFILE").unwrap_or_else(|_| "unknown".to_string());
 

--- a/src/common/observability.rs
+++ b/src/common/observability.rs
@@ -7,28 +7,17 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
 /// Initialize structured JSON tracing for a service.
 ///
-/// The `service` parameter identifies which service is emitting logs
-/// (e.g. `"data"`, `"inference"`, `"portfolio"`) and is included in the
-/// initial `Tracing initialized` log line for correlation.
+/// `service` (e.g. `"fund"`, `"tide-model-trainer"`) is included in the initial log line for
+/// correlation.
 ///
-/// Logs to stdout at the `RUST_LOG` level (default `info`). When the log
-/// directory is writable, also logs to a rolling daily file there; the
-/// directory is `FUND_LOG_DIR` when set, otherwise `/var/log/fund` (local
-/// dev sets `FUND_LOG_DIR` to a writable path via devenv). When `file_filter`
-/// is `Some`, the file layer uses that fixed directive
-/// (e.g. `"warn"` for an errors-only file), otherwise it follows the stdout
-/// level. If the log directory cannot be created (e.g. in tests or restricted
-/// environments), file logging is disabled and only stdout is used.
+/// Logs to stdout at `RUST_LOG` (default `info`), and to a rolling daily file under `FUND_LOG_DIR`
+/// or `/var/log/fund` when that directory is writable. `file_filter` overrides the file layer's
+/// level; `None` follows stdout. An uncreatable log directory disables file logging rather than
+/// failing.
 ///
-/// Returns `Some(WorkerGuard)` when file logging is active; the guard MUST be
-/// held for the lifetime of the process, since dropping it tears down the
-/// non-blocking file writer and buffered lines would be lost. Returns `None`
-/// when file logging is disabled. Uses `try_init`, so calling this more than
-/// once (e.g. across tests) is a no-op rather than a panic.
-///
-/// Services that own stdout for terminal rendering (e.g. the dashboard TUI)
-/// should call [`init_tracing_file_only`] instead to avoid corrupting the
-/// alternate screen with JSON log output.
+/// The returned `WorkerGuard` MUST be held for the process lifetime — dropping it tears down the
+/// non-blocking writer and buffered lines are lost. `None` when file logging is off. Uses
+/// `try_init`, so repeated calls across tests are a no-op rather than a panic.
 pub fn init_tracing(
     log_file: &str,
     file_filter: Option<&str>,
@@ -96,12 +85,8 @@ pub fn init_tracing(
 
 /// Initialize structured JSON tracing to a file only, with no stdout output.
 ///
-/// Identical to [`init_tracing`] except the stdout layer is omitted. Use this
-/// for services that own stdout for terminal rendering (e.g. the dashboard TUI)
-/// where writing JSON to stdout would corrupt the alternate screen buffer.
-///
-/// When the log directory is not writable, tracing is silently disabled rather
-/// than falling back to stdout.
+/// Identical to [`init_tracing`] without the stdout layer; used by the dashboard. An unwritable log
+/// directory disables tracing rather than falling back to stdout.
 pub fn init_tracing_file_only(log_file: &str, service: &str) -> Option<WorkerGuard> {
     let fund_profile = env::var("FUND_PROFILE").unwrap_or_else(|_| "unknown".to_string());
 

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -1,12 +1,10 @@
 //! The domain vocabulary every module speaks.
 //!
-//! Two kinds of type live here. **Validated primitives** wrap standard Rust types so unit-mismatch
-//! and sign bugs are compile errors rather than silent runtime surprises. **Record types** mirror
-//! the PostgreSQL tables and the Alpaca payloads they are built from.
+//! **Validated primitives** wrap standard Rust types so unit-mismatch and sign bugs are compile
+//! errors. **Record types** mirror the PostgreSQL tables and Alpaca payloads.
 //!
-//! Both follow the same rule: fields are private and construction goes through a constructor that
-//! validates. A value of one of these types in scope is proof that its invariants held at
-//! construction, so downstream code never re-checks.
+//! Both keep fields private and validate in the constructor, so a value in scope is proof its
+//! invariants held and downstream code never re-checks.
 
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
@@ -16,8 +14,7 @@ use uuid::Uuid;
 /// Liquidity thresholds defining the modeled and served equity universe.
 ///
 /// Training applies them per row and inference per ticker average; both sides must use the same
-/// values so the model trains on the population it serves. They were historically mismatched, which
-/// trained the scaler and model on penny-stock dynamics the service never predicts.
+/// values, or the scaler and model learn dynamics the service never predicts.
 pub const MINIMUM_CLOSE_PRICE: f64 = 10.0;
 pub const MINIMUM_VOLUME: f64 = 1_000_000.0;
 
@@ -188,14 +185,10 @@ impl<'de> Deserialize<'de> for Notional {
 
 /// A normalized US equity ticker symbol.
 ///
-/// Enforces the Alpaca US equity ticker format: 1–5 uppercase ASCII letters for the base symbol,
-/// with an optional dot-separated suffix of 1–3 uppercase ASCII letters for share class or warrant
-/// notation (e.g. `BRK.B`, `BRK.WS`).
+/// Enforces the Alpaca US equity ticker format: 1–5 uppercase ASCII letters, with an optional
+/// dot-separated suffix of 1–3 for share class or warrant notation (e.g. `BRK.B`, `BRK.WS`).
 ///
-/// Alpaca asset reference: <https://docs.alpaca.markets/us/reference/get-v2-assets-1>
-///
-/// The private field prevents construction without going through [`Ticker::new`], which trims,
-/// uppercases, and validates. A `Ticker` in scope is proof that the symbol passed format validation.
+/// Reference: <https://docs.alpaca.markets/us/reference/get-v2-assets-1>
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 pub struct Ticker(String);
 
@@ -390,19 +383,14 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for PairID {
 
 /// The sampling interval of an OHLCV bar.
 ///
-/// Part of the `equity_bars` primary key, so a single table carries daily and intraday history
-/// together. The post-close sync writes only [`BarInterval::OneDay`]; [`BarInterval::OneMinute`] is
-/// equally permitted by the CHECK constraint and is what `fetch_snapshots` tags Alpaca's `minuteBar`
-/// with in memory. Nothing persists a minute bar today, so treat "daily only" as a property of the
-/// current writer rather than of the table.
+/// Part of the `equity_bars` primary key. The post-close sync writes only
+/// [`BarInterval::OneDay`]; [`BarInterval::OneMinute`] is equally permitted by the CHECK constraint
+/// and is what `fetch_snapshots` tags Alpaca's `minuteBar` with in memory, so "daily only" is a
+/// property of the current writer rather than of the table.
 ///
-/// [`BarInterval::as_str`] is the canonical stored form and must match the `bar_interval` CHECK
-/// constraint in `schema.sql` exactly. It is the snake_case of the variant name — `one_day`, not
-/// `1day` or `1_day` — and that is load-bearing rather than cosmetic: it lets `rename_all` derive
-/// the same string for serde, so serializing and storing cannot drift into two vocabularies. They
-/// previously had: the derive emitted `OneDay` while the parser accepted only the stored form, so
-/// an `EquityBar` written to JSON could not be read back. Intervals added later follow the variant
-/// name the same way: `five_minute`, `fifteen_minute`, `sixty_minute`.
+/// [`BarInterval::as_str`] must match the `bar_interval` CHECK constraint exactly. It is the
+/// snake_case of the variant name, which lets `rename_all` derive the same string for serde so what
+/// is serialized and what is stored cannot drift apart.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum BarInterval {
@@ -648,12 +636,10 @@ pub struct EquityQuote {
 impl EquityQuote {
     /// Constructs an `EquityQuote`, rejecting a book that cannot be meaningfully averaged.
     ///
-    /// [`EquityQuote::mid_price`] is arithmetic with no opinion about its inputs, so the opinion has
-    /// to live here. A crossed book (bid above ask) or a zero side produces a midpoint that looks
-    /// like a price and is not one — a zero bid against a hundred-dollar ask yields a fifty-dollar
-    /// mid, which is the kind of number that reaches an order.
-    ///
-    /// A locked book (bid equal to ask) is legal and accepted.
+    /// [`EquityQuote::mid_price`] is arithmetic with no opinion about its inputs, so the opinion
+    /// lives here. A crossed book or a zero side yields a midpoint that looks like a price and is
+    /// not one — a zero bid against a hundred-dollar ask gives a fifty-dollar mid, and that reaches
+    /// an order. A locked book (bid equal to ask) is legal and accepted.
     pub fn new(
         ticker: Ticker,
         timestamp: DateTime<Utc>,

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -1,7 +1,8 @@
 //! The domain vocabulary every module speaks.
 //!
-//! **Validated primitives** wrap standard Rust types so unit-mismatch and sign bugs are compile
-//! errors. **Record types** mirror the PostgreSQL tables and Alpaca payloads.
+//! **Validated primitives** wrap standard Rust types so a unit mismatch is a compile error and
+//! sign and range constraints are enforced by the constructor. **Record types** mirror the
+//! PostgreSQL tables and Alpaca payloads.
 //!
 //! Both keep fields private and validate in the constructor, so a value in scope is proof its
 //! invariants held and downstream code never re-checks.

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -1,13 +1,11 @@
 //! The dashboard: a read-only page describing what the fund is doing.
 //!
-//! Runs as its own process alongside the service, connecting as `dashboard_reader` — a role holding
-//! SELECT on five tables and nothing else, so a bug here cannot write to the database the strategy
-//! trades from.
+//! Its own process, connecting as `dashboard_reader` — SELECT on five tables and nothing else, so
+//! a bug here cannot write to the database the strategy trades from.
 //!
-//! Two background tasks keep one shared state current: a poller that refreshes every view on a
-//! fixed interval, and a listener that appends events from the `events` NOTIFY channel as they
-//! happen. Request handlers read that state and never query, so the number of viewers has no
-//! bearing on the connection pool.
+//! A poller refreshes every view on a fixed interval; a listener appends events from the `events`
+//! NOTIFY channel as they arrive. Request handlers read that shared state and never query, so
+//! viewer count has no bearing on the connection pool.
 
 pub mod cache;
 pub mod database;

--- a/src/dashboard/cache.rs
+++ b/src/dashboard/cache.rs
@@ -1,12 +1,11 @@
 //! Shared in-memory state for the dashboard, and the two tasks that keep it current.
 //!
-//! A single polling task refreshes everything every [`POLL_INTERVAL`] behind an `RwLock`, and a
-//! separate listener appends events from the `events` NOTIFY channel as they arrive. Request
-//! handlers read the lock and never touch the database, so the number of people looking at the page
-//! has no bearing on the connection pool.
+//! A polling task refreshes everything every [`POLL_INTERVAL`] behind an `RwLock`; a listener
+//! appends `events` as they arrive. Request handlers read the lock and never touch the database, so
+//! viewer count has no bearing on the connection pool.
 //!
-//! A poll that fails leaves the previous state in place and records the error rather than blanking
-//! the page. Stale numbers with a visible "last updated" are more useful than no numbers.
+//! A failed poll leaves the previous state and records the error rather than blanking the page —
+//! stale numbers with a visible "last updated" beat no numbers.
 
 use std::collections::VecDeque;
 use std::sync::Arc;

--- a/src/dashboard/html.rs
+++ b/src/dashboard/html.rs
@@ -1,15 +1,11 @@
 //! The server-rendered page.
 //!
 //! Five sections stacked vertically — account, open pairs, predictions, closed pairs, events — in
-//! the amber CRT aesthetic the dashboard has always used. The page refreshes itself every thirty
-//! seconds with a `<meta>` tag, matching the poll interval; there is no client-side JavaScript and
-//! nothing to load from a CDN.
+//! an amber CRT aesthetic. The page refreshes every thirty seconds with a `<meta>` tag, matching
+//! the poll interval; no client-side JavaScript and nothing loaded from a CDN.
 //!
-//! Three sections the previous dashboard rendered are gone, because the tables behind them are:
-//! per-leg dollar allocations, the fund-versus-benchmark curve, and the training run's metrics. The
-//! rebuild's `account_snapshots` carries exposure as Alpaca reports it, the universe holds no index
-//! ETF to benchmark against, and the trainer publishes its metrics to S3 rather than to a table the
-//! dashboard can read.
+//! It renders only what the database can answer. There is no benchmark curve (the universe holds no
+//! index ETF) and no training metrics (the trainer publishes those to S3, not to a table).
 
 use chrono::{DateTime, Duration, Utc};
 use rust_decimal::Decimal;

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,15 +1,9 @@
-//! Market data and storage: what the market is, what it costs, and where the record goes.
+//! Market data and storage.
 //!
-//! [`calendar`] and [`universe`] answer the two questions every session opens with — does the
-//! market trade today and until when, and which symbols are eligible. Both are fetched once and
-//! held for the Eastern date, because neither changes intraday.
-//!
-//! [`bars`] and [`details`] are the market history the model and the pair screen read from.
-//! [`bars`] is shared with the trainer, which runs on a different machine with no database and
-//! writes the same frames to S3 — that shared code path is what keeps the training and inference
-//! datasets structurally identical.
-//!
-//! [`export`] and [`purge`] are the nightly archival pair, in that order and never the reverse.
+//! [`calendar`] and [`universe`] are fetched once and held for the Eastern date; neither changes
+//! intraday. [`bars`] is shared with the trainer, which has no database and writes the same frames
+//! to S3 — that shared path keeps the training and inference datasets structurally identical.
+//! [`export`] and [`purge`] run in that order and never the reverse.
 
 pub mod bars;
 pub mod calendar;

--- a/src/data/bars.rs
+++ b/src/data/bars.rs
@@ -1,18 +1,11 @@
 //! Equity bars: one fetch from Massive, three destinations.
 //!
-//! The application writes bars to PostgreSQL after the close. The trainer, on a different machine
-//! with no database, writes the same bars to S3 parquet before it trains. Both call
-//! [`fetch_daily_bars`] and both build their frames through [`bars_to_dataframe`], which is the
-//! whole point: if the two ever diverged, the model would train on columns the inference path does
-//! not produce, and the failure would surface as bad predictions rather than as a build error.
+//! The application writes bars to PostgreSQL after the close; the trainer writes the same bars to
+//! S3 parquet. Both go through [`fetch_daily_bars`] and [`bars_to_dataframe`] — if the two
+//! diverged, the model would train on columns the inference path does not produce and it would
+//! surface as bad predictions rather than a build error.
 //!
-//! Bars come from Massive's grouped endpoint rather than Alpaca's, for reasons recorded in
-//! [`crate::common::massive`]: it takes a date rather than a symbol list, which removes both the
-//! survivorship bias in any backfill and the ratchet that would otherwise close the tradable
-//! universe. Alpaca still prices the book intraday, because that is the venue we trade on.
-//!
-//! [`load_bars_dataframe`] is the read side, feeding the prediction pipeline and the correlation
-//! screen.
+//! Bars come from Massive rather than Alpaca; see [`crate::common::massive`].
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -62,13 +55,11 @@ pub struct FetchedBars {
 
 /// Fetches whole-market daily bars for each of `dates`.
 ///
-/// One request per date, because that is the grouped endpoint's unit. Dates that are not trading
-/// sessions cost a request and return nothing, so a caller with a calendar should filter first and
-/// one without can simply pass every calendar day.
+/// One request per date, the grouped endpoint's unit. Non-session dates cost a request and return
+/// nothing, so a caller with a calendar should filter first.
 ///
-/// A failed date is recorded and stepped over. Aborting would discard every date already
-/// retrieved, and the upsert makes re-running the same range cheap, so partial progress is worth
-/// more than an all-or-nothing guarantee that nothing else depends on.
+/// A failed date is recorded and stepped over rather than aborting, which would discard every date
+/// already retrieved. The upsert makes re-running a range cheap.
 pub async fn fetch_daily_bars(client: &MassiveClient, dates: &[NaiveDate]) -> FetchedBars {
     let mut fetched = FetchedBars::default();
 
@@ -288,15 +279,13 @@ pub async fn load_bars_dataframe(
 
 /// Loads a trailing window of closes per ticker, aligned across tickers by session.
 ///
-/// Every returned series has the same length, and position `i` in one is the same session as
-/// position `i` in every other. Tickers missing any session in the window are dropped rather than
-/// gap-filled, which is the whole reason this exists and is not a `GROUP BY ticker`: two series of
-/// equal length covering different dates produce a correlation between different days, and neither
-/// the correlation nor the spread that follows carries any sign that it happened.
+/// Every series has the same length and position `i` is the same session across all of them.
+/// Tickers missing any session are dropped rather than gap-filled — this is why it is not a
+/// `GROUP BY ticker`: two equal-length series covering different dates correlate different days,
+/// and nothing downstream carries a sign that it happened.
 ///
-/// The lower bound on `timestamp` is what keeps this from scanning every chunk of the hypertable.
-/// It is expressed against the column directly rather than wrapped in an expression, so chunk
-/// exclusion applies.
+/// The lower bound on `timestamp` is expressed against the column directly rather than wrapped in
+/// an expression, so hypertable chunk exclusion applies.
 pub async fn load_aligned_closes(
     pool: &PgPool,
     bar_interval: BarInterval,
@@ -367,14 +356,11 @@ pub type AlignedCloses = Arc<HashMap<Ticker, Vec<f64>>>;
 
 /// The aligned close history, loaded at most once per Eastern date.
 ///
-/// Daily bars are written after the close, so this does not change intraday — and the evaluation
-/// pass runs seventy-eight times a session and needs the whole thing on every pass that screens.
-/// Reloading it each time would be a six-figure row count re-read for a result known not to have
-/// moved.
+/// Daily bars are written after the close, so this cannot change intraday, and the evaluation pass
+/// needs all of it on every screening pass — seventy-eight times a session.
 ///
-/// Same shape as [`crate::data::calendar::CalendarCache`] and
-/// [`crate::data::universe::UniverseCache`], and for the same reason: a value held in state and
-/// passed explicitly, not a process-wide static.
+/// A value held in state and passed explicitly, not a process-wide static, like the calendar and
+/// universe caches.
 #[derive(Default)]
 pub struct CloseHistoryCache {
     inner: tokio::sync::Mutex<Option<(NaiveDate, AlignedCloses)>>,

--- a/src/data/calendar.rs
+++ b/src/data/calendar.rs
@@ -1,15 +1,14 @@
 //! The trading calendar, as Alpaca publishes it.
 //!
 //! Two questions get asked constantly — does the market trade today, and when does it close — and
-//! both are answered from a calendar fetched once and held in memory for the Eastern date. There is
-//! no `market_calendar` table any more: the calendar is reference data that Alpaca owns, and
-//! persisting a copy bought nothing except a second source that could disagree.
+//! both are answered from a calendar fetched once and held in memory for the Eastern date. It is
+//! deliberately not persisted: the calendar is reference data Alpaca owns, and a stored copy is
+//! just a second source that can disagree.
 //!
-//! There is also no hardcoded holiday fallback. The old one could not express a half-day, so every
-//! early close looked like a 16:00 session and the fail-safe liquidation fired hours after the
-//! market had shut. More importantly it made an unreachable Alpaca look like a normal trading day.
-//! **An absent calendar now means "do not trade", not "assume open"** — see
-//! [`TradingCalendar::is_trading_day`], which answers `false` for a date outside its horizon.
+//! There is deliberately no hardcoded holiday fallback: one cannot express a half-day, and it
+//! would make an unreachable Alpaca look like a normal trading day. **An absent calendar means "do
+//! not trade", not "assume open"** — [`TradingCalendar::is_trading_day`] answers `false` outside
+//! its horizon.
 //!
 //! Everything here is Eastern local time, because that is the timezone the trading day actually has.
 
@@ -49,16 +48,13 @@ pub fn eastern_time(instant: DateTime<Utc>) -> NaiveTime {
 
 /// The half-open UTC interval `[start, end)` covering one Eastern calendar date.
 ///
-/// This is the inverse of [`eastern_date`], and it exists so queries can bound a timestamp column
-/// directly instead of converting it. A predicate like
-/// `(created_at AT TIME ZONE 'America/New_York')::date = $1` hides the column behind an expression,
-/// which stops TimescaleDB excluding chunks and stops the B-tree index being used — on a hypertable
-/// that turns a one-day export into a full scan of every chunk. Resolving the bounds here once and
-/// filtering `column >= $start AND column < $end` keeps the predicate sargable.
+/// The inverse of [`eastern_date`], so queries can bound a timestamp column directly. A predicate
+/// like `(created_at AT TIME ZONE 'America/New_York')::date = $1` hides the column behind an
+/// expression, defeating chunk exclusion and the index — a one-day export becomes a full scan.
+/// Resolving bounds here keeps `column >= $start AND column < $end` sargable.
 ///
-/// Spring-forward makes local midnight nonexistent in some timezones; Eastern shifts at 02:00, so
-/// midnight is always well-defined here. `earliest()` is nonetheless used rather than `unwrap()`,
-/// with a UTC-midnight fallback, so a timezone database change cannot panic the export.
+/// Eastern shifts at 02:00 so local midnight always exists, but `earliest()` with a UTC fallback is
+/// used anyway so a timezone database change cannot panic the export.
 pub fn eastern_day_bounds(date: NaiveDate) -> (DateTime<Utc>, DateTime<Utc>) {
     let start = eastern_midnight(date);
     let end = eastern_midnight(date + Duration::days(1));

--- a/src/data/details.rs
+++ b/src/data/details.rs
@@ -1,12 +1,11 @@
 //! Ticker metadata: sector and industry.
 //!
-//! The pair screen requires the two legs to come from different sectors, so this is not decoration —
-//! without it every pair is a same-sector pair and the strategy is a bet on one industry rather than
-//! on a spread.
+//! The pair screen requires the two legs to come from different sectors, so without this every pair
+//! is same-sector and the strategy is a bet on one industry rather than on a spread.
 //!
-//! The seed comes from `data/equity_details.csv`, embedded at compile time so a fresh database can
-//! be populated with no network and no S3 access. Alpaca does not publish sector or industry, so the
-//! post-close sync refreshes only what changes: tickers that have appeared or been delisted.
+//! Seeded from `data/equity_details.csv`, embedded at compile time so a fresh database needs no
+//! network. Alpaca does not publish sector or industry, so the post-close sync refreshes only
+//! tickers that have appeared or been delisted.
 
 use std::collections::HashMap;
 

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -2,18 +2,15 @@
 //!
 //! Chained from a completed market data sync rather than scheduled, so it can never run against a
 //! half-synced database. Everything it writes is archival: the trainer fetches its own data from
-//! Alpaca on its own machine, so a failed export costs a backup rather than the next day's model.
+//! Massive, so a failed export costs a backup rather than the next day's model.
 //!
-//! Two export shapes, because the tables have two shapes. **Incremental** tables — events,
-//! predictions, bars — are written for one session date under a Hive-partitioned key, so a day's
-//! rows land in their own object and the history accumulates. **Snapshot** tables — pairs,
-//! account state, ticker metadata — are written whole each night, because they are small and
-//! because a row can change after the day it was created (a pair opened on Monday closes on
-//! Tuesday, and the closing is the interesting part).
+//! Two shapes. **Incremental** tables — events, predictions, bars — are written per session date
+//! under a Hive-partitioned key. **Snapshot** tables — pairs, account state, ticker metadata — are
+//! written whole each night, because a row can change after the day it was created (a pair opened
+//! Monday closes Tuesday, and the closing is the interesting part).
 //!
-//! A failure on one table is logged and the rest continue. Exporting six of seven tables is
-//! strictly better than exporting none, and the caller receives the list of failures so the
-//! completion event can report them.
+//! A failure on one table is logged and the rest continue; the caller receives the list so the
+//! completion event can report it.
 
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client as S3Client;

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -4,10 +4,10 @@
 //! half-synced database. Everything it writes is archival: the trainer fetches its own data from
 //! Massive, so a failed export costs a backup rather than the next day's model.
 //!
-//! Two shapes. **Incremental** tables — events, predictions, bars — are written per session date
-//! under a Hive-partitioned key. **Snapshot** tables — pairs, account state, ticker metadata — are
-//! written whole each night, because a row can change after the day it was created (a pair opened
-//! Monday closes Tuesday, and the closing is the interesting part).
+//! Two shapes. **Incremental** tables — events, predictions, bars, account activities — are written
+//! per session date under a Hive-partitioned key. **Snapshot** tables — pairs, account state,
+//! ticker metadata — are written whole each night, because a row can change after the day it was
+//! created (a pair opened Monday closes Tuesday, and the closing is the interesting part).
 //!
 //! A failure on one table is logged and the rest continue; the caller receives the list so the
 //! completion event can report it.

--- a/src/data/purge.rs
+++ b/src/data/purge.rs
@@ -4,10 +4,9 @@
 //! in the export rather than in the database. That ordering is the entire safety property: a purge
 //! that ran first, or ran on its own schedule, could delete rows that never reached S3.
 //!
-//! Retention is a window rather than a truncation. Keeping a few days in PostgreSQL costs almost
-//! nothing and means a question about yesterday — why did that pair close, what did the model say —
-//! is a query rather than an S3 download. It also means an export that silently failed has several
-//! nights to be noticed before the rows are gone.
+//! Retention is a window, not a truncation. A few days in PostgreSQL costs almost nothing, keeps
+//! questions about yesterday a query rather than an S3 download, and gives a silently failed export
+//! several nights to be noticed before the rows are gone.
 //!
 //! `equity_bars` is deliberately absent: TimescaleDB's retention policy owns it, and two mechanisms
 //! deleting from one table is how a rolling window becomes an empty one.

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -10,9 +10,8 @@
 //!    average. A universe wider than the training population means predicting on names the scaler
 //!    never saw.
 //!
-//! Roughly seven thousand symbols enter and a few hundred survive, which is why this is computed
-//! once at pre-open and held for the Eastern date rather than recomputed on every five-minute pass.
-//! The universe does not change intraday.
+//! Roughly seven thousand symbols enter and a few hundred survive, so it is computed once at
+//! pre-open and held for the Eastern date. The universe does not change intraday.
 
 use std::collections::HashSet;
 
@@ -200,11 +199,9 @@ impl UniverseCache {
     /// date.
     ///
     /// The lock is released before the Alpaca call and the liquidity query, and re-taken only to
-    /// store the result. Holding it across that I/O would block every other caller for the full
-    /// duration of a cold rebuild. The cost is that two callers arriving on a cold cache may both
-    /// rebuild; both are read-only and deterministic, so they produce the same universe and the
-    /// second store is a harmless overwrite. Blocking every caller to prevent a duplicate read is
-    /// the worse trade.
+    /// store. Two callers on a cold cache may both rebuild, but both are read-only and
+    /// deterministic, so the second store is a harmless overwrite — cheaper than blocking every
+    /// caller for the duration of a cold rebuild.
     pub async fn get(
         &self,
         client: &TradingClient,

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -199,9 +199,10 @@ impl UniverseCache {
     /// date.
     ///
     /// The lock is released before the Alpaca call and the liquidity query, and re-taken only to
-    /// store. Two callers on a cold cache may both rebuild, but both are read-only and
-    /// deterministic, so the second store is a harmless overwrite — cheaper than blocking every
-    /// caller for the duration of a cold rebuild.
+    /// store, so two callers on a cold cache may both rebuild and the later completion wins. Both
+    /// reads are read-only and scoped to one Eastern date, over which the universe does not change,
+    /// so the two rebuilds agree in practice — cheaper than blocking every caller for the duration
+    /// of a cold rebuild. Single-flight coordination would be the fix if that ever stopped holding.
     pub async fn get(
         &self,
         client: &TradingClient,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -3,11 +3,9 @@
 //! This is the only place that knows how a command name turns into work. The listener parses a
 //! notification and calls [`handle`]; everything else is a module doing one thing.
 //!
-//! Every handler returns a JSON summary, which becomes the `_completed` payload. That is
-//! deliberate and it is what makes the nightly export of the `events` table worth reading: a
-//! completed row that says only "it finished" tells you nothing the logs did not, whereas one
-//! carrying the pairs opened and closed, the rows synced, and the model run used is the record of
-//! the trading day.
+//! Every handler returns a JSON summary, which becomes the `_completed` payload. That is what
+//! makes the nightly export of `events` worth reading — a row carrying the pairs opened and closed,
+//! rows synced, and the model run used is the record of the trading day.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -28,7 +26,7 @@ use crate::data::details;
 use crate::data::export;
 use crate::data::purge;
 use crate::data::universe::{UniverseCache, UniverseError};
-use crate::models::{artifact, predict};
+use crate::models::tide::{artifact, predict};
 use crate::portfolio::account;
 use crate::portfolio::evaluate::{self, EvaluationContext};
 use crate::portfolio::execute::ExecutionSettings;
@@ -238,10 +236,8 @@ async fn dispatch(state: &ServiceState, command: Command) -> Result<Value, Handl
 
 /// Pre-open: warm the caches, resolve the newest artifact, run inference, write predictions.
 ///
-/// Also absorbs two jobs that used to be their own cron entries. The previous session's post-close
-/// commands are checked here rather than by a `scheduler_health_check` job, and the artifact is
-/// resolved here rather than by a `model_artifact_check` job. Both were work that only mattered
-/// immediately before a session, and neither needed a schedule of its own to say so.
+/// The previous session's post-close commands are checked here, and the artifact resolved here,
+/// rather than on schedules of their own — both only matter immediately before a session.
 async fn handle_predictions(state: &ServiceState) -> Result<Value, HandlerError> {
     let now = Utc::now();
     let today = eastern_date(now);
@@ -436,14 +432,12 @@ async fn handle_market_data_sync(state: &ServiceState) -> Result<Value, HandlerE
         return Ok(json!({ "skipped": "not_a_trading_day", "session_date": today }));
     }
 
-    // No universe load here any more, and that is the point rather than a tidy-up.
-    //
-    // This fetch used to ask Alpaca for `universe.symbols()`, while `load_liquidity` built that
-    // universe from averages over `equity_bars` — so the only tickers that got fresh bars were the
-    // ones already in the universe. Thirty days after a seed (`LIQUIDITY_LOOKBACK_DAYS`), nothing
-    // outside it had bars inside the window any more, and a stock that became liquid could never
-    // enter: the universe ratcheted closed and could only shrink. Massive's grouped endpoint takes
-    // a date rather than a symbol list, so every symbol that traded is stored and the liquidity
+    // Deliberately no universe load. `load_liquidity` builds the universe from averages over
+    // `equity_bars`, so fetching only `universe.symbols()` would mean the sole tickers getting
+    // fresh bars are the ones already in it. Past `LIQUIDITY_LOOKBACK_DAYS`, nothing outside would
+    // have bars in the window and a stock that became liquid could never enter — the universe
+    // ratchets closed and can only shrink. Massive's grouped endpoint takes a date rather than a
+    // symbol list, so every symbol that traded is stored and the liquidity
     // screen is a real re-selection each day.
 
     // A span wide enough to hold the requested sessions even through a holiday week. Six calendar

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,17 +9,6 @@
 //! model output, the long/short pair mapping, market history, and an audit trail of every command
 //! issued and outcome reached.
 //!
-//! - [`common`] — shared vocabulary and infrastructure: types, the event bus, the Alpaca client,
-//!   database pools, AWS clients, tracing.
-//! - [`data`] — market data and storage: the trading calendar, the tradable universe, bar and
-//!   detail syncing, S3 export, and purging.
-//! - [`models`] — the TiDE model: artifact handling, inference, and training.
-//! - [`portfolio`] — the strategy: pair selection, sizing, the risk gate, execution, and the
-//!   five-minute evaluation pass.
-//! - [`handlers`] — one function per command, and the state they share. The only module that knows
-//!   how an event name turns into work.
-//! - [`dashboard`] — a read-only page describing all of the above. Its own process, its own
-//!   read-only database role, and no path back into the strategy.
 
 pub mod common;
 pub mod dashboard;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,14 +1,3 @@
-//! The TiDE model: its definition, its training, its artifact, and its inference.
-//!
-//! Training and inference used to live apart — a `models/` module holding the architecture and an
-//! `inference/` module holding everything needed to run it — which meant the two sides of the same
-//! model were maintained in different places and drifted. They are one thing here.
-//!
-//! [`tide`] is the model itself: configuration, feature engineering, the Burn network, the loss,
-//! and the training loop. [`artifact`] is how a trained model crosses the machine boundary between
-//! the trainer VM and the application VM, as a `model.tar.gz` in S3. [`predict`] is what the
-//! application does with it.
+//! Forecasting models. One so far.
 
-pub mod artifact;
-pub mod predict;
 pub mod tide;

--- a/src/models/tide.rs
+++ b/src/models/tide.rs
@@ -1,15 +1,8 @@
-//! TiDE: configuration, feature engineering, the Burn model, and the training loop.
+//! TiDE: the model, its training, its artifact, and its inference.
 //!
-//! There are no feature gates here. The training modules used to sit behind a `train` feature so an
-//! inference-only build could skip the Autodiff backend, but Burn's `autodiff` feature adds no
-//! runtime cost to the NdArray inference path and was always compiled in regardless. All the gate
-//! actually excluded was `rand`, used to shuffle epochs. Carrying a whole feature flag — and a
-//! second build configuration to keep working — to avoid linking a random number generator was not
-//! a trade worth making.
-//!
-//! Artifact packaging lives one level up in [`crate::models::artifact`], alongside the reading side
-//! it is the mirror of.
+//! [`artifact`] is the only thing crossing between the trainer VM and the application VM.
 
+pub mod artifact;
 pub mod batch;
 pub mod config;
 pub mod data;
@@ -18,4 +11,5 @@ pub mod evaluate;
 pub mod fit;
 pub mod loss;
 pub mod model;
+pub mod predict;
 pub mod train;

--- a/src/models/tide/artifact.rs
+++ b/src/models/tide/artifact.rs
@@ -1,20 +1,11 @@
-//! TiDE model artifacts: writing them on the trainer, reading them on the application.
+//! TiDE model artifacts: written on the trainer, read on the application.
 //!
-//! The artifact is the only thing crossing the boundary between the two machines. The trainer VM
-//! packages a directory of trained files into a flat `model.tar.gz` and uploads it to
-//! `s3://{bucket}/models/tide/{run_id}/output/model.tar.gz`; the application VM resolves the newest
-//! one at pre-open and loads it. Nothing enforces the ordering between those two events, and
-//! nothing will — the trainer has no database connection. Running a session against yesterday's
-//! model is a normal outcome, reported as the artifact age in the `predictions_completed` payload
-//! rather than treated as a failure.
+//! Nothing orders the write against the read — the trainer has no database. Running a session
+//! against yesterday's model is normal, reported as the artifact age in the `predictions_completed`
+//! payload rather than as a failure.
 //!
-//! Both sides live here, rather than a write module beside the trainer and a read module beside
-//! inference, because they are one format. The tar is flat — one entry per file, no directory
-//! prefix — and the extraction on the reading side assumes exactly that.
-//!
-//! Resolution walks run folders newest-first and verifies the object exists before committing to
-//! it, so a trainer that crashed after creating its folder but before uploading falls back to the
-//! previous good artifact instead of failing the day.
+//! The tar is flat: one entry per file, no directory prefix. Both sides live here because that
+//! format is the only contract between them.
 
 use std::path::{Path, PathBuf};
 
@@ -45,7 +36,7 @@ pub struct ModelState {
     artifact_key: String,
     /// Training run id: the timestamp segment of the artifact key. Written to
     /// `equity_predictions.model_run_id`, which is how a prediction is traced back to the artifact
-    /// that produced it now that there is no `model_runs` table to join against.
+    /// that produced it.
     run_id: String,
     load_timestamp: i64,
 }
@@ -497,8 +488,7 @@ mod tests {
     use super::*;
 
     /// `Path::join` discards its base when given an absolute path, so an entry named `/tmp/...`
-    /// would previously have been written to that absolute location rather than inside the
-    /// extraction directory. Rejecting non-`Normal` components is what stops it.
+    /// would escape the extraction directory. Rejecting non-`Normal` components is what stops it.
     ///
     /// The header name is written directly because the `tar` crate refuses to *produce* an absolute
     /// entry path through its safe API — which is precisely why the reading side has to defend

--- a/src/models/tide/batch.rs
+++ b/src/models/tide/batch.rs
@@ -1,18 +1,13 @@
-//! Shared conversion of windowed ndarray datasets into Burn tensors.
+//! Windowed ndarray datasets into Burn tensors.
 //!
-//! Both training and inference flatten a [`TrainingDataset`] into the model's
-//! `[batch, input_size]` input here so the feature ordering can never drift
-//! between the two paths.
+//! Training and inference both flatten through here, so the feature ordering cannot drift between
+//! them.
 
 use burn::prelude::*;
 
 use crate::models::tide::data::TrainingDataset;
 
 /// Build the `[batch, input_size]` forward input for the given sample indices.
-///
-/// Features are flattened in the canonical order the model expects: past
-/// continuous, past categorical, future categorical, then static — each cast to
-/// f32.
 pub fn build_input_tensor<B: Backend>(
     dataset: &TrainingDataset,
     indices: &[usize],

--- a/src/models/tide/config.rs
+++ b/src/models/tide/config.rs
@@ -1,10 +1,10 @@
+//! Model hyperparameters. Serialized into the artifact, so changing a default only affects new
+//! training runs — existing artifacts keep the values they were trained with.
+
 use serde::{Deserialize, Serialize};
 
-/// TiDE model hyperparameters, persisted as `tide_parameters.json` in the
-/// training artifact and reloaded at inference time.
-///
-/// Fields are private; construct via [`ModelParameters::new`] (which applies
-/// the architecture defaults) or deserialize from a stored artifact.
+/// TiDE model hyperparameters, persisted as `tide_parameters.json` in the training artifact and
+/// reloaded at inference time.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelParameters {
     input_size: usize,

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -1,3 +1,8 @@
+//! Feature engineering, scaling, categorical encoding, and windowing.
+//!
+//! Training fits the scaler and mappings here; inference reuses the ones stored in the artifact.
+//! Both paths run the same functions, so a change to any of them changes both.
+
 use std::collections::HashMap;
 
 use chrono::Datelike;
@@ -128,11 +133,9 @@ pub(crate) const STATIC_CATEGORICAL_COLUMNS: &[&str] = &["ticker", "sector", "in
 
 /// Placeholder for a null categorical value.
 ///
-/// `into_no_null_iter` silently *skips* nulls, so building these columns with it produced a vector
-/// shorter than the frame whenever `sector` or `industry` was null — which either failed the column
-/// replacement outright or, worse, shifted every later row onto the wrong ticker. Substituting a
-/// sentinel preserves length and alignment, and for `ticker` the sentinel is the value the filter
-/// immediately below already drops.
+/// `into_no_null_iter` silently *skips* nulls, so a null `sector` or `industry` yields a column
+/// shorter than the frame, shifting every later row onto the wrong ticker. The sentinel preserves
+/// alignment.
 pub(crate) const UNKNOWN_CATEGORY: &str = "UNKNOWN";
 
 /// The model target is the future window of `daily_return`, which is the last
@@ -187,10 +190,8 @@ impl Data {
         Ok(Self::from_parts(data, scaler.clone(), mappings.clone()))
     }
 
-    /// Split the engineered frame into (train, validate) by a global date cutoff
-    /// at `min + (max - min) * validation_split`: rows at or before the cutoff
-    /// are training, later rows are validation (the Python trainer uses
-    /// `date <= split` for train).
+    /// Split the engineered frame into (train, validate) by a global date cutoff at
+    /// `min + (max - min) * validation_split`. Rows at or before the cutoff are training.
     pub fn split_by_timestamp(
         &self,
         validation_split: f64,
@@ -390,8 +391,7 @@ fn window_frame(
 pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn std::error::Error>> {
     // Sort by [ticker, timestamp] so daily returns and the downstream windowing
     // are chronological and contiguous within each ticker, independent of the
-    // order rows arrived in. Each ticker's first row gets a null return (like
-    // pct_change over ticker in the Python pipeline); clean_data drops it.
+    // order rows arrived in. Each ticker's first row gets a null return; clean_data drops it.
     let data = data
         .sort(
             ["ticker", "timestamp"],
@@ -451,7 +451,7 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn st
             .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap());
         let date = datetime.date_naive();
 
-        // Monday = 1 .. Sunday = 7, matching polars dt.weekday() in Python.
+        // Monday = 1 .. Sunday = 7, per polars `dt.weekday()`.
         day_of_week.push(date.weekday().number_from_monday() as i32);
         day_of_month.push(date.day() as i32);
         day_of_year.push(date.ordinal() as i32);
@@ -537,9 +537,8 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
 
     // Drop rows with a null or non-finite value in any continuous column —
     // each ticker's first observation (null return), missing vendor fields
-    // such as volume_weighted_average_price, and any division artifacts —
-    // matching the Python CleanData stage. Downstream scaling and windowing
-    // iterate these columns assuming they are dense and finite.
+    // such as volume_weighted_average_price, and any division artifacts. Downstream
+    // scaling and windowing iterate these columns assuming they are dense and finite.
     let mut keep_row = vec![true; cleaned.height()];
     for column in CONTINUOUS_COLUMNS {
         let values = cleaned
@@ -835,9 +834,8 @@ mod tests {
 
     #[test]
     fn test_engineer_features_nulls_first_row_per_ticker() {
-        // Mirrors the Python pct_change().over("ticker"): each ticker's first
-        // row has a null daily_return (dropped later by clean_data), never a
-        // synthetic zero and never a value carried across the ticker boundary.
+        // Each ticker's first row has a null daily_return (dropped later by clean_data), never
+        // a synthetic zero and never a value carried across the ticker boundary.
         let engineered = engineer_features(raw_two_ticker_frame()).unwrap();
         // Sorted by [ticker, timestamp]: AAA@0, AAA@1, BBB@0, BBB@1.
         let returns: Vec<Option<f32>> = engineered
@@ -855,8 +853,8 @@ mod tests {
 
     #[test]
     fn test_clean_data_drops_null_return_rows() {
-        // Python's CleanData filters null/NaN/non-finite daily_return rows, so
-        // each ticker's first observation never reaches the scaler or windows.
+        // Null, NaN, and non-finite daily_return rows are filtered, so each ticker's first
+        // observation never reaches the scaler or windows.
         let engineered = engineer_features(raw_two_ticker_frame()).unwrap();
         let cleaned = clean_data(engineered).unwrap();
         assert_eq!(cleaned.height(), 2);
@@ -873,8 +871,8 @@ mod tests {
     #[test]
     fn test_clean_data_drops_rows_with_null_continuous_values() {
         // A null volume_weighted_average_price (nullable in the database and in
-        // vendor data) must drop the row, like the Python CleanData stage; it
-        // must never silently shorten a column during scaling or windowing.
+        // vendor data) must drop the row; it must never silently shorten a column during
+        // scaling or windowing.
         let mut engineered = engineer_features(raw_two_ticker_frame()).unwrap();
         engineered
             .with_column(Column::new(
@@ -890,7 +888,7 @@ mod tests {
 
     #[test]
     fn test_engineer_features_day_of_week_is_monday_based_one_to_seven() {
-        // Python uses polars dt.weekday(): Monday = 1 .. Sunday = 7.
+        // Monday = 1 .. Sunday = 7.
         let monday = chrono::NaiveDate::from_ymd_opt(2026, 6, 8)
             .unwrap()
             .and_hms_opt(0, 0, 0)
@@ -931,9 +929,8 @@ mod tests {
 
     #[test]
     fn test_split_by_timestamp_boundary_row_goes_to_train() {
-        // Python: train is date <= split, validation is date > split. With 11
-        // daily rows (0..=10 days) and split 0.8 the cutoff lands exactly on
-        // day 8, which must belong to train.
+        // Train is date <= split, validation is date > split. With 11 daily rows (0..=10 days)
+        // and split 0.8 the cutoff lands exactly on day 8, which must belong to train.
         let data = empty_data(make_encoded_frame(1, 11));
         let (train, valid) = data.split_by_timestamp(0.8).unwrap();
         assert_eq!(train.height(), 9);

--- a/src/models/tide/drift.rs
+++ b/src/models/tide/drift.rs
@@ -1,7 +1,6 @@
-//! Model drift detection: compare a training run's CRPS against the baseline
-//! of recent prior runs. A direct port of the retired Python trainer's
-//! `check_drift` — drift is reported (logged and recorded in `model_runs`),
-//! never used to block an artifact upload.
+//! Model drift detection: compare a training run's CRPS against the baseline of recent prior runs.
+//!
+//! Drift is logged, never used to block an artifact upload.
 
 use serde::Serialize;
 
@@ -104,8 +103,8 @@ mod tests {
 
     #[test]
     fn test_no_drift_at_exact_degradation_limit() {
-        // baseline = 0.3, limit = 0.36; the Python check is strictly greater
-        // than, so a value exactly at the limit is not drift.
+        // baseline = 0.3, limit = 0.36. The check is strictly greater than, so a value
+        // exactly at the limit is not drift.
         let result = check_drift(0.36, &[0.3, 0.3, 0.3], 3, 0.20);
         assert_eq!(result.status, DriftStatus::NoDrift);
         assert_eq!(result.baseline_crps, Some(0.3));
@@ -136,7 +135,7 @@ mod tests {
     }
 
     #[test]
-    fn test_status_serializes_to_python_strings() {
+    fn test_status_serializes_to_snake_case() {
         assert_eq!(
             serde_json::to_value(DriftStatus::InsufficientHistory).unwrap(),
             "insufficient_history"

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -1,10 +1,8 @@
-//! Evaluation metrics for a trained TiDE model, computed on the validation set
-//! in scaled space. Ports the Python `evaluate.py` definitions exactly:
+//! Evaluation metrics for a trained TiDE model, computed on the validation set in scaled space.
 //!
-//! - CRPS: per row, the **sum** over quantiles of pinball loss (non-strict
-//!   `error >= 0` split), then the mean over rows.
-//! - directional accuracy: fraction of rows where `(q50 >= 0) == (target >= 0)`.
-//! - quantile coverage: fraction of rows where `q10 <= target <= q90`.
+//! CRPS here **sums** pinball loss over quantiles with a non-strict `error >= 0` split, where the
+//! training loss in [`crate::models::tide::loss`] averages with a strict split. The two are
+//! deliberately different.
 
 use burn::backend::NdArray;
 

--- a/src/models/tide/fit.rs
+++ b/src/models/tide/fit.rs
@@ -1,10 +1,7 @@
-//! Fit the scaler and categorical mappings from training data, and serialize
-//! the artifact JSON files the inference path loads.
+//! Fit the scaler and categorical mappings from training data, and serialize the artifact JSON
+//! files the inference path loads.
 //!
-//! Mirrors the Python trainer's preprocessing: z-score the continuous columns,
-//! integer-encode `ticker`/`sector`/`industry` over sorted-unique values (so the
-//! mapping is deterministic and interchangeable), and leave the calendar
-//! categoricals as their raw integers.
+//! Categoricals are encoded over sorted-unique values so the mapping is deterministic across runs.
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -102,10 +99,9 @@ fn build_mapping(
         .collect())
 }
 
-/// Row-level training filter mirroring the Python trainer: keep rows whose
-/// close price and volume meet the thresholds (inclusive) and whose ticker
-/// contains no lowercase letters (lowercase variants are distinct instruments
-/// that would collide with the uppercase ticker after cleaning).
+/// Row-level training filter: thresholds are inclusive, and tickers containing lowercase letters
+/// are dropped — they are distinct instruments that would collide with the uppercase ticker after
+/// cleaning.
 pub fn filter_training_bars(
     data: DataFrame,
     minimum_close_price: f64,
@@ -230,9 +226,8 @@ mod tests {
 
     #[test]
     fn test_filter_training_bars_is_row_level_and_inclusive() {
-        // Python: (close_price >= min) & (volume >= min) per row — a ticker
-        // with one qualifying row and one penny row keeps only the qualifying
-        // row, and rows exactly at the threshold are kept.
+        // The filter is per row, so a ticker with one qualifying row and one penny row keeps
+        // only the qualifying row. Rows exactly at the threshold are kept.
         let data = DataFrame::new(vec![
             Column::new("ticker".into(), vec!["AAA", "AAA", "BBB"]),
             Column::new("timestamp".into(), vec![0_i64, 86_400_000, 0]),
@@ -263,8 +258,8 @@ mod tests {
 
     #[test]
     fn test_filter_training_bars_drops_lowercase_tickers() {
-        // Python excludes tickers matching [a-z]: lowercase variants are
-        // distinct instruments that would collide once uppercased.
+        // Tickers containing lowercase letters are distinct instruments that would collide
+        // once uppercased.
         let data = DataFrame::new(vec![
             Column::new("ticker".into(), vec!["AAPL", "AAPLw", "brk.a"]),
             Column::new("timestamp".into(), vec![0_i64, 0, 0]),

--- a/src/models/tide/loss.rs
+++ b/src/models/tide/loss.rs
@@ -1,9 +1,8 @@
 //! Quantile (pinball) loss for the TiDE model, optionally Huber-smoothed.
 //!
-//! Ported from the Python trainer's `quantile_loss`. The training loss averages
-//! the per-quantile loss over all quantiles and uses a strict `error > 0` split;
-//! the evaluation CRPS (see [`crate::models::tide::evaluate`]) intentionally
-//! differs (sum over quantiles, non-strict split).
+//! This averages over quantiles with a strict `error > 0` split. The evaluation CRPS in
+//! [`crate::models::tide::evaluate`] sums instead, with a non-strict split — a deliberate
+//! difference, not a bug to reconcile.
 
 use burn::prelude::*;
 

--- a/src/models/tide/model.rs
+++ b/src/models/tide/model.rs
@@ -1,3 +1,5 @@
+//! The TiDE network: residual blocks, encoder, decoder, and the quantile output projection.
+
 use burn::backend::NdArray;
 use burn::module::Module;
 use burn::nn;
@@ -160,7 +162,6 @@ impl<B: Backend> TideModel<B> {
 
         let combined = decoder_output + encoder_output;
         let combined = self.final_layer_norm.forward(combined);
-        // The Python model projects relu(x): `output_projection(x.relu())`.
         let combined = burn::tensor::activation::relu(combined);
 
         let output = self.output_projection.forward(combined);
@@ -234,9 +235,8 @@ mod tests {
         )
         .reshape([4, input_size]);
 
-        // Compose the expected output from the model's own components, applying
-        // relu to the layer-normed combination before the output projection as
-        // the Python trainer does (`output_projection(x.relu())`).
+        // Compose the expected output from the model's own components, applying relu to the
+        // layer-normed combination before the output projection.
         let hidden =
             burn::tensor::activation::relu(model.feature_projection_1.forward(input.clone()));
         let hidden = burn::tensor::activation::relu(model.feature_projection_2.forward(hidden));

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -1,15 +1,8 @@
 //! Running the TiDE model: from stored market history to rows in `equity_predictions`.
 //!
-//! The transformations here are pure functions over Polars frames — consolidate bars with sector
-//! detail, filter to the liquid universe, restrict to tickers the model was actually trained on,
-//! run the network, and reshape the output. Loading the frames is `data`\'s job and persisting the
-//! result is the last step in this file, which keeps the model pipeline testable without a
-//! database.
-//!
-//! The liquidity filter matters more than it looks: training applies the same thresholds per row
-//! that inference applies per ticker average. They were historically mismatched, which trained the
-//! scaler on penny-stock dynamics the service never predicts. Both sides read the constants from
-//! [`crate::common::types`] now so they cannot drift again.
+//! Training and inference must apply the same liquidity thresholds — training per row, inference
+//! per ticker average. Both read them from [`crate::common::types`] so they cannot drift; a
+//! mismatch trains the scaler on dynamics the service never predicts.
 
 use burn::backend::NdArray;
 use chrono::{DateTime, Duration, Utc};
@@ -19,7 +12,7 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::common::types::{EquityPrediction, Ticker};
-use crate::models::artifact::ModelState;
+use crate::models::tide::artifact::ModelState;
 use crate::models::tide::data::Data;
 
 #[derive(Debug, thiserror::Error)]
@@ -80,8 +73,7 @@ pub fn consolidate_data(
                 .str()
                 .strip_chars(lit(" ")),
         ])
-        // Rows without a sector or industry cannot be categorically encoded;
-        // the Python pipeline drops them after the join.
+        // Rows without a sector or industry cannot be categorically encoded.
         .filter(
             col("sector")
                 .is_not_null()
@@ -210,10 +202,9 @@ pub fn filter_to_trained_tickers(
     Ok(filtered)
 }
 
-/// Inverse-scale the predicted `daily_return` quantiles and sort them so they
-/// are monotonic, exactly as the Python postprocessing does (`np.sort` per
-/// row). Quantile crossing is routine in quantile regression; sorting is the
-/// standard rearrangement remedy.
+/// Inverse-scale the predicted `daily_return` quantiles and sort them monotonic.
+///
+/// Quantile crossing is routine in quantile regression; sorting is the standard remedy.
 pub(crate) fn unscale_and_sort_quantiles(
     scaled_quantiles: &[f64],
     scaler: &crate::models::tide::data::Scaler,
@@ -226,8 +217,7 @@ pub(crate) fn unscale_and_sort_quantiles(
     unscaled
 }
 
-/// Timestamp (UTC midnight, milliseconds) for horizon step `step`, where step 0
-/// is `now`'s date — matching the Python labeling `now + timedelta(days=step)`.
+/// Timestamp (UTC midnight, milliseconds) for horizon step `step`, where step 0 is `now`'s date.
 pub(crate) fn step_timestamp_milliseconds(now: chrono::DateTime<Utc>, step: usize) -> i64 {
     (now + Duration::days(step as i64))
         .date_naive()
@@ -325,8 +315,7 @@ pub fn generate_predictions(
         }
     }
 
-    // Persist the final horizon step, now + (output_length - 1) days, exactly
-    // like the Python service.
+    // Persist the final horizon step, now + (output_length - 1) days.
     let target_date = step_timestamp_milliseconds(now, output_length - 1);
 
     let final_predictions: Vec<serde_json::Value> = results
@@ -415,12 +404,10 @@ pub fn validate_predictions(predictions: &[serde_json::Value]) -> Result<(), Str
 // Persistence
 // --------------------------------------------------------------------------
 
-/// Boundary morphism: converts an untrusted pipeline prediction JSON object
-/// into a validated [`EquityPrediction`].
+/// Converts a pipeline prediction JSON object into a validated [`EquityPrediction`].
 ///
-/// Predictions come from our own pipeline, so a missing or mistyped field is a
-/// real data bug upstream; this fails loudly with the offending field and
-/// ticker instead of persisting placeholder values.
+/// These come from our own pipeline, so a missing or mistyped field is a bug upstream. It fails
+/// loudly with the offending field and ticker rather than persisting placeholders.
 fn prediction_from_json(
     prediction: &serde_json::Value,
     correlation_id: Uuid,
@@ -752,8 +739,8 @@ mod tests {
 
     #[test]
     fn test_step_timestamp_step_zero_is_today_midnight() {
-        // Python labels horizon step t as now + t days at midnight: step 0 is
-        // today, and the persisted target is step output_length - 1.
+        // Horizon step t is now + t days at midnight: step 0 is today, and the persisted
+        // target is step output_length - 1.
         let now = chrono::DateTime::parse_from_rfc3339("2026-06-09T15:30:00Z")
             .unwrap()
             .with_timezone(&Utc);

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -315,7 +315,7 @@ pub fn generate_predictions(
         }
     }
 
-    // Persist the final horizon step, now + (output_length - 1) days.
+    // Select the final horizon step, now + (output_length - 1) days, for the caller to persist.
     let target_date = step_timestamp_milliseconds(now, output_length - 1);
 
     let final_predictions: Vec<serde_json::Value> = results

--- a/src/models/tide/train.rs
+++ b/src/models/tide/train.rs
@@ -1,8 +1,7 @@
-//! Rust-native TiDE training loop on the `Autodiff<NdArray>` backend.
+//! TiDE training loop on the `Autodiff<NdArray>` backend.
 //!
-//! A hand-rolled loop (no `burn-train` `Learner`) mirroring the Python trainer:
-//! Adam, mini-batch shuffling, validation-loss early stopping with patience, and
-//! best-checkpoint restore (kept in memory rather than round-tripped to disk).
+//! Hand-rolled rather than `burn-train`'s `Learner`. The best checkpoint is restored from memory
+//! rather than round-tripped to disk.
 
 use burn::backend::{Autodiff, NdArray};
 use burn::module::AutodiffModule;
@@ -103,18 +102,16 @@ impl Default for TrainConfig {
             epoch_count: 20,
             batch_size: 512,
             early_stopping_patience: 3,
-            // The scaled-return quantile loss sits around 1e-4, so the Python
-            // default min_delta of 1e-3 never registered an improvement and
-            // training always stopped after `patience`. Use a delta below the
-            // loss scale so genuine epoch-over-epoch gains keep training going.
+            // The scaled-return quantile loss sits around 1e-4, so a min_delta of 1e-3 never
+            // registers an improvement and training always stops after `patience`. This must stay
+            // below the loss scale for genuine epoch-over-epoch gains to keep training going.
             min_delta: 1e-5,
         }
     }
 }
 
-/// Epoch-end checkpoint and early-stopping policy, mirroring the Python
-/// trainer: the best model is snapshotted on any improvement, while the
-/// early-stopping counter only resets on improvements larger than `min_delta`.
+/// Epoch-end checkpoint and early-stopping policy. The best model is snapshotted on any
+/// improvement; the early-stopping counter only resets on improvements larger than `min_delta`.
 pub(crate) struct EarlyStopping {
     best_checkpoint_metric: f64,
     best_stopping_metric: f64,
@@ -381,10 +378,9 @@ mod tests {
 
     #[test]
     fn test_early_stopping_snapshots_below_min_delta_improvements() {
-        // Truth table from the Python trainer: any improvement checkpoints the
-        // model, but only improvements beyond min_delta reset the patience
-        // counter — small gains keep the best weights while still counting
-        // toward early stopping.
+        // Any improvement checkpoints the model, but only improvements beyond min_delta reset
+        // the patience counter — small gains keep the best weights while still counting toward
+        // early stopping.
         let mut policy = EarlyStopping::new();
         assert_eq!(policy.observe(0.5, 1e-3, 2), (true, false));
         // Better, but by less than min_delta: snapshot, counter advances.
@@ -406,10 +402,9 @@ mod tests {
 
     #[test]
     fn test_best_model_checkpointed_even_below_min_delta() {
-        // The Python trainer snapshots the best model whenever the stopping
-        // metric improves at all; min_delta only gates the early-stopping
-        // counter. With an enormous min_delta the counter never resets, but the
-        // returned model must still be the best epoch, not the initial weights.
+        // The best model is snapshotted whenever the stopping metric improves at all; min_delta
+        // only gates the early-stopping counter. With an enormous min_delta the counter never
+        // resets, but the returned model must still be the best epoch, not the initial weights.
         let input_length = 3;
         let output_length = 1;
         let dataset = overfit_dataset(32, input_length, output_length);

--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -1,12 +1,8 @@
 //! The strategy: which pairs to hold, how large, and when to let them go.
 //!
-//! [`pairs`] is the record — the long/short mapping and the signal that justified it. [`screen`]
-//! decides what is worth holding, [`size`] how much, and [`risk`] whether the book can take it.
-//! [`execute`] is the only module that sends an order, and [`evaluate`] is the five-minute pass
-//! that drives the rest.
-//!
-//! [`account`] is the post-close half: what Alpaca says actually happened, written back as the
-//! reference the next session's drawdown gate reads.
+//! [`execute`] is the only module that sends an order; [`evaluate`] is the five-minute pass that
+//! drives the rest. [`account`] is the post-close half, writing back what Alpaca says actually
+//! happened as the reference the next session's drawdown gate reads.
 
 pub mod account;
 pub mod evaluate;

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -1,14 +1,12 @@
 //! The post-close account sync: what Alpaca says actually happened.
 //!
-//! Three things come out of this, in order. The session's balances land in `account_snapshots`,
-//! whose `equity` is the reference the *next* session's drawdown gate measures against — that gate
-//! is the reason this table exists. The session's fills land in `account_activities`, keyed by
-//! Alpaca's own activity identifier so a re-run conflicts on every row and changes nothing. Then
-//! the fills are attributed back to the pairs they belong to.
+//! Three things, in order. Balances land in `account_snapshots`, whose `equity` is what the *next*
+//! session's drawdown gate measures against. Fills land in `account_activities`, keyed by Alpaca's
+//! activity identifier so a re-run conflicts on every row and changes nothing. Then the fills are
+//! attributed back to their pairs.
 //!
-//! Attribution is a materialization, not a source. Alpaca's activities remain the truth; the
-//! `realized_profit_and_loss` column exists so the dashboard does not re-join activities to pairs
-//! on ticker and time window on every page load.
+//! Attribution is a materialization, not a source: `realized_profit_and_loss` exists so the
+//! dashboard need not re-join activities to pairs on every page load.
 
 use std::collections::HashMap;
 
@@ -205,10 +203,9 @@ pub struct Attribution {
 /// a sell positive, so a pair that opened and closed cleanly sums to what it made.
 ///
 /// A fill matching more than one pair is counted against **none** of them and reported as
-/// unattributed. That happens when the same symbol was traded in two overlapping pairs, which the
-/// disjointness rule in [`crate::portfolio::screen::select_disjoint`] is supposed to prevent —
-/// so it is a signal that something upstream is wrong, and splitting the fill between the two
-/// candidates would produce two plausible numbers and hide it.
+/// unattributed. That means the same symbol traded in two overlapping pairs, which
+/// [`crate::portfolio::screen::select_disjoint`] is supposed to prevent — so splitting the fill
+/// would produce two plausible numbers and hide an upstream bug.
 pub fn attribute(closed: &[ClosedPair], activities: &[AccountActivity]) -> Attribution {
     let mut realized: HashMap<Uuid, Decimal> = closed
         .iter()

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -2,14 +2,10 @@
 //!
 //! Two properties the implementation has to preserve, and both are easy to lose:
 //!
-//! 1. **Exits run unconditionally.** A pass that cannot price the universe, cannot read
-//!    predictions, or finds no vacant slots still closes what should close. Only the entry half is
-//!    conditional, and every early return below is in the entry half.
-//! 2. **The entry half reuses the prices the exit half already fetched.** It asks Alpaca only for
-//!    the symbols it does not already have. Re-fetching an open leg between the exit decision and
-//!    the entry decision would make the cheap and expensive halves two opinions that can disagree,
-//!    which is the failure recorded in `dual_path_signal_agreement`; here they are one measurement
-//!    used twice.
+//! 1. **Exits run unconditionally.** Every early return below is in the entry half.
+//! 2. **The entry half reuses the prices the exit half already fetched**, asking Alpaca only for
+//!    symbols it does not have. Re-fetching an open leg between the two decisions would make them
+//!    two opinions that can disagree; here they are one measurement used twice.
 
 use std::collections::{HashMap, HashSet};
 
@@ -24,7 +20,7 @@ use crate::common::types::{EquityPrediction, Ticker};
 use crate::data::calendar::{eastern_date, eastern_day_bounds, TradingCalendar};
 use crate::data::details::{self, DetailsError};
 use crate::data::universe::Universe;
-use crate::models::predict;
+use crate::models::tide::predict;
 use crate::portfolio::account::{self, AccountError};
 use crate::portfolio::execute::{self, ExecutionError, ExecutionSettings, OpenOutcome};
 use crate::portfolio::pairs::{self, CloseReason, OpenPair, PairsError};
@@ -209,17 +205,12 @@ pub async fn run_pass(
         .collect();
 
     for (index, pair) in approved.iter().enumerate() {
-        // Checked between pairs, never inside one. Opening a pair is two broker legs and an insert,
-        // and abandoning it partway is the failure this whole path is arranged to avoid — so the
-        // pass finishes whatever it has started and declines to start the next one.
+        // Between pairs, never inside one: opening a pair is two broker legs and an insert, so the
+        // pass finishes what it started and declines to start the next. This is what makes the
+        // drain timeout in `bin/fund.rs` a real bound rather than a hope.
         //
-        // This is what makes the drain's timeout in `bin/fund.rs` a real bound rather than a hope.
-        // Without it the pass works through every approved candidate sequentially, and no fixed
-        // timeout covers a list whose length is decided by the screen.
-        //
-        // Only the entry half. `close_what_should_close` ran earlier in this pass and is never
-        // skipped: a close reduces risk, and declining one leaves the book holding something it had
-        // already decided to let go of.
+        // Entry half only. `close_what_should_close` ran earlier and is never skipped — a close
+        // reduces risk, and declining one leaves the book holding what it decided to let go of.
         if context.shutdown.is_cancelled() {
             summary.entries_abandoned = approved.len() - index;
             warn!(
@@ -243,14 +234,11 @@ pub async fn run_pass(
                 long_fill,
                 short_fill,
             } => {
-                // Both legs are filled at the broker before this line runs, and the broker and the
-                // database are separate systems — there is no transaction that spans them. If the
-                // insert fails, the position is live with no `equity_pairs` row, so no later pass
-                // can exit it on a signal and the account sync cannot attribute its fills.
-                //
-                // The pre-close liquidation is the backstop, and it is why it flattens the
-                // *account* rather than the pairs the application knows about. What this can add is
-                // a record precise enough to reconstruct the pair by hand before then.
+                // Both legs are already filled and no transaction spans the broker and the
+                // database. If this insert fails the position is live with no `equity_pairs` row,
+                // so no later pass can exit it on a signal. The pre-close liquidation is the
+                // backstop, which is why it flattens the *account* rather than known pairs; this
+                // log is what makes the pair reconstructable by hand before then.
                 if let Err(error) = pairs::record_open(context.pool, &entry, context.now).await {
                     error!(
                         pair_id = %entry.pair_id(),
@@ -295,12 +283,11 @@ pub struct LiquidationSummary {
 
 /// Flattens the account, then marks the pair records closed.
 ///
-/// The order is not negotiable. Marking the records first and flattening afterwards would, on a
-/// failure, leave the application believing it holds nothing while the account holds positions
-/// overnight — and nothing would look again until the next morning.
+/// The order is not negotiable: marking records first would, on failure, leave the application
+/// believing it holds nothing while the account holds positions overnight.
 ///
-/// A pair whose leg Alpaca refused to close stays open in the record. That is the honest state, and
-/// it is what makes `pairs_still_open` a usable alarm rather than a formality.
+/// A pair whose leg Alpaca refused to close stays open in the record, which is what makes
+/// `pairs_still_open` a usable alarm.
 pub async fn run_liquidation(
     pool: &PgPool,
     client: &TradingClient,

--- a/src/portfolio/execute.rs
+++ b/src/portfolio/execute.rs
@@ -1,14 +1,11 @@
 //! Order submission and fill confirmation. The only module that sends an order.
 //!
-//! Opening a pair is two orders that have to both work or neither hold. The short leg goes first
-//! and its fill is confirmed before the long leg is submitted at all, which is not the fastest
-//! ordering but is the one that fails cleanly: a short can be rejected for borrow reasons a long
-//! never is, and submitting them together means the common failure leaves a naked long to unwind.
-//! Sequenced this way, the usual rejection costs nothing to recover from because there is nothing
-//! yet to recover.
+//! Opening a pair is two orders that must both work or neither hold. The short leg goes first and
+//! its fill is confirmed before the long is submitted: a short can be rejected for borrow reasons a
+//! long never is, so the common failure costs nothing to recover from because nothing is held yet.
 //!
-//! Unwinding is still implemented, because the uncommon case — the short fills and the long does
-//! not — is the one that leaves an unhedged position, and it is the one worth having a path for.
+//! Unwinding is still implemented for the uncommon case — the short fills and the long does not —
+//! which is the one that leaves an unhedged position.
 
 use std::time::Duration;
 
@@ -240,14 +237,10 @@ pub async fn open_pair(
 
 /// Closes both legs of a pair.
 ///
-/// **Both closes are always attempted, including when the first one errors.** A missing position is
-/// `Ok(false)` and was never the hard case; a 500, a timeout, or a dropped connection is. Returning
-/// early on one of those would leave a live short leg on the book — the naked directional position
-/// the pair structure exists to avoid — and it would do so in exactly the situation where the leg is
-/// most likely still held.
-///
-/// The error is reported only after both attempts have been made, so a failure on the long leg costs
-/// the caller its error and nothing else.
+/// **Both closes are always attempted, even when the first errors.** A missing position is
+/// `Ok(false)`; a 500 or a timeout is the hard case, and returning early on one would leave a live
+/// short leg — the naked directional position the pair structure exists to avoid — in exactly the
+/// situation where it is most likely still held. The error is reported after both attempts.
 pub async fn close_pair(
     client: &TradingClient,
     long_ticker: &Ticker,

--- a/src/portfolio/pairs.rs
+++ b/src/portfolio/pairs.rs
@@ -1,13 +1,11 @@
 //! `equity_pairs` persistence: which long belongs with which short, and why.
 //!
-//! Alpaca holds the authoritative position, quantity, and fill. What it cannot answer is which
-//! long belongs with which short and what signal put them there, so that — and only that — is what
-//! this table stores. Nothing here is a position ledger, and nothing here should be trusted over
-//! Alpaca about what is actually held.
+//! Alpaca holds the authoritative position, quantity, and fill. What it cannot answer is which long
+//! belongs with which short and what signal put them there, so that — and only that — is stored
+//! here. This is not a position ledger and should never be trusted over Alpaca.
 //!
-//! `realized_profit_and_loss` is written by the post-close account sync in
-//! [`crate::portfolio::account`], not by the evaluation pass. The pass knows a pair closed; it does
-//! not know what the fills came back at.
+//! `realized_profit_and_loss` is written by the post-close sync in [`crate::portfolio::account`],
+//! not by the evaluation pass: the pass knows a pair closed, not what the fills came back at.
 
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;

--- a/src/portfolio/risk.rs
+++ b/src/portfolio/risk.rs
@@ -1,14 +1,11 @@
 //! The risk gate: four conditions, all of which only ever stop an *entry*.
 //!
-//! Nothing here can block an exit. That is the property the whole design rests on — the book is
-//! flat overnight without exception, so a gate that could refuse to close a position would be a way
-//! to carry one. Exits run first and unconditionally in [`crate::portfolio::evaluate`]; this module
-//! is consulted only afterwards, when the pass is deciding whether to open anything.
+//! Nothing here can block an exit. The book is flat overnight without exception, so a gate that
+//! could refuse to close a position would be a way to carry one. Exits run first and
+//! unconditionally in [`crate::portfolio::evaluate`]; this is consulted only afterwards.
 //!
-//! This is a much smaller surface than the system it replaces. What was removed, why, and the order
-//! it should come back in are recorded in `risk_management_reintroduction.md`. The short version:
-//! everything that modeled overnight exposure went with the requirement to hold overnight, and the
-//! beta-neutral optimizer went with the machinery that estimated the betas.
+//! Deliberately small: everything modelling overnight exposure went with the requirement to hold
+//! overnight, and the beta-neutral optimizer went with the machinery that estimated the betas.
 
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -1,14 +1,11 @@
 //! Pair selection: which two symbols, which way round, and how strong the signal.
 //!
-//! The screen is quadratic in the eligible universe, so everything cheap happens first: the
-//! prediction confidence floor, the shortable check, and the different-sector rule all reduce the
-//! input before a single correlation is computed.
+//! The screen is quadratic in the eligible universe, so everything cheap runs first: the confidence
+//! floor, the shortable check, and the different-sector rule all shrink the input before a single
+//! correlation is computed.
 //!
-//! [`SpreadModel`] is the load-bearing type. Entry and exit both measure the spread through it, and
-//! an open pair's model is rebuilt from its *stored* hedge ratio rather than refitted, so the
-//! spread a pass compares against the exit threshold is the same spread the entry threshold was
-//! applied to. Two code paths measuring the same quantity differently is the failure recorded in
-//! `dual_path_signal_agreement`, and this is where it would recur.
+//! [`SpreadModel`] is load-bearing. An open pair's model is rebuilt from its *stored* hedge ratio
+//! rather than refitted, so entry and exit measure the same spread.
 
 use std::collections::{HashMap, HashSet};
 
@@ -21,15 +18,14 @@ pub const CORRELATION_WINDOW_SESSIONS: usize = 60;
 
 /// Correlation band a pair's log returns must fall inside.
 ///
-/// The floor rejects pairs with no relationship to mean-revert to. The ceiling rejects pairs so
-/// alike that the spread is mostly microstructure noise — two share classes of one issuer, or an
-/// index fund and its largest holding — where the spread's standard deviation is small enough that
-/// a two-sigma move is inside the bid-ask spread.
+/// The floor rejects pairs with nothing to mean-revert to. The ceiling rejects pairs so alike the
+/// spread is mostly microstructure noise — two share classes of one issuer — where a two-sigma move
+/// is inside the bid-ask spread.
 ///
-/// **The band is on the signed correlation, not its magnitude.** An anti-correlated pair fits a
-/// negative hedge ratio, which turns `ln(short) - hedge_ratio * ln(long)` into a sum rather than a
-/// difference — a quantity that hedges nothing. Sizing is dollar-neutral regardless of the ratio, so
-/// admitting one produces a directional bet wearing the name of a market-neutral pair.
+/// **The band is on signed correlation, not magnitude.** An anti-correlated pair fits a negative
+/// hedge ratio, turning `ln(short) - hedge_ratio * ln(long)` into a sum that hedges nothing, and
+/// sizing is dollar-neutral regardless — so admitting one is a directional bet wearing a
+/// market-neutral name.
 const CORRELATION_MINIMUM: f64 = 0.5;
 const CORRELATION_MAXIMUM: f64 = 0.95;
 
@@ -175,16 +171,13 @@ impl SpreadModel {
 
     /// Rebuilds the distribution around a hedge ratio that was already decided.
     ///
-    /// This is the exit path. Refitting the hedge ratio here instead would mean the pass measures a
-    /// different spread from the one the entry was taken on, and the position would be judged
-    /// against a line it was never above.
+    /// This is the exit path. Refitting here would measure a different spread from the one the
+    /// entry was taken on, judging the position against a line it was never above.
     ///
-    /// The window length is enforced here as well as the hedge ratio, and for the same reason.
-    /// [`SpreadModel::fit`] is only ever called with exactly `CORRELATION_WINDOW_SESSIONS` closes,
-    /// so a shorter series here yields a mean and standard deviation drawn from a different sample
-    /// than the entry was measured against — and a z-score computed from it can cross the
-    /// convergence or stop threshold for a spread that has not moved. Reusing the hedge ratio but
-    /// not the window would reintroduce the asymmetry this type exists to prevent, one level down.
+    /// The window length is enforced for the same reason: [`SpreadModel::fit`] is only ever called
+    /// with exactly `CORRELATION_WINDOW_SESSIONS` closes, so a shorter series draws its mean and
+    /// standard deviation from a different sample and can cross a threshold for a spread that has
+    /// not moved.
     pub fn with_hedge_ratio(
         hedge_ratio: f64,
         long_closes: &[f64],
@@ -353,13 +346,11 @@ impl PairCandidate {
 /// 3. The spread, oriented so the short leg is the expensive one, is at or above `ENTRY_Z_SCORE`.
 /// 4. The model agrees with that orientation — it expects the long leg to out-return the short.
 ///
-/// Test four is the model doing more than gating eligibility. Without it a pair can be opened whose
-/// spread says buy A and sell B while the forecast says the opposite, and the two disagreements
-/// cancel into a position with no thesis at all.
+/// Test four is the model doing more than gating eligibility: without it a pair can open whose
+/// spread says buy A and sell B while the forecast says the opposite.
 ///
-/// No disjointness constraint is applied: the returned list is the full reservoir and pairs within
-/// it may share tickers. [`select_disjoint`] is the cheap second half, so a pass that rejects a
-/// candidate can re-select without paying for the ranking again.
+/// No disjointness constraint is applied — the returned list is the full reservoir and pairs may
+/// share tickers. [`select_disjoint`] is the cheap second half.
 pub fn score_candidates(inputs: &[ScreenInput]) -> Vec<PairCandidate> {
     let eligible: Vec<&ScreenInput> = inputs
         .iter()
@@ -631,16 +622,13 @@ mod tests {
 
     /// A cointegrated pair whose correlation lands inside the screen's band.
     ///
-    /// Both legs are driven by a common factor; the follower carries an idiosyncratic component at
-    /// a different frequency, which is what puts the correlation near 0.8 rather than at 1.0 and
-    /// what gives the spread dispersion to revert within.
+    /// Both legs share a common factor; the follower's idiosyncratic component puts the correlation
+    /// near 0.8 rather than 1.0 and gives the spread dispersion to revert within.
     ///
-    /// Two failure modes are being avoided deliberately, both recorded in
-    /// `statistical_arbitrage_test_fixtures`. A series with no idiosyncratic component correlates
-    /// at 1.0 and is rejected by `CORRELATION_MAXIMUM`; one whose spread has no variance yields an
-    /// infinite z-score. Either produces zero candidates, and every test built on it then passes
-    /// while asserting nothing — which is why `test_the_fixture_yields_at_least_one_candidate`
-    /// exists as a guard above the rest.
+    /// Two failure modes are avoided deliberately. A series with no idiosyncratic component
+    /// correlates at 1.0 and is rejected by `CORRELATION_MAXIMUM`; one whose spread has no variance
+    /// yields an infinite z-score. Either produces zero candidates and every test built on it then
+    /// asserts nothing, which is what `test_the_fixture_yields_at_least_one_candidate` guards.
     fn cointegrated_series(sessions: usize) -> (Vec<f64>, Vec<f64>) {
         let mut leader = Vec::with_capacity(sessions);
         let mut follower = Vec::with_capacity(sessions);

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -627,8 +627,9 @@ mod tests {
     ///
     /// Two failure modes are avoided deliberately. A series with no idiosyncratic component
     /// correlates at 1.0 and is rejected by `CORRELATION_MAXIMUM`; one whose spread has no variance
-    /// yields an infinite z-score. Either produces zero candidates and every test built on it then
-    /// asserts nothing, which is what `test_the_fixture_yields_at_least_one_candidate` guards.
+    /// is rejected by [`SpreadModel::build`]. Either produces zero candidates and every test built
+    /// on it then asserts nothing, which is what
+    /// `test_the_fixture_yields_at_least_one_candidate` guards.
     fn cointegrated_series(sessions: usize) -> (Vec<f64>, Vec<f64>) {
         let mut leader = Vec::with_capacity(sessions);
         let mut follower = Vec::with_capacity(sessions);

--- a/src/portfolio/size.rs
+++ b/src/portfolio/size.rs
@@ -6,11 +6,9 @@
 //! target rather than concentrating the full target into the pairs that happen to be open.
 //!
 //! **Both legs get equal notional, not hedge-ratio-weighted notional.** The hedge ratio decides
-//! where the spread's mean is, not how much to buy. Sizing the short leg at `hedge_ratio x` the
-//! long would make the book hedge-ratio-neutral instead of dollar-neutral, which is a different
-//! and larger claim about what the two legs have in common — and the machinery that justified it
-//! is what `risk_management_reintroduction.md` records as removed. Dollar neutrality is the
-//! assumption this version can actually support.
+//! where the spread's mean is, not how much to buy. Sizing the short at `hedge_ratio x` the long
+//! would make the book hedge-ratio-neutral rather than dollar-neutral — a larger claim about what
+//! the two legs share than this version can support.
 
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -18,7 +18,7 @@ use fund::common::events::{self, Command, EventType, Outcome};
 use fund::common::types::{BarInterval, PairID, Ticker};
 use fund::data::bars;
 use fund::data::calendar::{eastern_date, eastern_day_bounds};
-use fund::models::predict;
+use fund::models::tide::predict;
 use fund::portfolio::account;
 use fund::portfolio::pairs::{self, CloseReason, PairEntry};
 use rust_decimal::Decimal;


### PR DESCRIPTION
# Overview

Documentation-only change across `src/`, plus a module move and three corrections to `devenv.nix`
comments. No behaviour changes: 653 comment lines removed and 388 rewritten, a net reduction of 265
across 44 files, and two file renames.

## Changes

- Move `artifact.rs` and `predict.rs` from `models/` into `models/tide/`. Both are TiDE-only and
  always were — `ModelState` holds a `TideModel<NdArray>`, the artifact S3 prefix is hardcoded to
  `models/tide/`, the loader reads `tide_parameters.json`, and the `unsafe impl Sync` exists because
  of `TideModel` specifically
- Remove stale references to things that no longer exist: 23 mentions of a Python trainer (the
  repository contains no Python), an `inference/` module describing a split that was merged, a
  `train` feature gate (the crate has no features), and pointers to memory notes and `.scratchpad/`
  files, which are gitignored and unreadable to anyone holding only the repository
- Remove content derivable from the code beneath it: `lib.rs` re-describing six modules that each
  document themselves, `batch.rs` listing a flattening order that is the next ten lines, `config.rs`
  noting that fields are private
- Correct five factual errors (see Context)
- Add short module headers to `config.rs`, `data.rs`, and `model.rs`, which had none
- Correct the `database:backup`, `data:seed`, and `ensure-test-services` comments in `devenv.nix`

## Context

**Where a stale reference carried a real rule, the rule was kept and only the attribution dropped** —
the Monday=1 weekday convention, quantile monotonic sorting, inclusive liquidity thresholds, and the
lowercase-ticker collision are all still documented, just no longer as "matching the Python trainer".

**Five factual errors surfaced while trimming, not while looking for them.**

| Location | Claimed | Actual |
|---|---|---|
| `drift.rs` | Drift "recorded in `model_runs`" | No such table; the trainer only warns and infos |
| `observability.rs` | Services named `"data"`, `"inference"`, `"portfolio"` | The deleted three-process split; callers pass `"fund"`, `"dashboard"`, `"tide-model-trainer"` |
| `observability.rs` | `init_tracing_file_only` protects a "dashboard TUI" and its "alternate screen buffer" | No TUI exists — no `ratatui`, no `crossterm`; the dashboard is an axum web server |
| `export.rs` | The trainer fetches its own data from Alpaca | It fetches from Massive |
| `seed_equity_bars.rs`, `devenv.nix` | The model needs seventy sessions | Forty — `window_frame` skips any ticker shorter than `input_length + output_length` |

The TUI one is the most striking: two docstrings justified a function's entire existence by a
terminal-rendering hazard no code in the repository can produce.

**What was deliberately kept.** Anything a reader cannot recover from the code: the drain-timeout
arithmetic in `bin/fund.rs`, why subscribing precedes the recovery scan, why both pair legs are
closed even after the first errors, the sargable-predicate reasoning in `eastern_day_bounds`, the
signed-versus-magnitude correlation argument in `screen.rs`, and the crossed-book midpoint hazard in
`EquityQuote::new`.

**Why `models/` now wraps a single `tide/`.** The previous layout implied a seam between "the
artifact system" and a particular model, and that seam does not exist. If a second model arrives,
`predict.rs` already shows where the real one is: `consolidate_data`, `filter_equity_bars`,
`validate_predictions`, `insert_predictions`, and `load_predictions_between` have no model in them,
while `filter_to_trained_tickers` and `generate_predictions` do. That is worth discovering with a
second model in hand rather than guessing at now.

**`ensure-test-services`.** It probed `pg_isready` with its defaults rather than the endpoint the
suite connects to. `tests/common/mod.rs` reads `TEST_DATABASE_URL_BASE`, so the probe now derives
host and port from the same value and names the endpoint it tried when it fails. A data directory
records its port in `postgresql.conf`, so a profile initialised while 5432 was busy keeps the
shifted port, and the old probe would loop for a minute against a port nothing was listening on
before reporting "did not start".

**`database:backup`.** The comment claimed a pg_cron job at 22:00 UTC that does not exist —
`schema.sql` schedules six jobs, none of them a backup — and pg_cron runs SQL inside the database,
so it cannot invoke `pg_dump` as written. This matters beyond the comment: only that dump can
restore `equity_pairs`, which nothing else reconstructs, so the sentence described a safety net that
was not there. The comment now says backups are manual and distinguishes them from the nightly
parquet export the market data sync does chain. Whether to schedule a real dump is left open.

## Verification

- `devenv tasks run checks:rust` passes — format, clippy `-D warnings`, unused dependencies, tests,
  coverage 80%+ against a 75% gate
- `devenv tasks run checks:base` passes, which matters because the `devenv.nix` change edits shell
  inside a Nix string
- `cargo sqlx prepare --check -- --all-features` passes; no cache drift, as no query text changed
- Both file moves are detected as renames by git, so the documentation diff stays readable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified database readiness checks, timeout diagnostics, backup procedures, and data-seeding requirements.
  * Refreshed guidance across market data, forecasting, portfolio execution, dashboard behavior, recovery, logging, and artifact handling.
  * Documented current data-provider coverage, training workflows, retention behavior, and prediction validation.
* **Refactor**
  * Reorganized forecasting model components under a dedicated module without changing runtime behavior.
  * Updated internal references to reflect the current model structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->