### PR TITLE
Spell out TiDE identifiers and fix the prediction horizon and stamping

### DIFF
--- a/.claude/skills/run-autotrain/SKILL.md
+++ b/.claude/skills/run-autotrain/SKILL.md
@@ -154,7 +154,7 @@ Priority order: architecture > hyperparameters > epoch depth > loss function > d
 ## Files Modified During Loop
 
 Primarily:
-- `src/models/tide/model.rs` (model architecture — TideModel, encoder/decoder layers)
+- `src/models/tide/model.rs` (model architecture — TiDEModel, encoder/decoder layers)
 - `src/models/tide/data.rs` (data processing — feature engineering, dataset construction)
 - `src/models/tide/config.rs` (ModelParameters — architecture hyperparameters)
 - `src/models/tide/train.rs` (TrainConfig — learning rate, epochs, batch size, early stopping)
@@ -163,7 +163,7 @@ Primarily:
 ## Key Files
 
 - **Entrypoint**: `src/bin/tide_model_trainer.rs` (loads data, trains, evaluates, uploads artifact)
-- **Model**: `src/models/tide/model.rs` (Burn TideModel with encoder/decoder)
+- **Model**: `src/models/tide/model.rs` (Burn TiDEModel with encoder/decoder)
 - **Config**: `src/models/tide/config.rs` (ModelParameters with Default impl)
 - **Training**: `src/models/tide/train.rs` (TrainConfig, train loop, early stopping)
 - **Data**: `src/models/tide/data.rs` (TrainingDataset, feature engineering)

--- a/.claude/skills/run-autotrain/SKILL.md
+++ b/.claude/skills/run-autotrain/SKILL.md
@@ -89,7 +89,7 @@ run **multiple experiments in parallel** using Bash background jobs.
 
    ```bash
    git worktree add /tmp/autotrain-variant-1 HEAD
-   # edit config.rs in /tmp/autotrain-variant-1, then:
+   # edit configuration.rs in /tmp/autotrain-variant-1, then:
    cd /tmp/autotrain-variant-1 && secretspec run -- cargo run --release --features train --bin tide_model_trainer
    ```
 
@@ -97,8 +97,8 @@ run **multiple experiments in parallel** using Bash background jobs.
 
 4. **Identify the best performer**.
 
-5. **Apply the winning config** to the `Default` impl in `src/models/tide/config.rs`
-   (for `ModelParameters`) or `src/models/tide/train.rs` (for `TrainConfig`)
+5. **Apply the winning config** to the `Default` impl in `src/models/tide/configuration.rs`
+   (for `ModelParameters`) or `src/models/tide/train.rs` (for `TrainConfiguration`)
    if it beat the previous best. Commit with description.
 
 6. **Log result** to `autotrain/<model-name>/experiments.jsonl` with fields:
@@ -156,16 +156,16 @@ Priority order: architecture > hyperparameters > epoch depth > loss function > d
 Primarily:
 - `src/models/tide/model.rs` (model architecture — TiDEModel, encoder/decoder layers)
 - `src/models/tide/data.rs` (data processing — feature engineering, dataset construction)
-- `src/models/tide/config.rs` (ModelParameters — architecture hyperparameters)
-- `src/models/tide/train.rs` (TrainConfig — learning rate, epochs, batch size, early stopping)
+- `src/models/tide/configuration.rs` (ModelParameters — architecture hyperparameters)
+- `src/models/tide/train.rs` (TrainConfiguration — learning rate, epochs, batch size, early stopping)
 - `src/models/tide/loss.rs` (loss function — quantile loss, huber delta)
 
 ## Key Files
 
 - **Entrypoint**: `src/bin/tide_model_trainer.rs` (loads data, trains, evaluates, uploads artifact)
 - **Model**: `src/models/tide/model.rs` (Burn TiDEModel with encoder/decoder)
-- **Config**: `src/models/tide/config.rs` (ModelParameters with Default impl)
-- **Training**: `src/models/tide/train.rs` (TrainConfig, train loop, early stopping)
+- **Config**: `src/models/tide/configuration.rs` (ModelParameters with Default impl)
+- **Training**: `src/models/tide/train.rs` (TrainConfiguration, train loop, early stopping)
 - **Data**: `src/models/tide/data.rs` (TrainingDataset, feature engineering)
 - **Loss**: `src/models/tide/loss.rs` (quantile loss with huber delta)
 - **Evaluation**: `src/models/tide/evaluate.rs` (CRPS, directional accuracy, quantile coverage)

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -39,7 +39,7 @@ use fund::models::tide::predict::consolidate_data;
 use fund::models::tide::train::{train, TrainBackend, TrainConfiguration};
 
 const INPUT_LENGTH: usize = 35;
-const OUTPUT_LENGTH: usize = 5;
+const OUTPUT_LENGTH: usize = 1;
 const VALIDATION_SPLIT: f64 = 0.8;
 
 /// S3 prefix for the trainer's own bar archive.

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -29,14 +29,14 @@ use fund::data::details;
 use fund::models::tide::artifact::{
     candidate_folders_descending, list_run_folders, package_dir_to_tar_gz, upload_artifact,
 };
-use fund::models::tide::config::ModelParameters;
+use fund::models::tide::configuration::ModelParameters;
 use fund::models::tide::data::input_feature_size;
 use fund::models::tide::drift::{check_drift, DriftStatus};
 use fund::models::tide::evaluate::evaluate;
 use fund::models::tide::fit::{filter_training_bars, fit, write_artifact_json};
-use fund::models::tide::model::TideModel;
+use fund::models::tide::model::TiDEModel;
 use fund::models::tide::predict::consolidate_data;
-use fund::models::tide::train::{train, TrainBackend, TrainConfig};
+use fund::models::tide::train::{train, TrainBackend, TrainConfiguration};
 
 const INPUT_LENGTH: usize = 35;
 const OUTPUT_LENGTH: usize = 5;
@@ -147,24 +147,24 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let parameters = ModelParameters::new(input_size, INPUT_LENGTH, OUTPUT_LENGTH);
 
     let device = <TrainBackend as Backend>::Device::default();
-    let model = TideModel::<TrainBackend>::new(
+    let model = TiDEModel::<TrainBackend>::new(
         &device,
         input_size,
         parameters.hidden_size(),
-        parameters.num_encoder_layers(),
-        parameters.num_decoder_layers(),
+        parameters.encoder_layer_count(),
+        parameters.decoder_layer_count(),
         parameters.output_length(),
         parameters.quantiles().len(),
         parameters.dropout_rate(),
     );
 
-    let config = training_config()?;
+    let configuration = training_configuration()?;
     let (best_model, losses) = train(
         model,
         &train_dataset,
         Some(&valid_dataset),
         &parameters,
-        &config,
+        &configuration,
         &device,
     );
     info!(
@@ -337,11 +337,11 @@ fn read_positive_env(variable: &str, default: i64) -> Result<i64, Box<dyn std::e
 /// Rebuilt through the validated constructor rather than by assigning a field, so an epoch count of
 /// zero is rejected here with a message rather than reaching the training loop, which would run no
 /// epochs and publish an untrained model that looks exactly like a trained one.
-fn training_config() -> Result<TrainConfig, Box<dyn std::error::Error>> {
-    let defaults = TrainConfig::default();
+fn training_configuration() -> Result<TrainConfiguration, Box<dyn std::error::Error>> {
+    let defaults = TrainConfiguration::default();
     let epoch_count = read_positive_env("FUND_EPOCHS", defaults.epoch_count() as i64)? as usize;
 
-    Ok(TrainConfig::new(
+    Ok(TrainConfiguration::new(
         defaults.learning_rate(),
         epoch_count,
         defaults.batch_size(),
@@ -654,21 +654,21 @@ mod tests {
         }
     }
 
-    /// The docstring on `training_config` claims a zero epoch count is rejected with a message.
+    /// The docstring on `training_configuration` claims a zero epoch count is rejected with a message.
     /// Nothing proved that until now — and an accepted zero would publish an untrained model that
     /// looks exactly like a trained one.
     #[test]
     #[serial]
     fn test_a_zero_epoch_count_is_rejected() {
         let _guard = EnvironmentVariableGuard::set("FUND_EPOCHS", "0");
-        assert!(training_config().is_err());
+        assert!(training_configuration().is_err());
     }
 
     #[test]
     #[serial]
     fn test_a_malformed_epoch_count_is_rejected() {
         let _guard = EnvironmentVariableGuard::set("FUND_EPOCHS", "twenty");
-        assert!(training_config().is_err());
+        assert!(training_configuration().is_err());
     }
 
     #[test]
@@ -676,8 +676,8 @@ mod tests {
     fn test_an_absent_epoch_count_keeps_the_default() {
         let _guard = EnvironmentVariableGuard::unset("FUND_EPOCHS");
         assert_eq!(
-            training_config().unwrap().epoch_count(),
-            TrainConfig::default().epoch_count()
+            training_configuration().unwrap().epoch_count(),
+            TrainConfiguration::default().epoch_count()
         );
     }
 

--- a/src/data/calendar.rs
+++ b/src/data/calendar.rs
@@ -61,7 +61,8 @@ pub fn eastern_day_bounds(date: NaiveDate) -> (DateTime<Utc>, DateTime<Utc>) {
     (start, end)
 }
 
-fn eastern_midnight(date: NaiveDate) -> DateTime<Utc> {
+/// Midnight Eastern on `date`, as the equivalent UTC instant.
+pub(crate) fn eastern_midnight(date: NaiveDate) -> DateTime<Utc> {
     let local_midnight = date
         .and_hms_opt(0, 0, 0)
         .expect("midnight is a valid wall-clock time");

--- a/src/models/tide.rs
+++ b/src/models/tide.rs
@@ -4,7 +4,7 @@
 
 pub mod artifact;
 pub mod batch;
-pub mod config;
+pub mod configuration;
 pub mod data;
 pub mod drift;
 pub mod evaluate;

--- a/src/models/tide/artifact.rs
+++ b/src/models/tide/artifact.rs
@@ -17,16 +17,16 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use tracing::{debug, info, warn};
 
-use crate::models::tide::config::ModelParameters;
+use crate::models::tide::configuration::ModelParameters;
 use crate::models::tide::data::{FeatureMappings, Scaler};
-use crate::models::tide::model::TideModel;
+use crate::models::tide::model::TiDEModel;
 
 // --------------------------------------------------------------------------
 // The loaded artifact
 // --------------------------------------------------------------------------
 
 pub struct ModelState {
-    model: TideModel<NdArray>,
+    model: TiDEModel<NdArray>,
     parameters: ModelParameters,
     scaler: Scaler,
     mappings: FeatureMappings,
@@ -45,7 +45,7 @@ impl ModelState {
     /// Constructs a `ModelState` from a fully loaded artifact.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        model: TideModel<NdArray>,
+        model: TiDEModel<NdArray>,
         parameters: ModelParameters,
         scaler: Scaler,
         mappings: FeatureMappings,
@@ -70,7 +70,7 @@ impl ModelState {
         }
     }
 
-    pub fn model(&self) -> &TideModel<NdArray> {
+    pub fn model(&self) -> &TiDEModel<NdArray> {
         &self.model
     }
 
@@ -111,7 +111,7 @@ impl ModelState {
     }
 }
 
-// SAFETY: TideModel<NdArray> is not Sync due to burn's Param<T> using an RwLock
+// SAFETY: TiDEModel<NdArray> is not Sync due to burn's Param<T> using an RwLock
 // with a non-Sync FnOnce inside. We guard all access behind a Mutex, so this is safe.
 unsafe impl Send for ModelState {}
 unsafe impl Sync for ModelState {}
@@ -373,7 +373,7 @@ fn extract_tar_gz(tar_path: &Path, dest: &Path) -> Result<(), ArtifactError> {
 
 fn load_model_from_directory(dir: &Path, artifact_key: &str) -> Result<ModelState, ArtifactError> {
     let parameters_path = dir.join("tide_parameters.json");
-    let parameters = crate::models::tide::config::ModelParameters::load(&parameters_path)
+    let parameters = crate::models::tide::configuration::ModelParameters::load(&parameters_path)
         .map_err(|e| ArtifactError::ModelLoad(e.to_string()))?;
 
     let scaler_path = dir.join("tide_data_scaler.json");
@@ -388,15 +388,15 @@ fn load_model_from_directory(dir: &Path, artifact_key: &str) -> Result<ModelStat
         serde_json::from_str(&mappings_content)
             .map_err(|e| ArtifactError::ModelLoad(e.to_string()))?;
 
-    let num_quantiles = parameters.quantiles().len();
-    let model = crate::models::tide::model::TideModel::load(
+    let quantile_count = parameters.quantiles().len();
+    let model = crate::models::tide::model::TiDEModel::load(
         dir,
         parameters.input_size(),
         parameters.hidden_size(),
-        parameters.num_encoder_layers(),
-        parameters.num_decoder_layers(),
+        parameters.encoder_layer_count(),
+        parameters.decoder_layer_count(),
         parameters.output_length(),
-        num_quantiles,
+        quantile_count,
         parameters.dropout_rate(),
     )
     .map_err(|e| ArtifactError::ModelLoad(e.to_string()))?;

--- a/src/models/tide/batch.rs
+++ b/src/models/tide/batch.rs
@@ -15,31 +15,33 @@ pub fn build_input_tensor<B: Backend>(
     output_length: usize,
     device: &B::Device,
 ) -> Tensor<B, 2> {
-    let n_cont = dataset.past_continuous.shape()[2];
-    let n_cat = dataset.past_categorical.shape()[2];
-    let n_static = dataset.static_categorical.shape()[2];
-    let input_size =
-        input_length * n_cont + input_length * n_cat + output_length * n_cat + n_static;
+    let continuous_feature_count = dataset.past_continuous.shape()[2];
+    let categorical_feature_count = dataset.past_categorical.shape()[2];
+    let static_feature_count = dataset.static_categorical.shape()[2];
+    let input_size = input_length * continuous_feature_count
+        + input_length * categorical_feature_count
+        + output_length * categorical_feature_count
+        + static_feature_count;
 
     let mut buffer = Vec::with_capacity(indices.len() * input_size);
     for &sample in indices {
-        for t in 0..input_length {
-            for f in 0..n_cont {
-                buffer.push(dataset.past_continuous[[sample, t, f]]);
+        for step in 0..input_length {
+            for feature in 0..continuous_feature_count {
+                buffer.push(dataset.past_continuous[[sample, step, feature]]);
             }
         }
-        for t in 0..input_length {
-            for f in 0..n_cat {
-                buffer.push(dataset.past_categorical[[sample, t, f]] as f32);
+        for step in 0..input_length {
+            for feature in 0..categorical_feature_count {
+                buffer.push(dataset.past_categorical[[sample, step, feature]] as f32);
             }
         }
-        for t in 0..output_length {
-            for f in 0..n_cat {
-                buffer.push(dataset.future_categorical[[sample, t, f]] as f32);
+        for step in 0..output_length {
+            for feature in 0..categorical_feature_count {
+                buffer.push(dataset.future_categorical[[sample, step, feature]] as f32);
             }
         }
-        for f in 0..n_static {
-            buffer.push(dataset.static_categorical[[sample, 0, f]] as f32);
+        for feature in 0..static_feature_count {
+            buffer.push(dataset.static_categorical[[sample, 0, feature]] as f32);
         }
     }
 
@@ -61,8 +63,8 @@ pub fn build_target_tensor<B: Backend>(
         .expect("targets are required to build a target tensor");
     let mut buffer = Vec::with_capacity(indices.len() * output_length);
     for &sample in indices {
-        for t in 0..output_length {
-            buffer.push(targets[[sample, t, 0]]);
+        for step in 0..output_length {
+            buffer.push(targets[[sample, step, 0]]);
         }
     }
     Tensor::<B, 1>::from_floats(buffer.as_slice(), device).reshape([indices.len(), output_length])

--- a/src/models/tide/configuration.rs
+++ b/src/models/tide/configuration.rs
@@ -25,7 +25,7 @@ impl Default for ModelParameters {
             hidden_size: 64,
             encoder_layer_count: 3,
             decoder_layer_count: 2,
-            output_length: 5,
+            output_length: 1,
             input_length: 35,
             dropout_rate: 0.1,
             quantiles: vec![0.1, 0.5, 0.9],
@@ -125,17 +125,17 @@ mod tests {
     fn test_default_parameters() {
         let params = ModelParameters::default();
         assert_eq!(params.hidden_size(), 64);
-        assert_eq!(params.output_length(), 5);
+        assert_eq!(params.output_length(), 1);
         assert_eq!(params.input_length(), 35);
         assert_eq!(params.quantiles(), [0.1, 0.5, 0.9]);
     }
 
     #[test]
     fn test_new_applies_defaults_for_architecture() {
-        let params = ModelParameters::new(448, 35, 5);
-        assert_eq!(params.input_size(), 448);
+        let params = ModelParameters::new(428, 35, 1);
+        assert_eq!(params.input_size(), 428);
         assert_eq!(params.input_length(), 35);
-        assert_eq!(params.output_length(), 5);
+        assert_eq!(params.output_length(), 1);
         assert_eq!(params.hidden_size(), 64);
         assert_eq!(params.encoder_layer_count(), 3);
         assert_eq!(params.decoder_layer_count(), 2);

--- a/src/models/tide/configuration.rs
+++ b/src/models/tide/configuration.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 pub struct ModelParameters {
     input_size: usize,
     hidden_size: usize,
-    num_encoder_layers: usize,
-    num_decoder_layers: usize,
+    encoder_layer_count: usize,
+    decoder_layer_count: usize,
     output_length: usize,
     input_length: usize,
     dropout_rate: f64,
@@ -23,8 +23,8 @@ impl Default for ModelParameters {
         Self {
             input_size: 0,
             hidden_size: 64,
-            num_encoder_layers: 3,
-            num_decoder_layers: 2,
+            encoder_layer_count: 3,
+            decoder_layer_count: 2,
             output_length: 5,
             input_length: 35,
             dropout_rate: 0.1,
@@ -53,8 +53,8 @@ impl ModelParameters {
     pub fn for_tests(
         input_size: usize,
         hidden_size: usize,
-        num_encoder_layers: usize,
-        num_decoder_layers: usize,
+        encoder_layer_count: usize,
+        decoder_layer_count: usize,
         output_length: usize,
         input_length: usize,
         dropout_rate: f64,
@@ -64,8 +64,8 @@ impl ModelParameters {
         Self {
             input_size,
             hidden_size,
-            num_encoder_layers,
-            num_decoder_layers,
+            encoder_layer_count,
+            decoder_layer_count,
             output_length,
             input_length,
             dropout_rate,
@@ -88,12 +88,12 @@ impl ModelParameters {
         self.hidden_size
     }
 
-    pub fn num_encoder_layers(&self) -> usize {
-        self.num_encoder_layers
+    pub fn encoder_layer_count(&self) -> usize {
+        self.encoder_layer_count
     }
 
-    pub fn num_decoder_layers(&self) -> usize {
-        self.num_decoder_layers
+    pub fn decoder_layer_count(&self) -> usize {
+        self.decoder_layer_count
     }
 
     pub fn output_length(&self) -> usize {
@@ -137,8 +137,8 @@ mod tests {
         assert_eq!(params.input_length(), 35);
         assert_eq!(params.output_length(), 5);
         assert_eq!(params.hidden_size(), 64);
-        assert_eq!(params.num_encoder_layers(), 3);
-        assert_eq!(params.num_decoder_layers(), 2);
+        assert_eq!(params.encoder_layer_count(), 3);
+        assert_eq!(params.decoder_layer_count(), 2);
         assert_eq!(params.dropout_rate(), 0.1);
         assert_eq!(params.quantiles(), [0.1, 0.5, 0.9]);
         assert_eq!(params.huber_delta(), 0.5);
@@ -149,8 +149,8 @@ mod tests {
         let json = r#"{
             "input_size": 100,
             "hidden_size": 64,
-            "num_encoder_layers": 3,
-            "num_decoder_layers": 2,
+            "encoder_layer_count": 3,
+            "decoder_layer_count": 2,
             "output_length": 5,
             "input_length": 35,
             "dropout_rate": 0.1,

--- a/src/models/tide/configuration.rs
+++ b/src/models/tide/configuration.rs
@@ -74,9 +74,23 @@ impl ModelParameters {
         }
     }
 
+    /// Reads parameters from a training artifact, rejecting window lengths of zero.
+    ///
+    /// A zero `output_length` produces no horizon steps, so inference returns an empty set and a
+    /// corrupt artifact is indistinguishable from a session with nothing to forecast. Refusing it
+    /// here keeps the failure at the boundary where the untrusted file is read.
     pub fn load(path: &std::path::Path) -> Result<Self, Box<dyn std::error::Error>> {
         let content = std::fs::read_to_string(path)?;
         let params: Self = serde_json::from_str(&content)?;
+        if params.output_length == 0 || params.input_length == 0 {
+            return Err(format!(
+                "Model parameters at {} have a zero window length (input_length {}, output_length {})",
+                path.display(),
+                params.input_length,
+                params.output_length
+            )
+            .into());
+        }
         Ok(params)
     }
 
@@ -160,5 +174,30 @@ mod tests {
         let params: ModelParameters = serde_json::from_str(json).unwrap();
         assert_eq!(params.input_size(), 100);
         assert_eq!(params.hidden_size(), 64);
+    }
+
+    #[test]
+    fn test_load_rejects_a_zero_window_length() {
+        // A zero output_length yields no horizon steps, so inference would return an empty set and
+        // the corrupt artifact would read as a session with nothing to forecast.
+        let directory = tempfile::tempdir().unwrap();
+        let write = |name: &str, output_length: usize, input_length: usize| {
+            let path = directory.path().join(name);
+            std::fs::write(
+                &path,
+                format!(
+                    r#"{{"input_size": 100, "hidden_size": 64, "encoder_layer_count": 3,
+                         "decoder_layer_count": 2, "output_length": {output_length},
+                         "input_length": {input_length}, "dropout_rate": 0.1,
+                         "quantiles": [0.1, 0.5, 0.9], "huber_delta": 0.5}}"#
+                ),
+            )
+            .unwrap();
+            path
+        };
+
+        assert!(ModelParameters::load(&write("zero_output.json", 0, 35)).is_err());
+        assert!(ModelParameters::load(&write("zero_input.json", 1, 0)).is_err());
+        assert!(ModelParameters::load(&write("valid.json", 1, 35)).is_ok());
     }
 }

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -9,6 +9,8 @@ use chrono::Datelike;
 use polars::prelude::*;
 use serde::{Deserialize, Serialize};
 
+use crate::data::details::UNKNOWN as UNKNOWN_SECTOR_OR_INDUSTRY;
+
 pub type CategoryMapping = HashMap<String, i32>;
 pub type FeatureMappings = HashMap<String, CategoryMapping>;
 
@@ -131,12 +133,14 @@ pub(crate) const CATEGORICAL_COLUMNS: &[&str] = &[
 
 pub(crate) const STATIC_CATEGORICAL_COLUMNS: &[&str] = &["ticker", "sector", "industry"];
 
-/// Placeholder for a null categorical value.
+/// Placeholder written into `ticker` when the source value is null, then matched by the filter in
+/// [`clean_data`] to drop the row.
 ///
-/// `into_no_null_iter` silently *skips* nulls, so a null `sector` or `industry` yields a column
-/// shorter than the frame, shifting every later row onto the wrong ticker. The sentinel preserves
-/// alignment.
-pub(crate) const UNKNOWN_CATEGORY: &str = "UNKNOWN";
+/// `into_no_null_iter` silently *skips* nulls, so a null yields a column shorter than the frame,
+/// shifting every later row onto the wrong ticker. The sentinel preserves alignment until the row
+/// can be removed. Sector and industry instead fall back to [`UNKNOWN_SECTOR_OR_INDUSTRY`], which
+/// is a category the model keeps rather than a row it discards.
+pub(crate) const MISSING_TICKER: &str = "UNKNOWN";
 
 /// The model target is the future window of `daily_return`, which is the last
 /// continuous column. Fitting and windowing index into this position.
@@ -198,9 +202,10 @@ impl Data {
     ) -> Result<(DataFrame, DataFrame), Box<dyn std::error::Error>> {
         let timestamps = self.data.column("timestamp").map_err(|e| e.to_string())?;
         let timestamps = timestamps.i64().map_err(|e| e.to_string())?;
-        let min_ts = timestamps.min().unwrap_or(0);
-        let max_ts = timestamps.max().unwrap_or(0);
-        let cutoff = min_ts + (((max_ts - min_ts) as f64) * validation_split) as i64;
+        let minimum_timestamp = timestamps.min().unwrap_or(0);
+        let maximum_timestamp = timestamps.max().unwrap_or(0);
+        let cutoff = minimum_timestamp
+            + (((maximum_timestamp - minimum_timestamp) as f64) * validation_split) as i64;
 
         let train_mask = timestamps.lt_eq(cutoff);
         let valid_mask = timestamps.gt(cutoff);
@@ -247,12 +252,12 @@ fn window_frame(
     with_targets: bool,
 ) -> Result<TrainingDataset, Box<dyn std::error::Error>> {
     let window_size = input_length + output_length;
-    let n_cont = CONTINUOUS_COLUMNS.len();
-    let n_cat = CATEGORICAL_COLUMNS.len();
-    let n_static = STATIC_CATEGORICAL_COLUMNS.len();
+    let continuous_feature_count = CONTINUOUS_COLUMNS.len();
+    let categorical_feature_count = CATEGORICAL_COLUMNS.len();
+    let static_feature_count = STATIC_CATEGORICAL_COLUMNS.len();
     let target_index = CONTINUOUS_COLUMNS
         .iter()
-        .position(|c| *c == TARGET_COLUMN)
+        .position(|column| *column == TARGET_COLUMN)
         .expect("daily_return must be a continuous column");
 
     // `ticker` is integer-encoded by this point (encode_categoricals). Group by
@@ -268,10 +273,10 @@ fn window_frame(
         .collect();
     tickers.sort_unstable();
 
-    let mut all_past_cont: Vec<Vec<f32>> = Vec::new();
-    let mut all_past_cat: Vec<Vec<i32>> = Vec::new();
-    let mut all_future_cat: Vec<Vec<i32>> = Vec::new();
-    let mut all_static_cat: Vec<Vec<i32>> = Vec::new();
+    let mut all_past_continuous: Vec<Vec<f32>> = Vec::new();
+    let mut all_past_categorical: Vec<Vec<i32>> = Vec::new();
+    let mut all_future_categorical: Vec<Vec<i32>> = Vec::new();
+    let mut all_static_categorical: Vec<Vec<i32>> = Vec::new();
     let mut all_targets: Vec<Vec<f32>> = Vec::new();
 
     for ticker in &tickers {
@@ -287,9 +292,9 @@ fn window_frame(
             continue;
         }
 
-        let cont_arrays = get_float_columns(&ticker_data, CONTINUOUS_COLUMNS)?;
-        let cat_arrays = get_int_columns(&ticker_data, CATEGORICAL_COLUMNS)?;
-        let static_arrays = get_int_columns(&ticker_data, STATIC_CATEGORICAL_COLUMNS)?;
+        let continuous_column_values = get_float_columns(&ticker_data, CONTINUOUS_COLUMNS)?;
+        let categorical_column_values = get_int_columns(&ticker_data, CATEGORICAL_COLUMNS)?;
+        let static_column_values = get_int_columns(&ticker_data, STATIC_CATEGORICAL_COLUMNS)?;
 
         let windows: Vec<usize> = if predict_mode {
             vec![ticker_data.height() - window_size]
@@ -298,79 +303,91 @@ fn window_frame(
         };
 
         for start in windows {
-            let mut past_cont = Vec::with_capacity(input_length * n_cont);
-            for t in start..start + input_length {
-                for col in &cont_arrays {
-                    past_cont.push(col[t]);
+            let mut past_continuous_window =
+                Vec::with_capacity(input_length * continuous_feature_count);
+            for row in start..start + input_length {
+                for column in &continuous_column_values {
+                    past_continuous_window.push(column[row]);
                 }
             }
 
-            let mut past_cat = Vec::with_capacity(input_length * n_cat);
-            for t in start..start + input_length {
-                for col in &cat_arrays {
-                    past_cat.push(col[t]);
+            let mut past_categorical_window =
+                Vec::with_capacity(input_length * categorical_feature_count);
+            for row in start..start + input_length {
+                for column in &categorical_column_values {
+                    past_categorical_window.push(column[row]);
                 }
             }
 
-            let mut future_cat = Vec::with_capacity(output_length * n_cat);
-            for t in (start + input_length)..(start + input_length + output_length) {
-                for col in &cat_arrays {
-                    future_cat.push(col[t]);
+            let mut future_categorical_window =
+                Vec::with_capacity(output_length * categorical_feature_count);
+            for row in (start + input_length)..(start + input_length + output_length) {
+                for column in &categorical_column_values {
+                    future_categorical_window.push(column[row]);
                 }
             }
 
-            let mut static_cat = Vec::with_capacity(n_static);
-            for col in &static_arrays {
-                static_cat.push(col[start]);
+            let mut static_categorical_window = Vec::with_capacity(static_feature_count);
+            for column in &static_column_values {
+                static_categorical_window.push(column[start]);
             }
 
-            all_past_cont.push(past_cont);
-            all_past_cat.push(past_cat);
-            all_future_cat.push(future_cat);
-            all_static_cat.push(static_cat);
+            all_past_continuous.push(past_continuous_window);
+            all_past_categorical.push(past_categorical_window);
+            all_future_categorical.push(future_categorical_window);
+            all_static_categorical.push(static_categorical_window);
 
             if with_targets {
-                let returns = &cont_arrays[target_index];
+                let returns = &continuous_column_values[target_index];
                 let future = (start + input_length)..(start + input_length + output_length);
                 all_targets.push(returns[future].to_vec());
             }
         }
     }
 
-    let num_samples = all_past_cont.len();
+    let sample_count = all_past_continuous.len();
 
-    let past_continuous = if num_samples > 0 {
-        let flat: Vec<f32> = all_past_cont.into_iter().flatten().collect();
-        ndarray::Array3::from_shape_vec((num_samples, input_length, n_cont), flat)?
+    let past_continuous = if sample_count > 0 {
+        let flat: Vec<f32> = all_past_continuous.into_iter().flatten().collect();
+        ndarray::Array3::from_shape_vec(
+            (sample_count, input_length, continuous_feature_count),
+            flat,
+        )?
     } else {
-        ndarray::Array3::zeros((0, input_length, n_cont))
+        ndarray::Array3::zeros((0, input_length, continuous_feature_count))
     };
 
-    let past_categorical = if num_samples > 0 {
-        let flat: Vec<i32> = all_past_cat.into_iter().flatten().collect();
-        ndarray::Array3::from_shape_vec((num_samples, input_length, n_cat), flat)?
+    let past_categorical = if sample_count > 0 {
+        let flat: Vec<i32> = all_past_categorical.into_iter().flatten().collect();
+        ndarray::Array3::from_shape_vec(
+            (sample_count, input_length, categorical_feature_count),
+            flat,
+        )?
     } else {
-        ndarray::Array3::zeros((0, input_length, n_cat))
+        ndarray::Array3::zeros((0, input_length, categorical_feature_count))
     };
 
-    let future_categorical = if num_samples > 0 {
-        let flat: Vec<i32> = all_future_cat.into_iter().flatten().collect();
-        ndarray::Array3::from_shape_vec((num_samples, output_length, n_cat), flat)?
+    let future_categorical = if sample_count > 0 {
+        let flat: Vec<i32> = all_future_categorical.into_iter().flatten().collect();
+        ndarray::Array3::from_shape_vec(
+            (sample_count, output_length, categorical_feature_count),
+            flat,
+        )?
     } else {
-        ndarray::Array3::zeros((0, output_length, n_cat))
+        ndarray::Array3::zeros((0, output_length, categorical_feature_count))
     };
 
-    let static_categorical = if num_samples > 0 {
-        let flat: Vec<i32> = all_static_cat.into_iter().flatten().collect();
-        ndarray::Array3::from_shape_vec((num_samples, 1, n_static), flat)?
+    let static_categorical = if sample_count > 0 {
+        let flat: Vec<i32> = all_static_categorical.into_iter().flatten().collect();
+        ndarray::Array3::from_shape_vec((sample_count, 1, static_feature_count), flat)?
     } else {
-        ndarray::Array3::zeros((0, 1, n_static))
+        ndarray::Array3::zeros((0, 1, static_feature_count))
     };
 
-    let targets = if with_targets && num_samples > 0 {
+    let targets = if with_targets && sample_count > 0 {
         let flat: Vec<f32> = all_targets.into_iter().flatten().collect();
         Some(ndarray::Array3::from_shape_vec(
-            (num_samples, output_length, 1),
+            (sample_count, output_length, 1),
             flat,
         )?)
     } else if with_targets {
@@ -497,7 +514,7 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
         .str()
         .map_err(|e| e.to_string())?
         .into_iter()
-        .map(|value| value.unwrap_or(UNKNOWN_CATEGORY).to_uppercase())
+        .map(|value| value.unwrap_or(MISSING_TICKER).to_uppercase())
         .collect();
 
     let sector_upper: Vec<String> = data
@@ -506,7 +523,7 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
         .str()
         .map_err(|e| e.to_string())?
         .into_iter()
-        .map(|value| value.unwrap_or(UNKNOWN_CATEGORY).to_uppercase())
+        .map(|value| value.unwrap_or(UNKNOWN_SECTOR_OR_INDUSTRY).to_uppercase())
         .collect();
 
     let industry_upper: Vec<String> = data
@@ -515,7 +532,7 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
         .str()
         .map_err(|e| e.to_string())?
         .into_iter()
-        .map(|value| value.unwrap_or(UNKNOWN_CATEGORY).to_uppercase())
+        .map(|value| value.unwrap_or(UNKNOWN_SECTOR_OR_INDUSTRY).to_uppercase())
         .collect();
 
     data.with_column(Column::new("ticker".into(), ticker_upper))
@@ -525,13 +542,13 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
     data.with_column(Column::new("industry".into(), industry_upper))
         .map_err(|e| e.to_string())?;
 
-    // Filter out UNKNOWN tickers
+    // Drop the rows whose ticker was null.
     let mask = data
         .column("ticker")
         .map_err(|e| e.to_string())?
         .str()
         .map_err(|e| e.to_string())?
-        .not_equal(UNKNOWN_CATEGORY);
+        .not_equal(MISSING_TICKER);
 
     let cleaned = data.filter(&mask).map_err(|e| e.to_string())?;
 
@@ -563,17 +580,17 @@ pub(crate) fn apply_scaling(
     scaler: &Scaler,
 ) -> Result<DataFrame, Box<dyn std::error::Error>> {
     let mut result = data;
-    for col_name in CONTINUOUS_COLUMNS {
-        let mean = scaler.means.get(*col_name).copied().unwrap_or(0.0);
+    for column_name in CONTINUOUS_COLUMNS {
+        let mean = scaler.means.get(*column_name).copied().unwrap_or(0.0);
         let std = scaler
             .standard_deviations
-            .get(*col_name)
+            .get(*column_name)
             .copied()
             .unwrap_or(1.0);
         let std = if std == 0.0 { 1e-8 } else { std };
 
         let values: Vec<f32> = result
-            .column(col_name)
+            .column(column_name)
             .map_err(|e| e.to_string())?
             .cast(&DataType::Float64)
             .map_err(|e| e.to_string())?
@@ -584,7 +601,7 @@ pub(crate) fn apply_scaling(
             .collect();
 
         result
-            .with_column(Column::new((*col_name).into(), values))
+            .with_column(Column::new((*column_name).into(), values))
             .map_err(|e| e.to_string())?;
     }
     Ok(result)
@@ -602,10 +619,10 @@ pub(crate) fn encode_categoricals(
         .copied()
         .collect();
 
-    for col_name in all_categorical {
-        if let Some(mapping) = mappings.get(col_name) {
+    for column_name in all_categorical {
+        if let Some(mapping) = mappings.get(column_name) {
             let values: Vec<Option<i32>> = result
-                .column(col_name)
+                .column(column_name)
                 .map_err(|e| e.to_string())?
                 .str()
                 .map(|ca| {
@@ -615,7 +632,7 @@ pub(crate) fn encode_categoricals(
                 })
                 .or_else(|_| {
                     result
-                        .column(col_name)
+                        .column(column_name)
                         .map_err(|e| e.to_string())?
                         .i32()
                         .map(|ca| ca.into_iter().collect())
@@ -632,18 +649,18 @@ pub(crate) fn encode_categoricals(
             // `filter_to_trained_tickers` removes unmapped tickers before this on the prediction
             // path, but that guard lives in another module and nothing enforces the ordering, so
             // the invariant is also enforced here where it is relied upon.
-            let is_static = STATIC_CATEGORICAL_COLUMNS.contains(&col_name);
+            let is_static = STATIC_CATEGORICAL_COLUMNS.contains(&column_name);
             let unmapped = values.iter().filter(|value| value.is_none()).count();
             let keep: BooleanChunked = values.iter().map(|value| value.is_some()).collect();
             let encoded: Vec<i32> = values.into_iter().map(|v| v.unwrap_or(-1)).collect();
             result
-                .with_column(Column::new(col_name.into(), encoded))
+                .with_column(Column::new(column_name.into(), encoded))
                 .map_err(|e| e.to_string())?;
 
             if is_static && unmapped > 0 {
                 result = result.filter(&keep).map_err(|e| e.to_string())?;
                 tracing::warn!(
-                    column = col_name,
+                    column = column_name,
                     dropped_rows = unmapped,
                     "Dropped rows whose static categorical value is absent from the training mapping"
                 );
@@ -659,9 +676,9 @@ fn get_float_columns(
     columns: &[&str],
 ) -> Result<Vec<Vec<f32>>, Box<dyn std::error::Error>> {
     let mut result = Vec::new();
-    for col_name in columns {
+    for column_name in columns {
         let values: Vec<f32> = data
-            .column(col_name)
+            .column(column_name)
             .map_err(|e| e.to_string())?
             .cast(&DataType::Float32)
             .map_err(|e| e.to_string())?
@@ -679,9 +696,9 @@ fn get_int_columns(
     columns: &[&str],
 ) -> Result<Vec<Vec<i32>>, Box<dyn std::error::Error>> {
     let mut result = Vec::new();
-    for col_name in columns {
+    for column_name in columns {
         let values: Vec<i32> = data
-            .column(col_name)
+            .column(column_name)
             .map_err(|e| e.to_string())?
             .cast(&DataType::Int32)
             .map_err(|e| e.to_string())?
@@ -733,39 +750,39 @@ mod tests {
 
     /// Build a minimal, already engineered/scaled/encoded frame (ticker and the
     /// categorical columns are integer-encoded) for windowing tests.
-    fn make_encoded_frame(num_tickers: i32, rows_per_ticker: usize) -> DataFrame {
-        let total = num_tickers as usize * rows_per_ticker;
+    fn make_encoded_frame(ticker_count: i32, rows_per_ticker: usize) -> DataFrame {
+        let total = ticker_count as usize * rows_per_ticker;
         let mut ticker = Vec::with_capacity(total);
         let mut timestamp = Vec::with_capacity(total);
         let mut close = Vec::with_capacity(total);
         let mut daily_return = Vec::with_capacity(total);
-        for t in 0..num_tickers {
-            for r in 0..rows_per_ticker {
-                ticker.push(t);
-                timestamp.push((r as i64) * 86_400_000);
-                close.push(100.0_f64 + r as f64);
-                daily_return.push(0.01_f32 * (r as f32 + t as f32));
+        for ticker_id in 0..ticker_count {
+            for row in 0..rows_per_ticker {
+                ticker.push(ticker_id);
+                timestamp.push((row as i64) * 86_400_000);
+                close.push(100.0_f64 + row as f64);
+                daily_return.push(0.01_f32 * (row as f32 + ticker_id as f32));
             }
         }
-        let ones_f = vec![1.0_f64; total];
-        let ones_i = vec![1_i32; total];
+        let ones_float = vec![1.0_f64; total];
+        let ones_int = vec![1_i32; total];
         DataFrame::new(vec![
             Column::new("ticker".into(), ticker),
             Column::new("timestamp".into(), timestamp),
-            Column::new("open_price".into(), ones_f.clone()),
-            Column::new("high_price".into(), ones_f.clone()),
-            Column::new("low_price".into(), ones_f.clone()),
+            Column::new("open_price".into(), ones_float.clone()),
+            Column::new("high_price".into(), ones_float.clone()),
+            Column::new("low_price".into(), ones_float.clone()),
             Column::new("close_price".into(), close),
-            Column::new("volume".into(), ones_f.clone()),
-            Column::new("volume_weighted_average_price".into(), ones_f),
+            Column::new("volume".into(), ones_float.clone()),
+            Column::new("volume_weighted_average_price".into(), ones_float),
             Column::new("daily_return".into(), daily_return),
-            Column::new("day_of_week".into(), ones_i.clone()),
-            Column::new("day_of_month".into(), ones_i.clone()),
-            Column::new("day_of_year".into(), ones_i.clone()),
-            Column::new("month".into(), ones_i.clone()),
-            Column::new("year".into(), ones_i.clone()),
-            Column::new("sector".into(), ones_i.clone()),
-            Column::new("industry".into(), ones_i),
+            Column::new("day_of_week".into(), ones_int.clone()),
+            Column::new("day_of_month".into(), ones_int.clone()),
+            Column::new("day_of_year".into(), ones_int.clone()),
+            Column::new("month".into(), ones_int.clone()),
+            Column::new("year".into(), ones_int.clone()),
+            Column::new("sector".into(), ones_int.clone()),
+            Column::new("industry".into(), ones_int),
         ])
         .unwrap()
     }
@@ -866,6 +883,43 @@ mod tests {
             .into_no_null_iter()
             .collect();
         assert!(returns.iter().all(|r| (r - 0.1).abs() < 1e-6));
+    }
+
+    #[test]
+    fn test_clean_data_fills_null_sector_with_the_stored_default() {
+        // A null sector or industry must land on the same value the database writes by default,
+        // or the concept splits into two categories: rows loaded from `equity_details` encode as
+        // "NOT AVAILABLE" while any null-bearing frame encodes as something else. Because these
+        // are static columns, `encode_categoricals` drops rows whose value is absent from the
+        // training mapping rather than folding them into a fallback, so the split is silent.
+        let mut engineered = engineer_features(raw_two_ticker_frame()).unwrap();
+        engineered
+            .with_column(Column::new(
+                "sector".into(),
+                vec![None::<&str>, None, None, None],
+            ))
+            .unwrap();
+        engineered
+            .with_column(Column::new(
+                "industry".into(),
+                vec![None::<&str>, None, None, None],
+            ))
+            .unwrap();
+
+        let cleaned = clean_data(engineered).unwrap();
+        for column in ["sector", "industry"] {
+            let values: Vec<&str> = cleaned
+                .column(column)
+                .unwrap()
+                .str()
+                .unwrap()
+                .into_no_null_iter()
+                .collect();
+            assert!(
+                values.iter().all(|v| *v == crate::data::details::UNKNOWN),
+                "{column} fell back to {values:?} instead of the schema default"
+            );
+        }
     }
 
     #[test]

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -133,15 +133,6 @@ pub(crate) const CATEGORICAL_COLUMNS: &[&str] = &[
 
 pub(crate) const STATIC_CATEGORICAL_COLUMNS: &[&str] = &["ticker", "sector", "industry"];
 
-/// Placeholder written into `ticker` when the source value is null, then matched by the filter in
-/// [`clean_data`] to drop the row.
-///
-/// `into_no_null_iter` silently *skips* nulls, so a null yields a column shorter than the frame,
-/// shifting every later row onto the wrong ticker. The sentinel preserves alignment until the row
-/// can be removed. Sector and industry instead fall back to [`UNKNOWN_SECTOR_OR_INDUSTRY`], which
-/// is a category the model keeps rather than a row it discards.
-pub(crate) const MISSING_TICKER: &str = "UNKNOWN";
-
 /// The model target is the future window of `daily_return`, which is the last
 /// continuous column. Fitting and windowing index into this position.
 pub(crate) const TARGET_COLUMN: &str = "daily_return";
@@ -181,11 +172,18 @@ impl Data {
         }
     }
 
+    /// Inference-only preparation: the training path fits its own scaler and mappings instead.
+    ///
+    /// `target_session` is the session being forecast. It exists because inference has no bar for
+    /// that session yet — see [`append_forecast_session_rows`] — and it must be the same session the
+    /// caller stamps the output with, or the features and the label describe different days.
     pub fn apply_existing_scaler(
         data: DataFrame,
         scaler: &Scaler,
         mappings: &FeatureMappings,
+        target_session: chrono::NaiveDate,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        let data = append_forecast_session_rows(data, target_session)?;
         let data = engineer_features(data)?;
         let data = clean_data(data)?;
         let data = apply_scaling(data, scaler)?;
@@ -405,6 +403,89 @@ fn window_frame(
     })
 }
 
+/// Append one row per ticker carrying `target_session`, so the windowing has a future step to spend
+/// that is not a real bar.
+///
+/// [`window_frame`] splits one contiguous block of `input_length + output_length` rows into a past
+/// and a future half. Without this the newest bar is spent as the future calendar step, which both
+/// feeds the model the wrong session's calendar and pushes the most recent close out of the past
+/// window — so a pre-open run forecasts the session that already closed.
+///
+/// The appended row is the ticker's own last bar with `timestamp` moved to the target session.
+/// Copying it rather than inventing values means `close_price` equals the previous close, so the
+/// engineered `daily_return` is `0.0` and survives [`clean_data`]'s non-finite filter, and sector
+/// and industry carry over. None of those prices reach the model: the future half consumes only
+/// [`CATEGORICAL_COLUMNS`], and the extra row shifts the window so the past half lands on real bars.
+/// Calendar fields are left to [`engineer_features`] so only one place derives them.
+///
+/// Tickers already holding a bar at or after the target session are skipped, so a late run cannot
+/// duplicate a real row.
+pub(crate) fn append_forecast_session_rows(
+    data: DataFrame,
+    target_session: chrono::NaiveDate,
+) -> Result<DataFrame, Box<dyn std::error::Error>> {
+    let target_milliseconds =
+        crate::data::calendar::eastern_midnight(target_session).timestamp_millis();
+
+    let sorted = data
+        .sort(
+            ["ticker", "timestamp"],
+            SortMultipleOptions::default().with_maintain_order(true),
+        )
+        .map_err(|e| e.to_string())?;
+
+    let tickers: Vec<&str> = sorted
+        .column("ticker")
+        .map_err(|e| e.to_string())?
+        .str()
+        .map_err(|e| e.to_string())?
+        .into_no_null_iter()
+        .collect();
+    let timestamps: Vec<i64> = sorted
+        .column("timestamp")
+        .map_err(|e| e.to_string())?
+        .i64()
+        .map_err(|e| e.to_string())?
+        .into_no_null_iter()
+        .collect();
+
+    if tickers.len() != sorted.height() || timestamps.len() != sorted.height() {
+        return Err("Equity bars contain null ticker or timestamp values"
+            .to_string()
+            .into());
+    }
+
+    // Rows are sorted, so a ticker's last row is also its newest. Comparing that against the target
+    // both finds the row to copy and skips any ticker already carrying the target session.
+    let mut source_rows: Vec<polars::prelude::IdxSize> = Vec::new();
+    for index in 0..sorted.height() {
+        let is_last_for_ticker =
+            index + 1 == sorted.height() || tickers[index + 1] != tickers[index];
+        if is_last_for_ticker && timestamps[index] < target_milliseconds {
+            source_rows.push(index as polars::prelude::IdxSize);
+        }
+    }
+
+    if source_rows.is_empty() {
+        return Ok(sorted);
+    }
+
+    let source_index = IdxCa::from_vec("index".into(), source_rows);
+    let mut forecast_rows = sorted.take(&source_index).map_err(|e| e.to_string())?;
+    forecast_rows
+        .with_column(Column::new(
+            "timestamp".into(),
+            vec![target_milliseconds; forecast_rows.height()],
+        ))
+        .map_err(|e| e.to_string())?;
+
+    let mut combined = sorted;
+    combined
+        .vstack_mut(&forecast_rows)
+        .map_err(|e| e.to_string())?;
+    Ok(combined)
+}
+
 pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn std::error::Error>> {
     // Sort by [ticker, timestamp] so daily returns and the downstream windowing
     // are chronological and contiguous within each ticker, independent of the
@@ -507,14 +588,27 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn st
 }
 
 pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::error::Error>> {
-    // Uppercase ticker, sector, industry columns in-place
-    let ticker_upper: Vec<String> = data
+    // A row with no ticker cannot be attributed to an instrument, and substituting a placeholder
+    // would make it indistinguishable from a real symbol of the same spelling. Reject it the way
+    // `engineer_features` does rather than encoding one and filtering it back out.
+    let tickers = data
         .column("ticker")
         .map_err(|e| e.to_string())?
         .str()
-        .map_err(|e| e.to_string())?
-        .into_iter()
-        .map(|value| value.unwrap_or(MISSING_TICKER).to_uppercase())
+        .map_err(|e| e.to_string())?;
+    if tickers.null_count() > 0 {
+        return Err(format!(
+            "Equity bars contain {} null ticker values out of {} rows",
+            tickers.null_count(),
+            data.height()
+        )
+        .into());
+    }
+
+    // Uppercase ticker, sector, industry columns in-place
+    let ticker_upper: Vec<String> = tickers
+        .into_no_null_iter()
+        .map(|value| value.to_uppercase())
         .collect();
 
     let sector_upper: Vec<String> = data
@@ -542,15 +636,7 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
     data.with_column(Column::new("industry".into(), industry_upper))
         .map_err(|e| e.to_string())?;
 
-    // Drop the rows whose ticker was null.
-    let mask = data
-        .column("ticker")
-        .map_err(|e| e.to_string())?
-        .str()
-        .map_err(|e| e.to_string())?
-        .not_equal(MISSING_TICKER);
-
-    let cleaned = data.filter(&mask).map_err(|e| e.to_string())?;
+    let cleaned = data;
 
     // Drop rows with a null or non-finite value in any continuous column —
     // each ticker's first observation (null return), missing vendor fields
@@ -920,6 +1006,257 @@ mod tests {
                 "{column} fell back to {values:?} instead of the schema default"
             );
         }
+    }
+
+    /// Raw (pre-engineering) frame with string tickers and one bar per consecutive day.
+    ///
+    /// `close_price` is `100 + row`, so a window's contents identify which rows produced them.
+    fn raw_frame(ticker_count: usize, rows_per_ticker: usize) -> DataFrame {
+        let names = ["AAA", "BBB", "CCC"];
+        let total = ticker_count * rows_per_ticker;
+        let mut ticker = Vec::with_capacity(total);
+        let mut timestamp = Vec::with_capacity(total);
+        let mut close = Vec::with_capacity(total);
+        for index in 0..ticker_count {
+            for row in 0..rows_per_ticker {
+                ticker.push(names[index]);
+                let date = chrono::NaiveDate::from_ymd_opt(2026, 6, 1).unwrap()
+                    + chrono::Duration::days(row as i64);
+                timestamp.push(crate::data::calendar::eastern_midnight(date).timestamp_millis());
+                close.push(100.0 + row as f64);
+            }
+        }
+        DataFrame::new(vec![
+            Column::new("ticker".into(), ticker),
+            Column::new("timestamp".into(), timestamp),
+            Column::new("open_price".into(), vec![1.0_f64; total]),
+            Column::new("high_price".into(), vec![1.0_f64; total]),
+            Column::new("low_price".into(), vec![1.0_f64; total]),
+            Column::new("close_price".into(), close),
+            Column::new("volume".into(), vec![1.0_f64; total]),
+            Column::new("volume_weighted_average_price".into(), vec![1.0_f64; total]),
+            Column::new("sector".into(), vec!["S"; total]),
+            Column::new("industry".into(), vec!["I"; total]),
+        ])
+        .unwrap()
+    }
+
+    /// The session a pre-open run forecasts: the day after the newest bar in the frame.
+    fn forecast_session(frame: &DataFrame) -> chrono::NaiveDate {
+        let newest = frame
+            .column("timestamp")
+            .unwrap()
+            .i64()
+            .unwrap()
+            .max()
+            .unwrap();
+        crate::data::calendar::eastern_date(
+            chrono::DateTime::from_timestamp_millis(newest).unwrap(),
+        ) + chrono::Duration::days(1)
+    }
+
+    /// Everything `apply_existing_scaler` does to a frame, minus the scaler and mappings.
+    fn prepared(frame: DataFrame) -> DataFrame {
+        clean_data(engineer_features(frame).unwrap()).unwrap()
+    }
+
+    /// `prepared`, then integer-encoded the way `window_frame` expects. Mappings are fitted from
+    /// the frame itself, mirroring `fit_mappings`, which covers only the static columns.
+    fn prepared_and_encoded(frame: DataFrame) -> DataFrame {
+        let cleaned = prepared(frame);
+        let mut mappings = FeatureMappings::new();
+        for column in STATIC_CATEGORICAL_COLUMNS {
+            let mut values: Vec<String> = cleaned
+                .column(column)
+                .unwrap()
+                .str()
+                .unwrap()
+                .into_no_null_iter()
+                .map(str::to_string)
+                .collect::<std::collections::HashSet<_>>()
+                .into_iter()
+                .collect();
+            values.sort();
+            mappings.insert(
+                (*column).to_string(),
+                values
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, value)| (value, index as i32))
+                    .collect(),
+            );
+        }
+        encode_categoricals(cleaned, &mappings).unwrap()
+    }
+
+    #[test]
+    fn test_forecast_row_keeps_the_newest_bar_in_the_past_window() {
+        // Without the appended row the newest bar is spent as the future calendar step, so the
+        // model's price context stops a session short and it forecasts a close that already
+        // happened. close_price is 100 + row, so the window's contents identify their rows.
+        let input_length = 35usize;
+        let output_length = 1usize;
+        let frame = raw_frame(1, 40);
+        let session = forecast_session(&frame);
+
+        let without = window_frame(
+            &prepared_and_encoded(frame.clone()),
+            input_length,
+            output_length,
+            true,
+            false,
+        )
+        .unwrap();
+        let with = window_frame(
+            &prepared_and_encoded(append_forecast_session_rows(frame, session).unwrap()),
+            input_length,
+            output_length,
+            true,
+            false,
+        )
+        .unwrap();
+
+        let close_index = CONTINUOUS_COLUMNS
+            .iter()
+            .position(|column| *column == "close_price")
+            .unwrap();
+        let newest_in_past = |dataset: &TrainingDataset| {
+            dataset.past_continuous[[0, input_length - 1, close_index]] as usize - 100
+        };
+
+        // The newest real bar is row 39. Cleaning drops each ticker's first row, so the frame the
+        // window sees ends there either way -- only the appended row changes which side it lands on.
+        assert_eq!(
+            newest_in_past(&without),
+            38,
+            "precondition: without the appended row the newest bar is not a past feature"
+        );
+        assert_eq!(
+            newest_in_past(&with),
+            39,
+            "the newest real bar must be the last step of the past window"
+        );
+    }
+
+    #[test]
+    fn test_forecast_row_carries_the_target_session_calendar() {
+        // The future step must describe the session being forecast, not the last one observed.
+        let frame = raw_frame(1, 40);
+        let session = forecast_session(&frame);
+        let engineered =
+            engineer_features(append_forecast_session_rows(frame, session).unwrap()).unwrap();
+
+        let target_milliseconds =
+            crate::data::calendar::eastern_midnight(session).timestamp_millis();
+        let timestamps: Vec<i64> = engineered
+            .column("timestamp")
+            .unwrap()
+            .i64()
+            .unwrap()
+            .into_no_null_iter()
+            .collect();
+        let row = timestamps
+            .iter()
+            .position(|value| *value == target_milliseconds)
+            .expect("the appended session must survive feature engineering");
+
+        let day_of_week: Vec<i32> = engineered
+            .column("day_of_week")
+            .unwrap()
+            .i32()
+            .unwrap()
+            .into_no_null_iter()
+            .collect();
+        assert_eq!(
+            day_of_week[row],
+            session.weekday().number_from_monday() as i32,
+            "the appended row's calendar must match the forecast session"
+        );
+    }
+
+    #[test]
+    fn test_forecast_row_survives_cleaning_and_matches_the_stamped_session() {
+        // Two invariants together. The row must survive clean_data -- if it were dropped the window
+        // would silently revert to the misaligned behaviour with no error anywhere. And its session
+        // must equal the one `step_timestamp_milliseconds` stamps, or the features and the label
+        // describe different days, which is the shape of the bug this replaced.
+        let frame = raw_frame(2, 40);
+        let session = forecast_session(&frame);
+        let cleaned = prepared(append_forecast_session_rows(frame, session).unwrap());
+
+        let target_milliseconds =
+            crate::data::calendar::eastern_midnight(session).timestamp_millis();
+        let surviving = cleaned
+            .column("timestamp")
+            .unwrap()
+            .i64()
+            .unwrap()
+            .into_no_null_iter()
+            .filter(|value| *value == target_milliseconds)
+            .count();
+        assert_eq!(
+            surviving, 2,
+            "one appended row per ticker must survive cleaning"
+        );
+
+        // Any instant inside the forecast session must stamp that same session.
+        let noon = crate::data::calendar::eastern_midnight(session) + chrono::Duration::hours(12);
+        assert_eq!(
+            crate::models::tide::predict::step_timestamp_milliseconds(noon, 0),
+            target_milliseconds,
+            "the stamped session must be the session the appended row carries"
+        );
+    }
+
+    #[test]
+    fn test_forecast_row_is_not_appended_when_the_session_already_has_a_bar() {
+        // A run after the session's own bar has landed must not duplicate it.
+        let frame = raw_frame(1, 40);
+        let newest = frame
+            .column("timestamp")
+            .unwrap()
+            .i64()
+            .unwrap()
+            .max()
+            .unwrap();
+        let already_present = crate::data::calendar::eastern_date(
+            chrono::DateTime::from_timestamp_millis(newest).unwrap(),
+        );
+        let appended = append_forecast_session_rows(frame.clone(), already_present).unwrap();
+        assert_eq!(
+            appended.height(),
+            frame.height(),
+            "no row should be appended for a session already present"
+        );
+    }
+
+    #[test]
+    fn test_clean_data_rejects_a_null_ticker_and_keeps_every_real_one() {
+        // A null ticker is refused rather than encoded as a placeholder and filtered back out.
+        // `engineer_features` already rejects nulls, so this is the guard for a direct caller --
+        // and it means no real symbol can collide with a sentinel spelling and be dropped.
+        let mut engineered = engineer_features(raw_two_ticker_frame()).unwrap();
+        let kept = clean_data(engineered.clone()).unwrap();
+        let survivors: Vec<&str> = kept
+            .column("ticker")
+            .unwrap()
+            .str()
+            .unwrap()
+            .into_no_null_iter()
+            .collect();
+        assert!(!survivors.is_empty(), "no rows survived cleaning");
+
+        engineered
+            .with_column(Column::new(
+                "ticker".into(),
+                vec![Some("AAA"), None::<&str>, Some("BBB"), Some("BBB")],
+            ))
+            .unwrap();
+        let error = clean_data(engineered).unwrap_err().to_string();
+        assert!(
+            error.contains("null ticker"),
+            "expected a null-ticker rejection, got: {error}"
+        );
     }
 
     #[test]

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -7,9 +7,9 @@
 use burn::backend::NdArray;
 
 use crate::models::tide::batch::build_input_tensor;
-use crate::models::tide::config::ModelParameters;
+use crate::models::tide::configuration::ModelParameters;
 use crate::models::tide::data::TrainingDataset;
-use crate::models::tide::model::TideModel;
+use crate::models::tide::model::TiDEModel;
 
 const EVAL_BATCH: usize = 4096;
 
@@ -33,7 +33,7 @@ impl EvalMetrics {
 /// Run the (inner, non-autodiff) model over the validation dataset and compute
 /// the metrics. Returns zeros for an empty or target-less dataset.
 pub fn evaluate(
-    model: &TideModel<NdArray>,
+    model: &TiDEModel<NdArray>,
     dataset: &TrainingDataset,
     parameters: &ModelParameters,
 ) -> Result<EvalMetrics, Box<dyn std::error::Error>> {
@@ -45,8 +45,8 @@ pub fn evaluate(
 
     let output_length = parameters.output_length();
     let quantiles = parameters.quantiles();
-    let num_quantiles = quantiles.len();
-    if num_quantiles == 0 {
+    let quantile_count = quantiles.len();
+    if quantile_count == 0 {
         return Ok(EvalMetrics::zero());
     }
 
@@ -56,7 +56,7 @@ pub fn evaluate(
 
     let device = Default::default();
     let mut predictions: Vec<f32> =
-        Vec::with_capacity(sample_count * output_length * num_quantiles);
+        Vec::with_capacity(sample_count * output_length * quantile_count);
     let indices: Vec<usize> = (0..sample_count).collect();
     for chunk in indices.chunks(EVAL_BATCH) {
         let input = build_input_tensor::<NdArray>(
@@ -76,7 +76,7 @@ pub fn evaluate(
     // evaluation rather than an error. That can only happen if the forward pass returned a
     // different shape than the parameters describe -- a real mismatch, but one worth reporting as
     // an error the trainer can log rather than as a crash mid-run.
-    let expected_predictions = sample_count * output_length * num_quantiles;
+    let expected_predictions = sample_count * output_length * quantile_count;
     if predictions.len() < expected_predictions {
         return Err(format!(
             "model returned {} prediction values, expected {} for {} samples x {} horizon x {} quantiles",
@@ -84,7 +84,7 @@ pub fn evaluate(
             expected_predictions,
             sample_count,
             output_length,
-            num_quantiles
+            quantile_count
         )
         .into());
     }
@@ -97,7 +97,7 @@ pub fn evaluate(
     for sample in 0..sample_count {
         for t in 0..output_length {
             let target = targets[[sample, t, 0]] as f64;
-            let base = (sample * output_length + t) * num_quantiles;
+            let base = (sample * output_length + t) * quantile_count;
 
             let mut row_loss = 0.0_f64;
             for (q_index, &quantile) in quantiles.iter().enumerate() {
@@ -174,9 +174,9 @@ fn closest_to(values: &[f64], target: f64) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::tide::config::ModelParameters;
+    use crate::models::tide::configuration::ModelParameters;
     use crate::models::tide::data::TrainingDataset;
-    use crate::models::tide::model::TideModel;
+    use crate::models::tide::model::TiDEModel;
 
     // ---------------------------------------------------------------------------
     // argmin / argmax / closest_to
@@ -385,11 +385,11 @@ mod tests {
         }
     }
 
-    /// Build a TideModel that matches `make_tiny_dataset`: input_size=32,
-    /// output_length=1, num_quantiles=3.
-    fn make_tiny_model() -> TideModel<NdArray> {
+    /// Build a TiDEModel that matches `make_tiny_dataset`: input_size=32,
+    /// output_length=1, quantile_count=3.
+    fn make_tiny_model() -> TiDEModel<NdArray> {
         let device = Default::default();
-        TideModel::<NdArray>::new(&device, 32, 8, 1, 1, 1, 3, 0.0)
+        TiDEModel::<NdArray>::new(&device, 32, 8, 1, 1, 1, 3, 0.0)
     }
 
     /// Build ModelParameters aligned with `make_tiny_dataset` and
@@ -423,7 +423,7 @@ mod tests {
 
     #[test]
     fn test_evaluate_empty_quantiles_returns_zero() {
-        // num_quantiles == 0 triggers the early return after argmin/argmax/closest_to.
+        // quantile_count == 0 triggers the early return after argmin/argmax/closest_to.
         let model = make_tiny_model();
         let dataset = make_tiny_dataset(4, true);
         // Use a model whose quantile list is empty.

--- a/src/models/tide/fit.rs
+++ b/src/models/tide/fit.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use polars::prelude::*;
 
-use crate::models::tide::config::ModelParameters;
+use crate::models::tide::configuration::ModelParameters;
 use crate::models::tide::data::{
     apply_scaling, clean_data, encode_categoricals, engineer_features, CategoryMapping, Data,
     FeatureMappings, Scaler, CATEGORICAL_COLUMNS, CONTINUOUS_COLUMNS, STATIC_CATEGORICAL_COLUMNS,

--- a/src/models/tide/loss.rs
+++ b/src/models/tide/loss.rs
@@ -8,7 +8,7 @@ use burn::prelude::*;
 
 /// Compute the mean quantile loss.
 ///
-/// - `predictions`: `[batch, output_length * num_quantiles]` (the raw model output).
+/// - `predictions`: `[batch, output_length * quantile_count]` (the raw model output).
 /// - `targets`: `[batch, output_length]`.
 /// - `quantiles`: the quantile levels, e.g. `[0.1, 0.5, 0.9]`.
 /// - `huber_delta`: when `> 0`, applies Huber smoothing to the per-element error.
@@ -20,9 +20,9 @@ pub fn quantile_loss<B: Backend>(
     output_length: usize,
 ) -> Tensor<B, 1> {
     let [batch, _] = predictions.dims();
-    let num_quantiles = quantiles.len();
+    let quantile_count = quantiles.len();
     let device = predictions.device();
-    let reshaped = predictions.reshape([batch, output_length, num_quantiles]);
+    let reshaped = predictions.reshape([batch, output_length, quantile_count]);
 
     let mut total: Option<Tensor<B, 1>> = None;
     for (index, &quantile) in quantiles.iter().enumerate() {
@@ -67,7 +67,7 @@ pub fn quantile_loss<B: Backend>(
 
     total
         .expect("quantiles must not be empty")
-        .div_scalar(num_quantiles as f64)
+        .div_scalar(quantile_count as f64)
 }
 
 #[cfg(test)]

--- a/src/models/tide/model.rs
+++ b/src/models/tide/model.rs
@@ -34,7 +34,7 @@ impl<B: Backend> ResidualBlock<B> {
 }
 
 #[derive(Module, Debug)]
-pub struct TideModel<B: Backend> {
+pub struct TiDEModel<B: Backend> {
     feature_projection_1: nn::Linear<B>,
     feature_projection_2: nn::Linear<B>,
     encoder_blocks: Vec<ResidualBlock<B>>,
@@ -42,19 +42,19 @@ pub struct TideModel<B: Backend> {
     output_projection: nn::Linear<B>,
     final_layer_norm: nn::LayerNorm<B>,
     output_length: usize,
-    num_quantiles: usize,
+    quantile_count: usize,
 }
 
-impl TideModel<NdArray> {
+impl TiDEModel<NdArray> {
     #[allow(clippy::too_many_arguments)]
     pub fn load(
         directory_path: &std::path::Path,
         input_size: usize,
         hidden_size: usize,
-        num_encoder_layers: usize,
-        num_decoder_layers: usize,
+        encoder_layer_count: usize,
+        decoder_layer_count: usize,
         output_length: usize,
-        num_quantiles: usize,
+        quantile_count: usize,
         dropout_rate: f64,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let device = Default::default();
@@ -62,10 +62,10 @@ impl TideModel<NdArray> {
             &device,
             input_size,
             hidden_size,
-            num_encoder_layers,
-            num_decoder_layers,
+            encoder_layer_count,
+            decoder_layer_count,
             output_length,
-            num_quantiles,
+            quantile_count,
             dropout_rate,
         );
 
@@ -89,31 +89,31 @@ impl TideModel<NdArray> {
     }
 }
 
-impl<B: Backend> TideModel<B> {
+impl<B: Backend> TiDEModel<B> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         device: &B::Device,
         input_size: usize,
         hidden_size: usize,
-        num_encoder_layers: usize,
-        num_decoder_layers: usize,
+        encoder_layer_count: usize,
+        decoder_layer_count: usize,
         output_length: usize,
-        num_quantiles: usize,
+        quantile_count: usize,
         dropout_rate: f64,
     ) -> Self {
         let feature_projection_1 = nn::LinearConfig::new(input_size, hidden_size * 2).init(device);
         let feature_projection_2 = nn::LinearConfig::new(hidden_size * 2, hidden_size).init(device);
 
-        let encoder_blocks = (0..num_encoder_layers)
+        let encoder_blocks = (0..encoder_layer_count)
             .map(|_| ResidualBlock::new(device, hidden_size, dropout_rate))
             .collect();
 
-        let decoder_blocks = (0..num_decoder_layers)
+        let decoder_blocks = (0..decoder_layer_count)
             .map(|_| ResidualBlock::new(device, hidden_size, dropout_rate))
             .collect();
 
         let output_projection =
-            nn::LinearConfig::new(hidden_size, output_length * num_quantiles).init(device);
+            nn::LinearConfig::new(hidden_size, output_length * quantile_count).init(device);
 
         let final_layer_norm = nn::LayerNormConfig::new(hidden_size).init(device);
 
@@ -125,12 +125,12 @@ impl<B: Backend> TideModel<B> {
             output_projection,
             final_layer_norm,
             output_length,
-            num_quantiles,
+            quantile_count,
         }
     }
 
     /// Persist the model weights as a Burn record at `directory_path/tide_states`,
-    /// the exact stem [`TideModel::<NdArray>::load`] reads back. The on-disk file
+    /// the exact stem [`TiDEModel::<NdArray>::load`] reads back. The on-disk file
     /// gets the recorder's own extension; the loader re-derives it from the stem.
     pub fn save(&self, directory_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
         std::fs::create_dir_all(directory_path)?;
@@ -165,7 +165,7 @@ impl<B: Backend> TideModel<B> {
         let combined = burn::tensor::activation::relu(combined);
 
         let output = self.output_projection.forward(combined);
-        output.reshape([batch_size, self.output_length * self.num_quantiles])
+        output.reshape([batch_size, self.output_length * self.quantile_count])
     }
 }
 
@@ -180,24 +180,24 @@ mod tests {
         let input_size = 100;
         let hidden_size = 32;
         let output_length = 5;
-        let num_quantiles = 3;
+        let quantile_count = 3;
         let batch_size = 4;
 
-        let model: TideModel<NdArray> = TideModel::new(
+        let model: TiDEModel<NdArray> = TiDEModel::new(
             &device,
             input_size,
             hidden_size,
             2,
             2,
             output_length,
-            num_quantiles,
+            quantile_count,
             0.1,
         );
 
         let input = Tensor::<NdArray, 2>::zeros([batch_size, input_size], &device);
         let output = model.forward(input);
 
-        assert_eq!(output.dims(), [batch_size, output_length * num_quantiles]);
+        assert_eq!(output.dims(), [batch_size, output_length * quantile_count]);
     }
 
     #[test]
@@ -214,7 +214,7 @@ mod tests {
         // No tide_states record in the directory: load must error rather than
         // fall back to random weights and report success.
         let dir = tempfile::tempdir().unwrap();
-        let result = TideModel::<NdArray>::load(dir.path(), 24, 16, 2, 1, 5, 3, 0.0);
+        let result = TiDEModel::<NdArray>::load(dir.path(), 24, 16, 2, 1, 5, 3, 0.0);
         assert!(result.is_err());
         let message = result.err().unwrap().to_string();
         assert!(message.contains("Failed to load model weights"));
@@ -224,7 +224,7 @@ mod tests {
     fn test_forward_applies_relu_before_output_projection() {
         let device = Default::default();
         let input_size = 12;
-        let model: TideModel<NdArray> = TideModel::new(&device, input_size, 8, 1, 1, 2, 3, 0.0);
+        let model: TiDEModel<NdArray> = TiDEModel::new(&device, input_size, 8, 1, 1, 2, 3, 0.0);
 
         let input = Tensor::<NdArray, 1>::from_floats(
             (0..(4 * input_size))
@@ -272,7 +272,7 @@ mod tests {
     fn test_save_load_round_trip_preserves_forward() {
         let device = Default::default();
         let input_size = 24;
-        let model: TideModel<NdArray> = TideModel::new(&device, input_size, 16, 2, 1, 5, 3, 0.0);
+        let model: TiDEModel<NdArray> = TiDEModel::new(&device, input_size, 16, 2, 1, 5, 3, 0.0);
 
         // A non-trivial input so a random-weight fallback would differ.
         let input = Tensor::<NdArray, 1>::from_floats(
@@ -289,7 +289,7 @@ mod tests {
         model.save(dir.path()).unwrap();
 
         let loaded =
-            TideModel::<NdArray>::load(dir.path(), input_size, 16, 2, 1, 5, 3, 0.0).unwrap();
+            TiDEModel::<NdArray>::load(dir.path(), input_size, 16, 2, 1, 5, 3, 0.0).unwrap();
         let actual: Vec<f32> = loaded.forward(input).to_data().to_vec().unwrap();
 
         assert_eq!(expected.len(), actual.len());

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -217,14 +217,15 @@ pub(crate) fn unscale_and_sort_quantiles(
     unscaled
 }
 
-/// Timestamp (UTC midnight, milliseconds) for horizon step `step`, where step 0 is `now`'s date.
+/// Timestamp for horizon step `step`, where step 0 is the Eastern session `now` falls in.
+///
+/// Midnight *Eastern*, not UTC. The evaluation pass selects forecasts with
+/// [`crate::data::calendar::eastern_day_bounds`], and a UTC midnight sits at 20:00 the previous
+/// Eastern day under daylight time -- so a UTC-stamped forecast lands in the wrong session's
+/// window and the morning's inference run is never read by that day's passes.
 pub(crate) fn step_timestamp_milliseconds(now: chrono::DateTime<Utc>, step: usize) -> i64 {
-    (now + Duration::days(step as i64))
-        .date_naive()
-        .and_hms_opt(0, 0, 0)
-        .expect("midnight is always a valid time")
-        .and_utc()
-        .timestamp_millis()
+    let session = crate::data::calendar::eastern_date(now) + Duration::days(step as i64);
+    crate::data::calendar::eastern_midnight(session).timestamp_millis()
 }
 
 pub fn generate_predictions(
@@ -315,8 +316,11 @@ pub fn generate_predictions(
         }
     }
 
-    // Select the final horizon step, now + (output_length - 1) days, for the caller to persist.
-    let target_date = step_timestamp_milliseconds(now, output_length - 1);
+    // Step 0 -- the coming close -- is the only horizon the book can act on: the pre-close
+    // liquidation flattens every position the same session, so a forecast further out describes a
+    // holding period this strategy never has. Selected explicitly rather than as the last step, so
+    // widening `output_length` for research does not silently move the traded signal.
+    let target_date = step_timestamp_milliseconds(now, 0);
 
     let final_predictions: Vec<serde_json::Value> = results
         .into_iter()
@@ -738,22 +742,67 @@ mod tests {
     }
 
     #[test]
-    fn test_step_timestamp_step_zero_is_today_midnight() {
-        // Horizon step t is now + t days at midnight: step 0 is today, and the persisted
-        // target is step output_length - 1.
+    fn test_predictions_are_visible_to_the_same_session_evaluation() {
+        // The 09:00 Eastern run exists to feed the same session's evaluation passes, which select
+        // rows with `eastern_day_bounds`. A stamp built at UTC midnight falls in the *previous*
+        // Eastern day's window -- 20:00 the day before, under EDT -- so the forecast written this
+        // morning is never the one read this afternoon.
+        use crate::data::calendar::{eastern_date, eastern_day_bounds};
+
+        for day in [
+            "2026-08-03",
+            "2026-08-04",
+            "2026-08-05",
+            "2026-08-06",
+            "2026-08-07",
+        ] {
+            // 13:00Z is 09:00 Eastern while daylight time is in effect.
+            let now = chrono::DateTime::parse_from_rfc3339(&format!("{day}T13:00:00Z"))
+                .unwrap()
+                .with_timezone(&Utc);
+            let stamp = DateTime::<Utc>::from_timestamp_millis(step_timestamp_milliseconds(now, 0))
+                .unwrap();
+            let (start, end) = eastern_day_bounds(eastern_date(now));
+            assert!(
+                stamp >= start && stamp < end,
+                "{day}: forecast stamped {stamp} is outside the session window [{start}, {end})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_step_timestamp_step_zero_is_the_current_eastern_session() {
+        // Step t is the Eastern session t days out, stamped at Eastern midnight. 15:30Z is 11:30
+        // Eastern, so step 0 is that same session rather than the one UTC is already into.
+        use crate::data::calendar::eastern_midnight;
+
         let now = chrono::DateTime::parse_from_rfc3339("2026-06-09T15:30:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        let midnight = chrono::NaiveDate::from_ymd_opt(2026, 6, 9)
-            .unwrap()
-            .and_hms_opt(0, 0, 0)
-            .unwrap()
-            .and_utc()
-            .timestamp_millis();
-        assert_eq!(step_timestamp_milliseconds(now, 0), midnight);
+        let session = chrono::NaiveDate::from_ymd_opt(2026, 6, 9).unwrap();
+        assert_eq!(
+            step_timestamp_milliseconds(now, 0),
+            eastern_midnight(session).timestamp_millis()
+        );
         assert_eq!(
             step_timestamp_milliseconds(now, 4),
-            midnight + 4 * 86_400_000
+            eastern_midnight(session + Duration::days(4)).timestamp_millis()
+        );
+    }
+
+    #[test]
+    fn test_late_evening_eastern_still_stamps_the_current_session() {
+        // 01:00Z is 21:00 the previous Eastern day. Stamping off the UTC date would jump the
+        // forecast a session forward, which is the failure this function exists to avoid.
+        use crate::data::calendar::eastern_midnight;
+
+        let now = chrono::DateTime::parse_from_rfc3339("2026-06-10T01:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(
+            step_timestamp_milliseconds(now, 0),
+            eastern_midnight(chrono::NaiveDate::from_ymd_opt(2026, 6, 9).unwrap())
+                .timestamp_millis()
         );
     }
 

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -232,8 +232,15 @@ pub fn generate_predictions(
     data: DataFrame,
     model_state: &ModelState,
 ) -> Result<serde_json::Value, PredictionError> {
-    let tide_data = Data::apply_existing_scaler(data, model_state.scaler(), model_state.mappings())
-        .map_err(|e| PredictionError::Preprocessing(e.to_string()))?;
+    // One `now` for the whole run. The session the synthesized future row carries and the session
+    // the output is stamped with are both derived from it, so the features and the label cannot
+    // describe different days -- which is the shape of the bug this replaced.
+    let now = Utc::now();
+    let session = crate::data::calendar::eastern_date(now);
+
+    let tide_data =
+        Data::apply_existing_scaler(data, model_state.scaler(), model_state.mappings(), session)
+            .map_err(|e| PredictionError::Preprocessing(e.to_string()))?;
 
     let output_length = model_state.parameters().output_length();
     let dataset_input_length = model_state.parameters().input_length();
@@ -288,8 +295,6 @@ pub fn generate_predictions(
     })?;
     let reverse_ticker_map: std::collections::HashMap<i32, &String> =
         ticker_mapping.iter().map(|(k, v)| (*v, k)).collect();
-
-    let now = Utc::now();
 
     for sample_idx in 0..num_samples {
         let ticker_id = dataset.static_categorical[[sample_idx, 0, 0]];
@@ -1093,15 +1098,49 @@ mod tests {
     }
 
     #[test]
-    fn test_step_timestamp_advances_one_day_per_step() {
+    fn test_step_timestamp_advances_one_session_per_step() {
+        // Compared against `eastern_midnight` rather than a fixed 86,400,000 ms stride: successive
+        // Eastern midnights are 23 or 25 hours apart across a daylight-saving transition, so a
+        // fixed stride asserts something that is only true away from March and November.
+        use crate::data::calendar::eastern_midnight;
+
         let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        let step0 = step_timestamp_milliseconds(now, 0);
-        let step1 = step_timestamp_milliseconds(now, 1);
-        let step7 = step_timestamp_milliseconds(now, 7);
-        assert_eq!(step1 - step0, 86_400_000);
-        assert_eq!(step7 - step0, 7 * 86_400_000);
+        let session = chrono::NaiveDate::from_ymd_opt(2025, 12, 31).unwrap();
+        for step in [0usize, 1, 7] {
+            assert_eq!(
+                step_timestamp_milliseconds(now, step),
+                eastern_midnight(session + Duration::days(step as i64)).timestamp_millis(),
+                "step {step} did not land on its Eastern session midnight"
+            );
+        }
+    }
+
+    #[test]
+    fn test_step_timestamp_crosses_daylight_saving_transitions() {
+        // Eastern time springs forward 2026-03-08 and falls back 2026-11-01. Stepping across either
+        // boundary must still land on the session's own midnight, which a fixed day-length stride
+        // would miss by an hour in each direction.
+        use crate::data::calendar::eastern_midnight;
+
+        for (start, label) in [
+            ("2026-03-06T17:00:00Z", "spring forward"),
+            ("2026-10-30T17:00:00Z", "fall back"),
+        ] {
+            let now = chrono::DateTime::parse_from_rfc3339(start)
+                .unwrap()
+                .with_timezone(&Utc);
+            let session = crate::data::calendar::eastern_date(now);
+            for step in 0..5usize {
+                let expected = eastern_midnight(session + Duration::days(step as i64));
+                assert_eq!(
+                    step_timestamp_milliseconds(now, step),
+                    expected.timestamp_millis(),
+                    "{label}: step {step} did not land on {expected}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -266,13 +266,13 @@ pub fn generate_predictions(
         .to_vec()
         .map_err(|e| PredictionError::Inference(format!("{e:?}")))?;
 
-    let num_quantiles = model_state.parameters().quantiles().len();
+    let quantile_count = model_state.parameters().quantiles().len();
     // The output schema is fixed at quantile_10/quantile_50/quantile_90, so a
     // model with any other quantile count cannot be served correctly; fail
     // loudly instead of indexing out of bounds or mislabeling values.
-    if num_quantiles != 3 {
+    if quantile_count != 3 {
         return Err(PredictionError::Postprocessing(format!(
-            "Expected exactly 3 quantiles (10/50/90); the loaded model has {num_quantiles}"
+            "Expected exactly 3 quantiles (10/50/90); the loaded model has {quantile_count}"
         )));
     }
     let mut results = Vec::new();
@@ -298,9 +298,9 @@ pub fn generate_predictions(
             .unwrap_or("UNKNOWN");
 
         for t in 0..output_length {
-            let base_idx = (sample_idx * output_length + t) * num_quantiles;
+            let base_idx = (sample_idx * output_length + t) * quantile_count;
 
-            let scaled: Vec<f64> = (0..num_quantiles)
+            let scaled: Vec<f64> = (0..quantile_count)
                 .map(|q| predictions_data[base_idx + q] as f64)
                 .collect();
             let quantiles = unscale_and_sort_quantiles(&scaled, model_state.scaler());

--- a/src/models/tide/train.rs
+++ b/src/models/tide/train.rs
@@ -12,15 +12,15 @@ use rand::SeedableRng;
 use tracing::info;
 
 use crate::models::tide::batch::{build_input_tensor, build_target_tensor};
-use crate::models::tide::config::ModelParameters;
+use crate::models::tide::configuration::ModelParameters;
 use crate::models::tide::data::TrainingDataset;
 use crate::models::tide::loss::quantile_loss;
-use crate::models::tide::model::TideModel;
+use crate::models::tide::model::TiDEModel;
 
 /// The training backend: reverse-mode autodiff over the CPU NdArray backend.
 pub type TrainBackend = Autodiff<NdArray>;
 
-pub struct TrainConfig {
+pub struct TrainConfiguration {
     learning_rate: f64,
     epoch_count: usize,
     batch_size: usize,
@@ -31,12 +31,12 @@ pub struct TrainConfig {
 /// Why a training configuration was rejected.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 #[error("invalid training configuration: {reason}")]
-pub struct TrainConfigError {
+pub struct TrainConfigurationError {
     pub reason: String,
 }
 
-impl TrainConfig {
-    /// Constructs a validated `TrainConfig`.
+impl TrainConfiguration {
+    /// Constructs a validated `TrainConfiguration`.
     ///
     /// `batch_size` is the one that bites hardest: it reaches `slice::chunks`, which panics on
     /// zero, so a zero batch size aborts the training task rather than failing it. A non-positive
@@ -47,9 +47,9 @@ impl TrainConfig {
         batch_size: usize,
         early_stopping_patience: usize,
         min_delta: f64,
-    ) -> Result<Self, TrainConfigError> {
+    ) -> Result<Self, TrainConfigurationError> {
         let reject = |reason: &str| {
-            Err(TrainConfigError {
+            Err(TrainConfigurationError {
                 reason: reason.to_string(),
             })
         };
@@ -95,7 +95,7 @@ impl TrainConfig {
     }
 }
 
-impl Default for TrainConfig {
+impl Default for TrainConfiguration {
     fn default() -> Self {
         Self {
             learning_rate: 0.001,
@@ -151,13 +151,13 @@ impl EarlyStopping {
 /// Train the model, returning the best-checkpoint model and the per-epoch
 /// training loss history.
 pub fn train(
-    mut model: TideModel<TrainBackend>,
+    mut model: TiDEModel<TrainBackend>,
     train_dataset: &TrainingDataset,
     valid_dataset: Option<&TrainingDataset>,
     parameters: &ModelParameters,
-    config: &TrainConfig,
+    configuration: &TrainConfiguration,
     device: &<TrainBackend as Backend>::Device,
-) -> (TideModel<TrainBackend>, Vec<f64>) {
+) -> (TiDEModel<TrainBackend>, Vec<f64>) {
     let num_samples = train_dataset.len();
     let mut losses = Vec::new();
     if num_samples == 0 {
@@ -166,7 +166,7 @@ pub fn train(
 
     let mut optimizer = AdamConfig::new()
         .with_epsilon(1e-8)
-        .init::<TrainBackend, TideModel<TrainBackend>>();
+        .init::<TrainBackend, TiDEModel<TrainBackend>>();
 
     // Deterministic shuffle so runs are reproducible.
     let mut rng = rand::rngs::StdRng::seed_from_u64(0);
@@ -174,14 +174,14 @@ pub fn train(
     let mut best_model = model.clone();
     let mut early_stopping = EarlyStopping::new();
 
-    for epoch in 0..config.epoch_count {
+    for epoch in 0..configuration.epoch_count {
         let mut order: Vec<usize> = (0..num_samples).collect();
         order.shuffle(&mut rng);
 
         let mut loss_sum = 0.0_f64;
         let mut batch_count = 0usize;
 
-        for batch_indices in order.chunks(config.batch_size) {
+        for batch_indices in order.chunks(configuration.batch_size) {
             let input = build_input_tensor::<TrainBackend>(
                 train_dataset,
                 batch_indices,
@@ -210,7 +210,7 @@ pub fn train(
 
             let gradients = loss.backward();
             let gradient_params = GradientsParams::from_grads(gradients, &model);
-            model = optimizer.step(config.learning_rate, model, gradient_params);
+            model = optimizer.step(configuration.learning_rate, model, gradient_params);
         }
 
         let train_loss = if batch_count > 0 {
@@ -222,7 +222,7 @@ pub fn train(
 
         let stopping_loss = match valid_dataset {
             Some(valid) if !valid.is_empty() => {
-                validation_loss(&model, valid, parameters, config.batch_size)
+                validation_loss(&model, valid, parameters, configuration.batch_size)
             }
             _ => train_loss,
         };
@@ -236,8 +236,8 @@ pub fn train(
 
         let (snapshot, stop) = early_stopping.observe(
             stopping_loss,
-            config.min_delta,
-            config.early_stopping_patience,
+            configuration.min_delta,
+            configuration.early_stopping_patience,
         );
         if snapshot {
             best_model = model.clone();
@@ -253,7 +253,7 @@ pub fn train(
 
 /// Mean validation loss using the dropout-disabled inner (`NdArray`) model.
 fn validation_loss(
-    model: &TideModel<TrainBackend>,
+    model: &TiDEModel<TrainBackend>,
     valid: &TrainingDataset,
     parameters: &ModelParameters,
     batch_size: usize,
@@ -302,37 +302,37 @@ mod tests {
     /// aborts the training task rather than failing it. A non-positive learning rate is quieter and
     /// worse: training completes and learns nothing.
     #[test]
-    fn test_train_config_rejects_values_that_break_the_loop() {
+    fn test_train_configuration_rejects_values_that_break_the_loop() {
         assert!(
-            TrainConfig::new(0.001, 20, 0, 3, 1e-5).is_err(),
+            TrainConfiguration::new(0.001, 20, 0, 3, 1e-5).is_err(),
             "zero batch"
         );
         assert!(
-            TrainConfig::new(0.001, 0, 512, 3, 1e-5).is_err(),
+            TrainConfiguration::new(0.001, 0, 512, 3, 1e-5).is_err(),
             "zero epochs"
         );
         assert!(
-            TrainConfig::new(0.0, 20, 512, 3, 1e-5).is_err(),
+            TrainConfiguration::new(0.0, 20, 512, 3, 1e-5).is_err(),
             "zero learning rate"
         );
         assert!(
-            TrainConfig::new(-0.1, 20, 512, 3, 1e-5).is_err(),
+            TrainConfiguration::new(-0.1, 20, 512, 3, 1e-5).is_err(),
             "negative learning rate"
         );
         assert!(
-            TrainConfig::new(f64::NAN, 20, 512, 3, 1e-5).is_err(),
+            TrainConfiguration::new(f64::NAN, 20, 512, 3, 1e-5).is_err(),
             "non-finite"
         );
         assert!(
-            TrainConfig::new(0.001, 20, 512, 3, -1.0).is_err(),
+            TrainConfiguration::new(0.001, 20, 512, 3, -1.0).is_err(),
             "negative min_delta"
         );
     }
 
     #[test]
-    fn test_train_config_accepts_the_defaults() {
-        let defaults = TrainConfig::default();
-        assert!(TrainConfig::new(
+    fn test_train_configuration_accepts_the_defaults() {
+        let defaults = TrainConfiguration::default();
+        assert!(TrainConfiguration::new(
             defaults.learning_rate(),
             defaults.epoch_count(),
             defaults.batch_size(),
@@ -422,19 +422,19 @@ mod tests {
         );
 
         let device = Default::default();
-        let model = TideModel::<TrainBackend>::new(
+        let model = TiDEModel::<TrainBackend>::new(
             &device,
             parameters.input_size(),
             parameters.hidden_size(),
-            parameters.num_encoder_layers(),
-            parameters.num_decoder_layers(),
+            parameters.encoder_layer_count(),
+            parameters.decoder_layer_count(),
             parameters.output_length(),
             parameters.quantiles().len(),
             parameters.dropout_rate(),
         );
         let initial = model.clone();
 
-        let config = TrainConfig {
+        let configuration = TrainConfiguration {
             learning_rate: 0.01,
             epoch_count: 10,
             batch_size: 16,
@@ -442,11 +442,12 @@ mod tests {
             min_delta: 1e9,
         };
 
-        let (best, losses) = train(model, &dataset, None, &parameters, &config, &device);
+        let (best, losses) = train(model, &dataset, None, &parameters, &configuration, &device);
         assert_eq!(losses.len(), 10);
 
-        let initial_loss = validation_loss(&initial, &dataset, &parameters, config.batch_size);
-        let best_loss = validation_loss(&best, &dataset, &parameters, config.batch_size);
+        let initial_loss =
+            validation_loss(&initial, &dataset, &parameters, configuration.batch_size);
+        let best_loss = validation_loss(&best, &dataset, &parameters, configuration.batch_size);
         assert!(
             best_loss < initial_loss,
             "best model was not checkpointed: {best_loss} vs initial {initial_loss}"
@@ -472,18 +473,18 @@ mod tests {
         );
 
         let device = Default::default();
-        let model = TideModel::<TrainBackend>::new(
+        let model = TiDEModel::<TrainBackend>::new(
             &device,
             parameters.input_size(),
             parameters.hidden_size(),
-            parameters.num_encoder_layers(),
-            parameters.num_decoder_layers(),
+            parameters.encoder_layer_count(),
+            parameters.decoder_layer_count(),
             parameters.output_length(),
             parameters.quantiles().len(),
             parameters.dropout_rate(),
         );
 
-        let config = TrainConfig {
+        let configuration = TrainConfiguration {
             learning_rate: 0.01,
             epoch_count: 80,
             batch_size: 16,
@@ -491,7 +492,7 @@ mod tests {
             min_delta: 0.0,
         };
 
-        let (_model, losses) = train(model, &dataset, None, &parameters, &config, &device);
+        let (_model, losses) = train(model, &dataset, None, &parameters, &configuration, &device);
         assert!(losses.len() >= 2);
         let first = losses.first().unwrap();
         let last = losses.last().unwrap();


### PR DESCRIPTION
# Overview

Spells out the abbreviated identifiers across the TiDE module, then fixes two defects that meant the
09:00 Eastern inference run was never read by the session it was written for.

## Changes

- Spell out `num_encoder_layers` / `num_decoder_layers` as `encoder_layer_count` /
  `decoder_layer_count`, `num_quantiles` as `quantile_count`, and `TideModel` as `TiDEModel`
- Rename `config.rs` to `configuration.rs`, `TrainConfig` to `TrainConfiguration`, and
  `TrainConfigError` to `TrainConfigurationError`
- Expand the windowing and batching locals in `data.rs` and `batch.rs`: `n_cont`, `n_cat`,
  `n_static`, `cont_arrays`, `all_past_cont`, `past_cat`, `num_samples`, and the `t` / `f` / `col`
  loop indices
- Fall back to `crate::data::details::UNKNOWN` for a null sector or industry, matching the
  `NOT AVAILABLE` default the schema writes, and keep a separate `MISSING_TICKER` sentinel for the
  ticker filter
- Stamp `equity_predictions.timestamp` at Eastern midnight rather than UTC midnight
- Set `output_length` to 1 and select horizon step 0 explicitly rather than `output_length - 1`
- Append a synthesized row per ticker for the session being forecast, so the newest bar stays a past
  feature instead of being spent as the future calendar step
- Reject a null ticker in `clean_data` outright and remove the unreachable `MISSING_TICKER` sentinel
- Reject a zero `input_length` or `output_length` in `ModelParameters::load`

## Context

**The timestamp skew.** `step_timestamp_milliseconds` built midnight in UTC while every consumer
selects rows with `eastern_day_bounds` — the evaluation pass, the model-run lookup, and the nightly
S3 export. A UTC midnight is 20:00 the previous Eastern day under daylight time, so a forecast
targeting a session landed in the preceding session's window. `eastern_midnight` is promoted to
`pub(crate)` so the write and the reads share one definition instead of two that have to agree.

**The horizon.** Only the final step was persisted, so with a five-step model the traded signal was
the forecast four calendar days out. Combined with the skew, each weekday's evaluation needed a
forecast generated three days earlier — and Tuesday and Wednesday needed one generated Saturday and
Sunday, when `predictions-requested` does not run. Those two sessions found nothing and screened no
entries, while Wednesday's and Thursday's forecasts targeted weekend dates nothing reads. A book
that flattens at 15:45 every session can only act on the coming close, so step 0 is now selected by
index rather than as a side effect of `output_length`.

**The predict window (raised in review).** `window_frame` splits one contiguous block of
`input_length + output_length` rows into a past and a future half, so the newest bar was consumed as
the future calendar step. A probe on a 40-row frame with `input_length` 35 put rows 4..38 in the past
window and spent row 39. Pre-open, the newest bar is the prior session — so the model's price context
stopped two sessions back and it forecast a close that had already happened, which was then stamped
for today. This predates the pull request; the horizon change above narrowed it from five sessions to
one rather than causing it.

`append_forecast_session_rows` adds one row per ticker carrying the target session, built by copying
that ticker's last bar and moving its timestamp. Copying rather than inventing values means
`close_price` equals the previous close, so the engineered `daily_return` is `0.0` and the row
survives `clean_data`'s non-finite filter. Those prices never reach the model: the future half
consumes only `CATEGORICAL_COLUMNS`, and the extra row shifts the window so the past half lands on
real bars. Calendar fields are left to `engineer_features` so only one place derives them, and the
appended session and the persisted stamp are both derived from a single `now`.

**Verification.** `test_predictions_are_visible_to_the_same_session_evaluation` walks Monday through
Friday and was confirmed to fail against the UTC stamping, reporting the four-hour offset;
`test_late_evening_eastern_still_stamps_the_current_session` covers 21:00 Eastern, where the UTC
date has already rolled forward. `test_clean_data_fills_null_sector_with_the_stored_default` was
likewise confirmed to fail against the previous fallback before being kept. The window test asserts
the pre-fix value as a precondition, so it cannot pass vacuously. `checks:rust` passes at
80.25 percent coverage.

**Artifacts trained before this will not load**, three ways: `ModelParameters` derives
`Serialize`/`Deserialize` with no rename attributes so the parameter keys change, `TiDEModel`
changes the burn-generated record type, and the shorter horizon narrows the model input from 448 to
428. Nothing is deployed, so no compatibility shim is included. A retrain is required before the
horizon fix takes effect.

**Deliberately not included.** `CONFIDENCE_FLOOR` is `0.5`, which inverts to a prediction-interval
width of 1.0; since `daily_return` is a fraction that is a 100 percentage-point band, against a
realistic daily 10–90 band of 0.02–0.06. The gate is likely already inert, and the shorter horizon
should narrow intervals further. Recalibrating needs the observed `quantile_90 - quantile_10`
distribution from a model trained at `output_length = 1`, so it is a follow-up rather than a guess
made here.

Burn's `LinearConfig`, `DropoutConfig`, `LayerNormConfig`, and `AdamConfig` are untouched, as are
the `map_err(|e| ...)` closures, where the short form is the prevailing convention across `src/`.
