### PR TITLE
Audit time and timezone handling, and give a session its own type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,19 @@ This is a collection of guidelines and references.
   handled and the compiler flags missing cases when variants change
 - Wrap primitive types in tuple structs to enforce domain type safety (e.g., `struct Price(f64)`); never accept
   a raw `f64` or `String` where a specific domain value is required
+- Time has exactly two kinds and they never mix: an instant is a moment on the timeline and is always UTC
+  (`DateTime<Utc>`, `TIMESTAMPTZ`), while a session is a trading day and is always an `America/New_York`
+  calendar date — that is what the exchange's day is, not a display preference. A session is
+  `data::calendar::SessionDate`, never a bare `NaiveDate`: derive one from an instant with `SessionDate::at`
+  and convert back with `.midnight()`/`.bounds()`, never via `Utc::now().date_naive()` or a hardcoded offset
+- `SessionDate::from_date` is for dates that arrive already being sessions — a parsed argument, a `DATE`
+  column, an exchange calendar entry — so transport modules (`common::alpaca`, `common::massive`,
+  `common::aws`) keep `NaiveDate` and the wrap happens at the domain boundary; render Eastern only at the
+  display boundary, and stamp test fixtures with `.midnight()` so they match how bars really arrive
+- Write `Eastern` or `America/New_York`, never `EST` or `EDT` — each names only half the year; elapsed
+  durations and timeouts carry no zone, so measure them on a monotonic clock (`tokio::time::Instant`), and
+  schedule trading jobs with a UTC cron expression gated on the Eastern wall clock, a pairing that
+  `tests/test_schedules.rs` enforces
 - Model state machines with two enums (states and transitions) matched as a tuple:
   `match (current_state, transition) { ... }` — keeps business logic exhaustive and legible
 - Design structs to be flat and normalized: each struct represents one concept with only its own fields;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,10 +91,13 @@ This is a collection of guidelines and references.
   calendar date — that is what the exchange's day is, not a display preference. A session is
   `data::calendar::SessionDate`, never a bare `NaiveDate`: derive one from an instant with `SessionDate::at`
   and convert back with `.midnight()`/`.bounds()`, never via `Utc::now().date_naive()` or a hardcoded offset
-- `SessionDate::from_date` is for dates that arrive already being sessions — a parsed argument, a `DATE`
+- `SessionDate::from_date` is for dates already expressed in Eastern terms — a parsed argument, a `DATE`
   column, an exchange calendar entry — so transport modules (`common::alpaca`, `common::massive`,
   `common::aws`) keep `NaiveDate` and the wrap happens at the domain boundary; render Eastern only at the
   display boundary, and stamp test fixtures with `.midnight()` so they match how bars really arrive
+- `SessionDate` guarantees the timezone, not tradability: weekends and holidays are representable and
+  `plus_calendar_days` will land on them, so only `TradingCalendar::is_trading_day` answers whether a date
+  trades — never infer it from the type
 - Write `Eastern` or `America/New_York`, never `EST` or `EDT` — each names only half the year; elapsed
   durations and timeouts carry no zone, so measure them on a monotonic clock (`tokio::time::Instant`), and
   schedule trading jobs with a UTC cron expression gated on the Eastern wall clock, a pairing that

--- a/devenv.nix
+++ b/devenv.nix
@@ -632,14 +632,21 @@ in {
     # which timezone it is in -- pg_cron has `cron.timezone = UTC` in the settings above -- and this
     # one was reading it from host state nobody sets, so "23:00 UTC" was a hope rather than a fact.
     #
-    # Checked independently of the entry below, and prepended rather than appended, for the reason
-    # in the comment at the top of this script: a machine provisioned before the pin existed has the
-    # training entry already, so a check that rode along with it would never run there. A crontab
-    # variable applies to the entries that follow it, so position is not cosmetic.
-    if crontab -l 2>/dev/null | grep -qE '^CRON_TZ=UTC$'; then
+    # Checked independently of the entry below, for the reason in the comment at the top of this
+    # script: a machine provisioned before the pin existed has the training entry already, so a
+    # check that rode along with it would never run there.
+    #
+    # A crontab variable applies only to the entries *below* it, so presence is not proof. A second
+    # assignment above the trainer entry would leave that schedule in the host timezone while a
+    # grep for CRON_TZ=UTC anywhere still passed. Rather than test for that, this normalizes: every
+    # CRON_TZ line is stripped and exactly one is prepended, so the managed crontab carries a single
+    # timezone declaration at the top and every entry inherits it regardless of the order they were
+    # installed in. Idempotent, and it makes the invariant true instead of merely checked.
+    if [ "$(crontab -l 2>/dev/null | grep -c '^CRON_TZ=' || true)" = "1" ] \
+       && crontab -l 2>/dev/null | head -n 1 | grep -qE '^CRON_TZ=UTC$'; then
       echo "Cron timezone already pinned to UTC"
     else
-      (echo 'CRON_TZ=UTC'; crontab -l 2>/dev/null || true) | crontab -
+      (echo 'CRON_TZ=UTC'; crontab -l 2>/dev/null | grep -v '^CRON_TZ=' || true) | crontab -
       echo "Pinned cron timezone to UTC (host is $(date +%Z), offset $(date +%z))"
     fi
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -418,7 +418,13 @@ in {
     # test_dashboard is not optional cover. The dashboard is the only part of the
     # tree using raw sqlx::query rather than the checked macros, so nothing else
     # catches a mistyped column there until the page is loaded.
-    TEST_ARGS="--lib --bins --all-features --test test_database --test test_handlers --test test_dashboard"
+    #
+    # test_schedules is the exception to the paragraph above: it needs neither
+    # PostgreSQL nor MinIO, because it reads schema.sql as text. It is here
+    # because the pg_cron blocks it checks are stripped out by
+    # tests/common/mod.rs before the schema is applied, so the trading schedules
+    # have no other executable cover at all.
+    TEST_ARGS="--lib --bins --all-features --test test_database --test test_handlers --test test_dashboard --test test_schedules"
 
     mkdir -p .coverage_output
     export LLVM_COV=$(which llvm-cov)
@@ -621,6 +627,22 @@ in {
     # A fixed UTC hour is what makes that true year-round. 06:00 UTC, the previous schedule, is
     # 01:00 or 02:00 Eastern -- after the close it was named for, but on the wrong side of
     # midnight, so the run and the session it served never shared a date.
+    #
+    # CRON_TZ pins the hour to UTC in the crontab itself. Every other schedule in this system says
+    # which timezone it is in -- pg_cron has `cron.timezone = UTC` in the settings above -- and this
+    # one was reading it from host state nobody sets, so "23:00 UTC" was a hope rather than a fact.
+    #
+    # Checked independently of the entry below, and prepended rather than appended, for the reason
+    # in the comment at the top of this script: a machine provisioned before the pin existed has the
+    # training entry already, so a check that rode along with it would never run there. A crontab
+    # variable applies to the entries that follow it, so position is not cosmetic.
+    if crontab -l 2>/dev/null | grep -qE '^CRON_TZ=UTC$'; then
+      echo "Cron timezone already pinned to UTC"
+    else
+      (echo 'CRON_TZ=UTC'; crontab -l 2>/dev/null || true) | crontab -
+      echo "Pinned cron timezone to UTC (host is $(date +%Z), offset $(date +%z))"
+    fi
+
     if crontab -l 2>/dev/null | grep -qF 'train-tide-model'; then
       echo "Training cron entry already installed"
     else

--- a/src/bin/seed_equity_bars.rs
+++ b/src/bin/seed_equity_bars.rs
@@ -12,14 +12,14 @@
 //! list. Asking Alpaca means asking for its *current* tradable set, so every symbol delisted since
 //! the start date would be missing from its own history.
 
-use chrono::{Duration, NaiveDate, Utc};
+use chrono::{NaiveDate, Utc};
 use tracing::{error, info, warn};
 
 use fund::common::database::connect_pool;
 use fund::common::massive::MassiveClient;
 use fund::common::observability::init_tracing;
 use fund::data::bars;
-use fund::data::calendar::eastern_date;
+use fund::data::calendar::SessionDate;
 
 const USAGE: &str = "Usage: seed_equity_bars <start YYYY-MM-DD> [end YYYY-MM-DD]";
 
@@ -34,13 +34,13 @@ const CHUNK_DAYS: i64 = 30;
 /// Inclusive date range, validated on construction.
 #[derive(Debug, PartialEq, Eq)]
 struct SeedRange {
-    start: NaiveDate,
-    end: NaiveDate,
+    start: SessionDate,
+    end: SessionDate,
 }
 
 impl SeedRange {
     /// Rejects an inverted range, so a `SeedRange` in scope is proof the window is orderable.
-    fn new(start: NaiveDate, end: NaiveDate) -> Result<Self, String> {
+    fn new(start: SessionDate, end: SessionDate) -> Result<Self, String> {
         if start > end {
             return Err(format!(
                 "Invalid range: start date {start} must be on or before end date {end}"
@@ -57,12 +57,14 @@ impl SeedRange {
         let mut chunks = Vec::new();
         let mut window_start = self.start;
         while window_start <= self.end {
-            let window_end = (window_start + Duration::days(CHUNK_DAYS - 1)).min(self.end);
+            let window_end = window_start
+                .plus_calendar_days(CHUNK_DAYS - 1)
+                .min(self.end);
             chunks.push(SeedRange {
                 start: window_start,
                 end: window_end,
             });
-            window_start = window_end + Duration::days(1);
+            window_start = window_end.plus_calendar_days(1);
         }
         chunks
     }
@@ -73,19 +75,20 @@ impl SeedRange {
     /// where the database is empty, and the published calendar is one of the things that is not
     /// there yet. A weekend costs one request and answers with nothing, which is cheap enough that
     /// filtering is not worth a dependency on data the caller may not have.
-    fn dates(&self) -> Vec<NaiveDate> {
+    fn dates(&self) -> Vec<SessionDate> {
         let mut dates = Vec::new();
         let mut date = self.start;
         while date <= self.end {
             dates.push(date);
-            date += Duration::days(1);
+            date = date.plus_calendar_days(1);
         }
         dates
     }
 }
 
-fn parse_date(value: &str) -> Result<NaiveDate, String> {
+fn parse_date(value: &str) -> Result<SessionDate, String> {
     NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map(SessionDate::from_date)
         .map_err(|error| format!("Invalid date '{value}': expected YYYY-MM-DD ({error})"))
 }
 
@@ -93,7 +96,7 @@ fn parse_date(value: &str) -> Result<NaiveDate, String> {
 ///
 /// `today` is a parameter rather than read from the clock here, because a function that reads the
 /// wall clock cannot be tested across the hours where the Eastern date and the UTC date disagree.
-fn parse_arguments(arguments: &[String], today: NaiveDate) -> Result<SeedRange, String> {
+fn parse_arguments(arguments: &[String], today: SessionDate) -> Result<SeedRange, String> {
     match arguments {
         [] => Err(format!("Start date is required\n{USAGE}")),
         [start] => SeedRange::new(parse_date(start)?, today),
@@ -133,7 +136,7 @@ async fn main() {
     let tracing_guard = init_tracing("seed-equity-bars.log", Some("info"), "seed-equity-bars");
 
     let arguments: Vec<String> = std::env::args().skip(1).collect();
-    let range = match parse_arguments(&arguments, eastern_date(Utc::now())) {
+    let range = match parse_arguments(&arguments, SessionDate::at(Utc::now())) {
         Ok(range) => range,
         Err(message) => {
             eprintln!("{message}");
@@ -246,8 +249,10 @@ async fn seed_chunk(
 mod tests {
     use super::*;
 
-    fn date(value: &str) -> NaiveDate {
-        NaiveDate::parse_from_str(value, "%Y-%m-%d").expect("a valid test date")
+    fn date(value: &str) -> SessionDate {
+        SessionDate::from_date(
+            NaiveDate::parse_from_str(value, "%Y-%m-%d").expect("a valid test date"),
+        )
     }
 
     #[test]
@@ -319,13 +324,13 @@ mod tests {
         for window in chunks.windows(2) {
             assert_eq!(
                 window[1].start,
-                window[0].end + Duration::days(1),
+                window[0].end.plus_calendar_days(1),
                 "chunks must abut without a gap or an overlap"
             );
         }
 
         for chunk in &chunks {
-            let span = (chunk.end - chunk.start).num_days() + 1;
+            let span = (chunk.end.date() - chunk.start.date()).num_days() + 1;
             assert!(span <= CHUNK_DAYS, "chunk of {span} days exceeds the bound");
         }
     }
@@ -353,7 +358,7 @@ mod tests {
         assert_eq!(dates[0], date("2026-01-01"));
         assert_eq!(dates[9], date("2026-01-10"));
         for window in dates.windows(2) {
-            assert_eq!(window[1], window[0] + Duration::days(1));
+            assert_eq!(window[1], window[0].plus_calendar_days(1));
         }
     }
 

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -15,7 +15,7 @@ use std::io::Cursor;
 use aws_sdk_s3::operation::get_object::GetObjectError;
 use burn::module::AutodiffModule;
 use burn::tensor::backend::Backend;
-use chrono::{Duration, NaiveDate, Utc};
+use chrono::Utc;
 use polars::prelude::*;
 use tracing::{error, info, warn};
 
@@ -24,7 +24,7 @@ use fund::common::massive::MassiveClient;
 use fund::common::observability::init_tracing;
 use fund::common::types::{MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
 use fund::data::bars;
-use fund::data::calendar::{eastern_date, is_weekend};
+use fund::data::calendar::SessionDate;
 use fund::data::details;
 use fund::models::tide::artifact::{
     candidate_folders_descending, list_run_folders, package_dir_to_tar_gz, upload_artifact,
@@ -95,9 +95,22 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let s3_client = fund::common::aws::s3_client().await;
 
+    // One instant for the whole run, resolved once to its Eastern session.
+    //
+    // The stages disagreed before: the fetch keyed archive partitions by the Eastern date while the
+    // load walked them by the UTC date, and a run that crossed UTC midnight -- which one starting at
+    // 23:00 UTC does whenever training takes over an hour -- read a window shifted a day off the one
+    // it had just written, silently dropping its oldest session. Deriving every date below from this
+    // one value is what makes the stages agree regardless of how long training takes.
+    let now = Utc::now();
+    let session = SessionDate::at(now);
+
     info!(
         bucket,
-        artifact_prefix, lookback_days, "Starting tide training"
+        artifact_prefix,
+        lookback_days,
+        %session,
+        "Starting tide training"
     );
 
     // --- stage one: fetch and archive ---
@@ -105,14 +118,14 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // A failure here is logged and stepped over rather than fatal. The archive already holds a
     // year; a night with no new partition trains on 364 days instead of 365, which is a far better
     // outcome than publishing no model because Massive was briefly unreachable.
-    match fetch_and_archive(&s3_client, &bucket).await {
+    match fetch_and_archive(&s3_client, &bucket, session).await {
         Ok(rows) => info!(rows, "Session bars archived"),
         Err(error) => warn!(%error, "Fetch stage failed; training on the existing archive"),
     }
 
     // --- stage two: load the accumulated window ---
 
-    let equity_bars = load_archived_bars(&s3_client, &bucket, lookback_days).await?;
+    let equity_bars = load_archived_bars(&s3_client, &bucket, lookback_days, session).await?;
     info!(rows = equity_bars.height(), "Loaded equity bars from S3");
 
     let equity_details = details::details_to_dataframe(&details::parse_embedded_details()?)?;
@@ -196,7 +209,17 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // The run identifier is a sortable timestamp, and the application reads its date prefix to
     // report how stale the model it is serving is. A different format would silently turn that
     // staleness field into "unknown" on every session.
-    let timestamp = Utc::now().format("%Y-%m-%d-%H-%M-%S-%3f").to_string();
+    //
+    // Eastern, not UTC, because that date prefix is read back as a *session*. Stamped in UTC it
+    // named the session after next whenever training crossed midnight, so the same artifact
+    // reported a different staleness depending only on how long it had taken to build.
+    //
+    // Still sortable: `resolve_artifact_key` picks the lexicographically greatest folder, and
+    // Eastern local time is monotonic except across the hour that repeats on the autumn transition
+    // -- 01:00 Eastern on a Sunday, which a weekday 23:00 UTC schedule cannot reach.
+    let timestamp = fund::data::calendar::eastern_datetime(now)
+        .format("%Y-%m-%d-%H-%M-%S-%3f")
+        .to_string();
     let model_key = format!("{artifact_prefix}{timestamp}/output/model.tar.gz");
     upload_artifact(
         &s3_client,
@@ -241,16 +264,16 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         ),
     }
 
-    let end_date = Utc::now().date_naive();
-    let start_date = end_date - Duration::days(lookback_days);
+    let end_date = session;
+    let start_date = end_date.plus_calendar_days(-lookback_days);
     let metadata = serde_json::json!({
         "artifact_timestamp": timestamp,
         "input_size": input_size,
         "input_length": INPUT_LENGTH,
         "output_length": OUTPUT_LENGTH,
         "lookback_days": lookback_days,
-        "start_date": start_date.format("%Y-%m-%d").to_string(),
-        "end_date": end_date.format("%Y-%m-%d").to_string(),
+        "start_date": start_date.to_string(),
+        "end_date": end_date.to_string(),
         "epochs_run": losses.len(),
         "final_train_loss": losses.last().copied().unwrap_or_default(),
         "metrics": metrics,
@@ -360,13 +383,14 @@ fn training_configuration() -> Result<TrainConfiguration, Box<dyn std::error::Er
 async fn fetch_and_archive(
     s3_client: &aws_sdk_s3::Client,
     bucket: &str,
+    session: SessionDate,
 ) -> Result<usize, Box<dyn std::error::Error>> {
     let client = MassiveClient::from_env()?;
 
-    let end = most_recent_weekday(eastern_date(Utc::now()));
-    let start = end - Duration::days(FETCH_LOOKBACK_SESSIONS * 2);
-    let dates: Vec<NaiveDate> = (0..=(end - start).num_days())
-        .map(|offset| start + Duration::days(offset))
+    let end = most_recent_weekday(session);
+    let start = end.plus_calendar_days(-(FETCH_LOOKBACK_SESSIONS * 2));
+    let dates: Vec<SessionDate> = (0..=(end.date() - start.date()).num_days())
+        .map(|offset| start.plus_calendar_days(offset))
         .collect();
     info!(%start, %end, dates = dates.len(), "Fetching session bars from Massive");
 
@@ -385,18 +409,18 @@ async fn fetch_and_archive(
 
     // One partition per session date, so the archive stays date-partitioned and the loader below
     // can walk it a day at a time.
-    let mut by_date: std::collections::BTreeMap<NaiveDate, Vec<_>> =
+    let mut by_date: std::collections::BTreeMap<SessionDate, Vec<_>> =
         std::collections::BTreeMap::new();
     for bar in fetched.bars {
         by_date
-            .entry(eastern_date(bar.timestamp()))
+            .entry(SessionDate::at(bar.timestamp()))
             .or_default()
             .push(bar);
     }
 
     let mut written = 0;
     for (date, bars_for_date) in by_date {
-        let key = date_partitioned_key(BAR_ARCHIVE_PREFIX, date);
+        let key = date_partitioned_key(BAR_ARCHIVE_PREFIX, date.date());
         let fetched_frame = bars::bars_to_dataframe(&bars_for_date)?;
 
         // Merged with whatever the partition already holds, not written over it. This matters less
@@ -483,10 +507,10 @@ fn merge_partitions(
 /// A weekday check rather than a calendar lookup. The trainer would otherwise need the published
 /// calendar for one date arithmetic, and a request for a holiday's partition simply returns nothing
 /// — which the loader below already steps over.
-fn most_recent_weekday(date: NaiveDate) -> NaiveDate {
+fn most_recent_weekday(date: SessionDate) -> SessionDate {
     let mut candidate = date;
-    while is_weekend(candidate) {
-        candidate = candidate.pred_opt().unwrap_or(candidate);
+    while candidate.is_weekend() {
+        candidate = candidate.plus_calendar_days(-1);
     }
     candidate
 }
@@ -500,21 +524,19 @@ async fn load_archived_bars(
     s3_client: &aws_sdk_s3::Client,
     bucket: &str,
     lookback_days: i64,
+    session: SessionDate,
 ) -> Result<DataFrame, Box<dyn std::error::Error>> {
-    let end_date = Utc::now().date_naive();
-    let start_date = end_date - Duration::days(lookback_days);
+    let end_date = session;
+    let start_date = end_date.plus_calendar_days(-lookback_days);
 
     let mut frames: Vec<LazyFrame> = Vec::new();
     let mut date = start_date;
     while date <= end_date {
-        let key = date_partitioned_key(BAR_ARCHIVE_PREFIX, date);
+        let key = date_partitioned_key(BAR_ARCHIVE_PREFIX, date.date());
         if let Some(frame) = read_partition(s3_client, bucket, &key).await? {
             frames.push(frame.lazy());
         }
-        date = match date.succ_opt() {
-            Some(next_date) => next_date,
-            None => break,
-        };
+        date = date.plus_calendar_days(1);
     }
 
     if frames.is_empty() {
@@ -577,6 +599,7 @@ async fn fetch_prior_crps(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::NaiveDate;
     use serial_test::serial;
 
     /// RAII guard restoring one environment variable on drop, so an assertion failure cannot leave
@@ -609,8 +632,10 @@ mod tests {
         }
     }
 
-    fn date(year: i32, month: u32, day: u32) -> NaiveDate {
-        NaiveDate::from_ymd_opt(year, month, day).expect("test date must be valid")
+    fn date(year: i32, month: u32, day: u32) -> SessionDate {
+        SessionDate::from_date(
+            NaiveDate::from_ymd_opt(year, month, day).expect("test date must be valid"),
+        )
     }
 
     #[test]

--- a/src/dashboard/cache.rs
+++ b/src/dashboard/cache.rs
@@ -11,7 +11,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use serde_json::Value;
 use sqlx::postgres::PgListener;
@@ -21,6 +21,7 @@ use tracing::{error, info, warn};
 
 use crate::common::events::Notification;
 use crate::common::types::{PairID, Ticker};
+use crate::data::calendar::SessionDate;
 use crate::portfolio::pairs::CloseReason;
 
 /// How often the background task refreshes every view from PostgreSQL.
@@ -35,7 +36,7 @@ const EVENT_BUFFER_CAPACITY: usize = 500;
 /// One session's account state, as Alpaca reported it after the close.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AccountSnapshot {
-    pub session_date: NaiveDate,
+    pub session_date: SessionDate,
     pub equity: Decimal,
     pub cash: Decimal,
     pub buying_power: Decimal,
@@ -268,7 +269,7 @@ pub fn spawn_event_listener_task(state: SharedState, pool: PgPool) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
+    use chrono::{NaiveDate, TimeZone};
     use std::str::FromStr;
 
     fn decimal(value: &str) -> Decimal {
@@ -277,7 +278,9 @@ mod tests {
 
     fn snapshot(long: &str, short: &str) -> AccountSnapshot {
         AccountSnapshot {
-            session_date: NaiveDate::from_ymd_opt(2026, 7, 31).expect("a valid test date"),
+            session_date: SessionDate::from_date(
+                NaiveDate::from_ymd_opt(2026, 7, 31).expect("a valid test date"),
+            ),
             equity: decimal("100000"),
             cash: decimal("50000"),
             buying_power: decimal("200000"),

--- a/src/dashboard/database.rs
+++ b/src/dashboard/database.rs
@@ -8,7 +8,7 @@
 //! it was handed, which is what makes win rate, profit factor, and period returns testable without
 //! a database.
 
-use chrono::{DateTime, Datelike, Duration, NaiveDate, Utc};
+use chrono::{DateTime, Datelike, NaiveDate, Utc};
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
 use sqlx::{PgPool, Row};
@@ -18,6 +18,7 @@ use crate::common::types::{PairID, Ticker};
 use crate::dashboard::cache::{
     AccountSnapshot, ClosedPair, ClosedSummary, EventEntry, OpenPair, PeriodReturns, Prediction,
 };
+use crate::data::calendar::SessionDate;
 use crate::portfolio::pairs::CloseReason;
 
 /// Sessions of account history fetched for the equity curve.
@@ -88,7 +89,7 @@ async fn fetch_equity_history(pool: &PgPool) -> Result<Vec<AccountSnapshot>, sql
     rows.into_iter()
         .map(|row| {
             Ok(AccountSnapshot {
-                session_date: row.try_get("session_date")?,
+                session_date: SessionDate::from_date(row.try_get("session_date")?),
                 equity: row.try_get("equity")?,
                 cash: row.try_get("cash")?,
                 buying_power: row.try_get("buying_power")?,
@@ -301,7 +302,7 @@ fn percentage_change(baseline: Decimal, latest: Decimal) -> Option<f64> {
 /// exactly one week back is a Saturday two times in seven.
 fn baseline_at_or_before(
     history: &[AccountSnapshot],
-    cutoff: NaiveDate,
+    cutoff: SessionDate,
 ) -> Option<&AccountSnapshot> {
     history
         .iter()
@@ -316,15 +317,15 @@ pub fn compute_period_returns(history: &[AccountSnapshot]) -> PeriodReturns {
     };
 
     let horizon = |days: i64| {
-        baseline_at_or_before(history, latest.session_date - Duration::days(days))
+        baseline_at_or_before(history, latest.session_date.plus_calendar_days(-days))
             .and_then(|baseline| percentage_change(baseline.equity, latest.equity))
     };
 
     // Year to date measures from the last session of the previous year, so the first session of
     // January is a full day of performance rather than a flat zero.
-    let year_start = NaiveDate::from_ymd_opt(latest.session_date.year(), 1, 1);
+    let year_start = NaiveDate::from_ymd_opt(latest.session_date.date().year(), 1, 1);
     let year_to_date = year_start
-        .and_then(|start| baseline_at_or_before(history, start.pred_opt()?))
+        .and_then(|start| baseline_at_or_before(history, SessionDate::from_date(start.pred_opt()?)))
         .or_else(|| history.first())
         .and_then(|baseline| percentage_change(baseline.equity, latest.equity));
 
@@ -434,7 +435,7 @@ pub fn compute_closed_summary(closed: &[ClosedPair]) -> ClosedSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
+    use chrono::{Duration, TimeZone};
     use std::str::FromStr;
 
     fn decimal(value: &str) -> Decimal {
@@ -443,7 +444,9 @@ mod tests {
 
     fn snapshot(date: &str, equity: &str) -> AccountSnapshot {
         AccountSnapshot {
-            session_date: NaiveDate::parse_from_str(date, "%Y-%m-%d").expect("a valid test date"),
+            session_date: SessionDate::from_date(
+                NaiveDate::parse_from_str(date, "%Y-%m-%d").expect("a valid test date"),
+            ),
             equity: decimal(equity),
             cash: decimal("0"),
             buying_power: decimal("0"),

--- a/src/dashboard/html.rs
+++ b/src/dashboard/html.rs
@@ -30,13 +30,35 @@ pub fn render_html(state: &DashboardState) -> String {
     render_html_at(state, Utc::now())
 }
 
+/// Formats an instant for display: Eastern wall clock, with the zone stated.
+///
+/// Every timestamp on this page goes through here, so the page cannot mix zones. Eastern rather
+/// than UTC because that is the timezone the trading day has — rendered in UTC, the page disagreed
+/// with the session it was describing for the last four or five hours of every evening, which is
+/// exactly when an operator is checking whether the post-close jobs ran and exactly when the UTC
+/// date has already rolled over to tomorrow.
+///
+/// Elapsed times — [`format_age`], holding durations — are differences between two instants and
+/// carry no zone, so they do not come through here.
+fn eastern_stamp(instant: DateTime<Utc>, format: &str) -> String {
+    format!(
+        "{} ET",
+        crate::data::calendar::eastern_datetime(instant).format(format)
+    )
+}
+
 /// Renders the page as of `now`.
 ///
 /// The clock is a parameter so the age calculations can be tested at a fixed instant rather than
 /// whenever the suite happens to run.
 fn render_html_at(state: &DashboardState, now: DateTime<Utc>) -> String {
-    let date_string = now.format("%d-%b-%Y").to_string().to_uppercase();
-    let time_string = now.format("%H:%M:%S UTC").to_string();
+    // The date carries no suffix of its own; the time sits beside it in the header and states the
+    // zone for both.
+    let date_string = crate::data::calendar::eastern_datetime(now)
+        .format("%d-%b-%Y")
+        .to_string()
+        .to_uppercase();
+    let time_string = eastern_stamp(now, "%H:%M:%S");
     let updated = render_updated_line(state, now);
     let freshness = render_freshness_line(state, now);
     let account = render_account_section(state);
@@ -217,7 +239,7 @@ fn render_predictions_section(state: &DashboardState) -> String {
         (Some(run_id), Some(timestamp)) => format!(
             "Run {} at {}",
             html_escape(run_id),
-            timestamp.format("%Y-%m-%d %H:%M UTC")
+            eastern_stamp(timestamp, "%Y-%m-%d %H:%M")
         ),
         (Some(run_id), None) => format!("Run {}", html_escape(run_id)),
         _ => "Run unknown".to_string(),
@@ -259,7 +281,7 @@ fn render_closed_pairs_section(state: &DashboardState) -> String {
                 pair.entry_z_score,
                 html_escape(pair.close_reason.as_str()),
                 format_holding(pair.holding_hours()),
-                pair.closed_at.format("%Y-%m-%d %H:%M"),
+                eastern_stamp(pair.closed_at, "%Y-%m-%d %H:%M"),
             )
         })
         .collect();
@@ -304,7 +326,7 @@ fn render_events_section(state: &DashboardState) -> String {
         .map(|event| {
             format!(
                 r#"<tr><td>{}</td><td class="{}">{}</td><td>{}</td></tr>"#,
-                event.created_at.format("%Y-%m-%d %H:%M:%S"),
+                eastern_stamp(event.created_at, "%Y-%m-%d %H:%M:%S"),
                 event_css_class(&event.event_type),
                 html_escape(&event.event_type),
                 html_escape(&truncate_payload(&event.payload)),
@@ -559,7 +581,9 @@ mod tests {
 
         DashboardState {
             account: Some(AccountSnapshot {
-                session_date: NaiveDate::from_ymd_opt(2026, 7, 31).expect("a valid date"),
+                session_date: crate::data::calendar::SessionDate::from_date(
+                    NaiveDate::from_ymd_opt(2026, 7, 31).expect("a valid date"),
+                ),
                 equity: decimal("1234567.89"),
                 cash: decimal("500000"),
                 buying_power: decimal("2000000"),
@@ -632,6 +656,36 @@ mod tests {
         assert!(html.contains("run-2026-07-31"));
         assert!(html.contains("portfolio_evaluation_completed"));
         assert!(html.contains("convergence=1"));
+    }
+
+    /// Every timestamp on the page is Eastern, and none is left unlabelled.
+    ///
+    /// The fixture instant is 20:00 UTC, which is 16:00 Eastern, so the two cannot be confused: a
+    /// regression to UTC brings the 20:00 back and the assertion fails rather than passing on a
+    /// shared substring. The closed pair at 19:00 UTC and the event at 19:55 UTC are checked for
+    /// the same reason — they are the two columns that used to render with no zone at all.
+    #[test]
+    fn test_every_timestamp_renders_in_eastern_and_says_so() {
+        let html = render_html_at(&populated_state(), now());
+
+        assert!(html.contains("16:00:00 ET"), "the header must be Eastern");
+        assert!(
+            html.contains("2026-07-31 15:00 ET"),
+            "the closed pair's 19:00 UTC close must render as 15:00 Eastern"
+        );
+        assert!(
+            html.contains("2026-07-31 15:55:00 ET"),
+            "the event's 19:55 UTC instant must render as 15:55 Eastern"
+        );
+
+        assert!(
+            !html.contains("20:00:00"),
+            "the UTC wall clock must not appear anywhere"
+        );
+        assert!(
+            !html.contains("UTC"),
+            "no timestamp may still be labelled UTC"
+        );
     }
 
     /// A failed poll must say so. Serving the previous numbers under a header that reads "Updated

--- a/src/data/bars.rs
+++ b/src/data/bars.rs
@@ -10,13 +10,14 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use chrono::{DateTime, Duration, NaiveDate, Utc};
+use chrono::{DateTime, Duration, Utc};
 use polars::prelude::*;
 use sqlx::PgPool;
 use tracing::{info, warn};
 
 use crate::common::massive::{MassiveClient, MassiveError};
 use crate::common::types::{BarInterval, EquityBar, Ticker};
+use crate::data::calendar::SessionDate;
 
 /// Rows per insert chunk.
 ///
@@ -50,7 +51,7 @@ pub enum BarsError {
 #[derive(Debug, Default)]
 pub struct FetchedBars {
     pub bars: Vec<EquityBar>,
-    pub dates_failed: Vec<NaiveDate>,
+    pub dates_failed: Vec<SessionDate>,
 }
 
 /// Fetches whole-market daily bars for each of `dates`.
@@ -60,11 +61,11 @@ pub struct FetchedBars {
 ///
 /// A failed date is recorded and stepped over rather than aborting, which would discard every date
 /// already retrieved. The upsert makes re-running a range cheap.
-pub async fn fetch_daily_bars(client: &MassiveClient, dates: &[NaiveDate]) -> FetchedBars {
+pub async fn fetch_daily_bars(client: &MassiveClient, dates: &[SessionDate]) -> FetchedBars {
     let mut fetched = FetchedBars::default();
 
     for date in dates {
-        match client.fetch_grouped_daily(*date).await {
+        match client.fetch_grouped_daily(date.date()).await {
             Ok(bars) => fetched.bars.extend(bars),
             Err(error) => {
                 warn!(%date, %error, "Failed to fetch a session's bars, continuing");
@@ -363,7 +364,7 @@ pub type AlignedCloses = Arc<HashMap<Ticker, Vec<f64>>>;
 /// universe caches.
 #[derive(Default)]
 pub struct CloseHistoryCache {
-    inner: tokio::sync::Mutex<Option<(NaiveDate, AlignedCloses)>>,
+    inner: tokio::sync::Mutex<Option<(SessionDate, AlignedCloses)>>,
 }
 
 impl CloseHistoryCache {
@@ -383,7 +384,7 @@ impl CloseHistoryCache {
         sessions: usize,
         now: DateTime<Utc>,
     ) -> Result<AlignedCloses, BarsError> {
-        let today = crate::data::calendar::eastern_date(now);
+        let today = SessionDate::at(now);
 
         if let Some((cached_date, closes)) = self.inner.lock().await.as_ref() {
             if *cached_date == today {
@@ -400,8 +401,7 @@ impl CloseHistoryCache {
 
     /// Replaces the cached history. Used by tests and by the pre-open warm path.
     pub async fn install(&self, now: DateTime<Utc>, closes: HashMap<Ticker, Vec<f64>>) {
-        *self.inner.lock().await =
-            Some((crate::data::calendar::eastern_date(now), Arc::new(closes)));
+        *self.inner.lock().await = Some((SessionDate::at(now), Arc::new(closes)));
     }
 
     /// Drops the cached history so the next caller reloads it.

--- a/src/data/calendar.rs
+++ b/src/data/calendar.rs
@@ -32,13 +32,98 @@ const HORIZON_DAYS_FORWARD: i64 = 90;
 /// case. Thirty days is generous.
 const HORIZON_DAYS_BACKWARD: i64 = 30;
 
-/// The Eastern calendar date at an instant.
+/// A trading day, identified by its `America/New_York` calendar date.
 ///
-/// The trading day rolls over at Eastern midnight, not UTC midnight, and the two differ for five
-/// hours of every day. Every cache key, session comparison, and "is this still today" check in the
-/// system goes through here.
-pub fn eastern_date(instant: DateTime<Utc>) -> NaiveDate {
-    instant.with_timezone(&New_York).date_naive()
+/// The type exists to make a session and an instant impossible to confuse. Both used to be spelled
+/// `NaiveDate`/`DateTime`, and every timekeeping bug this system has had was that confusion: a
+/// session derived from `Utc::now().date_naive()`, a forecast stamped at UTC midnight, a session
+/// and its label computed from two separate expressions. None of those is expressible here.
+///
+/// There are exactly two ways in. [`SessionDate::at`] converts an instant, which is the only
+/// correct way to answer "what trading day is it now". [`SessionDate::from_date`] takes a date that
+/// is *already* a session — parsed from a command-line argument, read from a `DATE` column, or
+/// returned by an exchange API that publishes Eastern dates. A `NaiveDate` obtained any other way
+/// has no business becoming one of these.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
+#[serde(transparent)]
+pub struct SessionDate(NaiveDate);
+
+impl SessionDate {
+    /// The trading day an instant falls in.
+    ///
+    /// The trading day rolls over at Eastern midnight, not UTC midnight, and the two differ for
+    /// four or five hours of every day. Every cache key, session comparison, and "is this still
+    /// today" check in the system goes through here.
+    pub fn at(instant: DateTime<Utc>) -> Self {
+        Self(instant.with_timezone(&New_York).date_naive())
+    }
+
+    /// Wraps a date that is already known to be a session.
+    ///
+    /// For values that arrive as session dates rather than being derived from a clock: a parsed
+    /// argument, a `DATE` column, an exchange calendar entry. Deriving one from an instant is
+    /// [`SessionDate::at`]'s job, and going through `date_naive()` to reach here is the bug this
+    /// type prevents.
+    pub fn from_date(date: NaiveDate) -> Self {
+        Self(date)
+    }
+
+    /// The underlying calendar date, for formatting and for binding to a `DATE` column.
+    pub fn date(self) -> NaiveDate {
+        self.0
+    }
+
+    /// Midnight Eastern on this session, as the equivalent UTC instant.
+    ///
+    /// Eastern shifts at 02:00 so local midnight always exists, but `earliest()` with a UTC
+    /// fallback is used anyway so a timezone database change cannot panic a caller.
+    pub fn midnight(self) -> DateTime<Utc> {
+        let local_midnight = self
+            .0
+            .and_hms_opt(0, 0, 0)
+            .expect("midnight is a valid wall-clock time");
+        New_York
+            .from_local_datetime(&local_midnight)
+            .earliest()
+            .map(|zoned| zoned.with_timezone(&Utc))
+            .unwrap_or_else(|| local_midnight.and_utc())
+    }
+
+    /// The half-open UTC interval `[start, end)` covering this session.
+    ///
+    /// The inverse of [`SessionDate::at`], so queries can bound a timestamp column directly. A
+    /// predicate like `(created_at AT TIME ZONE 'America/New_York')::date = $1` hides the column
+    /// behind an expression, defeating chunk exclusion and the index — a one-day export becomes a
+    /// full scan. Resolving bounds here keeps `column >= $start AND column < $end` sargable.
+    pub fn bounds(self) -> (DateTime<Utc>, DateTime<Utc>) {
+        (self.midnight(), self.plus_calendar_days(1).midnight())
+    }
+
+    /// This session shifted by whole **calendar** days.
+    ///
+    /// Named for the distinction it must not lose: this steps over weekends and holidays, unlike
+    /// [`TradingCalendar::previous_trading_day`] and [`TradingCalendar::next_trading_day`], which
+    /// land on published sessions. Used to bound fetch ranges, where overshooting is free.
+    pub fn plus_calendar_days(self, days: i64) -> Self {
+        Self(self.0 + Duration::days(days))
+    }
+
+    /// Whether this date falls on a weekend.
+    ///
+    /// Not a substitute for [`TradingCalendar::is_trading_day`] — it knows nothing about holidays —
+    /// but useful for bounding a fetch range before the calendar is available.
+    pub fn is_weekend(self) -> bool {
+        matches!(
+            self.0.weekday(),
+            chrono::Weekday::Sat | chrono::Weekday::Sun
+        )
+    }
+}
+
+impl std::fmt::Display for SessionDate {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(formatter)
+    }
 }
 
 /// The Eastern wall-clock time at an instant.
@@ -46,31 +131,14 @@ pub fn eastern_time(instant: DateTime<Utc>) -> NaiveTime {
     instant.with_timezone(&New_York).time()
 }
 
-/// The half-open UTC interval `[start, end)` covering one Eastern calendar date.
+/// The Eastern wall-clock date and time at an instant.
 ///
-/// The inverse of [`eastern_date`], so queries can bound a timestamp column directly. A predicate
-/// like `(created_at AT TIME ZONE 'America/New_York')::date = $1` hides the column behind an
-/// expression, defeating chunk exclusion and the index — a one-day export becomes a full scan.
-/// Resolving bounds here keeps `column >= $start AND column < $end` sargable.
-///
-/// Eastern shifts at 02:00 so local midnight always exists, but `earliest()` with a UTC fallback is
-/// used anyway so a timezone database change cannot panic the export.
-pub fn eastern_day_bounds(date: NaiveDate) -> (DateTime<Utc>, DateTime<Utc>) {
-    let start = eastern_midnight(date);
-    let end = eastern_midnight(date + Duration::days(1));
-    (start, end)
-}
-
-/// Midnight Eastern on `date`, as the equivalent UTC instant.
-pub(crate) fn eastern_midnight(date: NaiveDate) -> DateTime<Utc> {
-    let local_midnight = date
-        .and_hms_opt(0, 0, 0)
-        .expect("midnight is a valid wall-clock time");
-    New_York
-        .from_local_datetime(&local_midnight)
-        .earliest()
-        .map(|zoned| zoned.with_timezone(&Utc))
-        .unwrap_or_else(|| local_midnight.and_utc())
+/// For callers that need both halves as one value — naming an artifact after the session that
+/// produced it, where the date must be the Eastern one and the time is what orders two runs within
+/// it. Reading [`SessionDate::at`] and [`eastern_time`] separately would work, but only because
+/// both resolve the same zone; taking them from one conversion means they cannot disagree.
+pub fn eastern_datetime(instant: DateTime<Utc>) -> chrono::NaiveDateTime {
+    instant.with_timezone(&New_York).naive_local()
 }
 
 /// Published trading sessions over a bounded horizon.
@@ -80,16 +148,20 @@ pub(crate) fn eastern_midnight(date: NaiveDate) -> DateTime<Utc> {
 /// with their real hours.
 #[derive(Debug, Clone, Default)]
 pub struct TradingCalendar {
-    days: BTreeMap<NaiveDate, CalendarDay>,
+    days: BTreeMap<SessionDate, CalendarDay>,
 }
 
 impl TradingCalendar {
     /// Builds a calendar from published days.
+    ///
+    /// This is the boundary where a date Alpaca sent over the wire becomes a [`SessionDate`].
+    /// [`CalendarDay`] stays on `NaiveDate` because it is what the transport parsed; everything
+    /// above this line deals in sessions.
     pub fn from_days(days: Vec<CalendarDay>) -> Self {
         Self {
             days: days
                 .into_iter()
-                .map(|day| (day.session_date(), day))
+                .map(|day| (SessionDate::from_date(day.session_date()), day))
                 .collect(),
         }
     }
@@ -99,12 +171,12 @@ impl TradingCalendar {
     /// A date outside the published horizon answers `false`. That is deliberately conservative: the
     /// caller cannot distinguish "holiday" from "we do not know", and the safe response to not
     /// knowing is to sit out rather than to trade into a closed or unknown market.
-    pub fn is_trading_day(&self, date: NaiveDate) -> bool {
+    pub fn is_trading_day(&self, date: SessionDate) -> bool {
         self.days.contains_key(&date)
     }
 
     /// The published session for `date`, if it trades.
-    pub fn session(&self, date: NaiveDate) -> Option<&CalendarDay> {
+    pub fn session(&self, date: SessionDate) -> Option<&CalendarDay> {
         self.days.get(&date)
     }
 
@@ -113,7 +185,7 @@ impl TradingCalendar {
     /// Distinct from [`TradingCalendar::is_trading_day`]: a date inside the horizon with no session
     /// is a holiday, while a date outside it is unknown. Both answer `false` to "does it trade",
     /// but only the second means the calendar needs refreshing.
-    pub fn covers(&self, date: NaiveDate) -> bool {
+    pub fn covers(&self, date: SessionDate) -> bool {
         match self.horizon() {
             Some((first, last)) => date >= first && date <= last,
             None => false,
@@ -121,7 +193,7 @@ impl TradingCalendar {
     }
 
     /// The first and last published dates, if any.
-    pub fn horizon(&self) -> Option<(NaiveDate, NaiveDate)> {
+    pub fn horizon(&self) -> Option<(SessionDate, SessionDate)> {
         let first = *self.days.keys().next()?;
         let last = *self.days.keys().next_back()?;
         Some((first, last))
@@ -139,17 +211,17 @@ impl TradingCalendar {
     /// The most recent trading day strictly before `date`.
     ///
     /// This is what the post-close bar sync asks for: the session whose bars are now final.
-    pub fn previous_trading_day(&self, date: NaiveDate) -> Option<NaiveDate> {
+    pub fn previous_trading_day(&self, date: SessionDate) -> Option<SessionDate> {
         self.days.range(..date).next_back().map(|(day, _)| *day)
     }
 
     /// The next trading day on or after `date`.
-    pub fn next_trading_day(&self, date: NaiveDate) -> Option<NaiveDate> {
+    pub fn next_trading_day(&self, date: SessionDate) -> Option<SessionDate> {
         self.days.range(date..).next().map(|(day, _)| *day)
     }
 
     /// Every trading day in an inclusive range.
-    pub fn trading_days_in_range(&self, start: NaiveDate, end: NaiveDate) -> Vec<NaiveDate> {
+    pub fn trading_days_in_range(&self, start: SessionDate, end: SessionDate) -> Vec<SessionDate> {
         self.days.range(start..=end).map(|(day, _)| *day).collect()
     }
 
@@ -161,7 +233,7 @@ impl TradingCalendar {
     /// close from the published calendar rather than assuming 16:00 is what makes it correct on a
     /// half-day.
     pub fn minutes_until_close(&self, instant: DateTime<Utc>) -> Option<i64> {
-        let session = self.session(eastern_date(instant))?;
+        let session = self.session(SessionDate::at(instant))?;
         let now = eastern_time(instant);
         if now >= session.session_close() {
             return None;
@@ -171,7 +243,7 @@ impl TradingCalendar {
 
     /// Whether the regular session is open at `instant`.
     pub fn is_open_at(&self, instant: DateTime<Utc>) -> bool {
-        match self.session(eastern_date(instant)) {
+        match self.session(SessionDate::at(instant)) {
             Some(session) => {
                 let now = eastern_time(instant);
                 now >= session.session_open() && now < session.session_close()
@@ -188,7 +260,7 @@ impl TradingCalendar {
 /// rather than an elapsed duration means the rollover invalidates without a timer.
 #[derive(Default)]
 pub struct CalendarCache {
-    inner: tokio::sync::Mutex<Option<(NaiveDate, TradingCalendar)>>,
+    inner: tokio::sync::Mutex<Option<(SessionDate, TradingCalendar)>>,
 }
 
 impl CalendarCache {
@@ -206,7 +278,7 @@ impl CalendarCache {
         client: &TradingClient,
         now: DateTime<Utc>,
     ) -> Result<TradingCalendar, ClientError> {
-        let today = eastern_date(now);
+        let today = SessionDate::at(now);
 
         if let Some((cached_date, calendar)) = self.inner.lock().await.as_ref() {
             if *cached_date == today {
@@ -214,9 +286,10 @@ impl CalendarCache {
             }
         }
 
-        let start = today - Duration::days(HORIZON_DAYS_BACKWARD);
-        let end = today + Duration::days(HORIZON_DAYS_FORWARD);
-        let calendar = TradingCalendar::from_days(client.fetch_calendar(start, end).await?);
+        let start = today.plus_calendar_days(-HORIZON_DAYS_BACKWARD);
+        let end = today.plus_calendar_days(HORIZON_DAYS_FORWARD);
+        let calendar =
+            TradingCalendar::from_days(client.fetch_calendar(start.date(), end.date()).await?);
 
         if calendar.is_empty() {
             // Reported rather than cached: an empty calendar would otherwise pin "nothing trades"
@@ -235,29 +308,21 @@ impl CalendarCache {
 
     /// Replaces the cached calendar. Used by tests and by the pre-open warm path.
     pub async fn install(&self, now: DateTime<Utc>, calendar: TradingCalendar) {
-        *self.inner.lock().await = Some((eastern_date(now), calendar));
+        *self.inner.lock().await = Some((SessionDate::at(now), calendar));
     }
-}
-
-/// Whether `date` falls on a weekend.
-///
-/// Not a substitute for [`TradingCalendar::is_trading_day`] — it knows nothing about holidays — but
-/// useful for bounding a fetch range before the calendar is available.
-pub fn is_weekend(date: NaiveDate) -> bool {
-    matches!(date.weekday(), chrono::Weekday::Sat | chrono::Weekday::Sun)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn date(year: i32, month: u32, day: u32) -> NaiveDate {
-        NaiveDate::from_ymd_opt(year, month, day).unwrap()
+    fn date(year: i32, month: u32, day: u32) -> SessionDate {
+        SessionDate::from_date(NaiveDate::from_ymd_opt(year, month, day).unwrap())
     }
 
-    fn day(date_value: NaiveDate, open: (u32, u32), close: (u32, u32)) -> CalendarDay {
+    fn day(date_value: SessionDate, open: (u32, u32), close: (u32, u32)) -> CalendarDay {
         CalendarDay::new(
-            date_value,
+            date_value.date(),
             NaiveTime::from_hms_opt(open.0, open.1, 0).unwrap(),
             NaiveTime::from_hms_opt(close.0, close.1, 0).unwrap(),
         )
@@ -397,10 +462,10 @@ mod tests {
     #[test]
     fn test_eastern_date_rolls_at_eastern_midnight() {
         let late_evening = "2026-06-11T03:00:00Z".parse::<DateTime<Utc>>().unwrap();
-        assert_eq!(eastern_date(late_evening), date(2026, 6, 10));
+        assert_eq!(SessionDate::at(late_evening), date(2026, 6, 10));
 
         let morning = "2026-06-11T13:00:00Z".parse::<DateTime<Utc>>().unwrap();
-        assert_eq!(eastern_date(morning), date(2026, 6, 11));
+        assert_eq!(SessionDate::at(morning), date(2026, 6, 11));
     }
 
     /// Daylight saving must be handled by the timezone database, not by an offset constant.
@@ -423,7 +488,7 @@ mod tests {
     /// Eastern is UTC-4, so the day runs 04:00 to 04:00 UTC.
     #[test]
     fn test_eastern_day_bounds_span_the_local_day_in_summer() {
-        let (start, end) = eastern_day_bounds(date(2026, 6, 10));
+        let (start, end) = date(2026, 6, 10).bounds();
         assert_eq!(start.to_rfc3339(), "2026-06-10T04:00:00+00:00");
         assert_eq!(end.to_rfc3339(), "2026-06-11T04:00:00+00:00");
         assert_eq!((end - start).num_hours(), 24);
@@ -433,7 +498,7 @@ mod tests {
     /// get one of these two cases wrong.
     #[test]
     fn test_eastern_day_bounds_span_the_local_day_in_winter() {
-        let (start, end) = eastern_day_bounds(date(2026, 1, 14));
+        let (start, end) = date(2026, 1, 14).bounds();
         assert_eq!(start.to_rfc3339(), "2026-01-14T05:00:00+00:00");
         assert_eq!(end.to_rfc3339(), "2026-01-15T05:00:00+00:00");
     }
@@ -442,14 +507,14 @@ mod tests {
     /// would silently include or exclude an hour of rows on exactly these two days a year.
     #[test]
     fn test_eastern_day_bounds_handle_daylight_saving_transitions() {
-        let (spring_start, spring_end) = eastern_day_bounds(date(2026, 3, 8));
+        let (spring_start, spring_end) = date(2026, 3, 8).bounds();
         assert_eq!(
             (spring_end - spring_start).num_hours(),
             23,
             "spring forward is a 23-hour day"
         );
 
-        let (autumn_start, autumn_end) = eastern_day_bounds(date(2026, 11, 1));
+        let (autumn_start, autumn_end) = date(2026, 11, 1).bounds();
         assert_eq!(
             (autumn_end - autumn_start).num_hours(),
             25,
@@ -462,17 +527,59 @@ mod tests {
     #[test]
     fn test_eastern_day_bounds_round_trip_against_eastern_date() {
         let day = date(2026, 6, 10);
-        let (start, end) = eastern_day_bounds(day);
-        assert_eq!(eastern_date(start), day);
-        assert_eq!(eastern_date(end - Duration::seconds(1)), day);
-        assert_eq!(eastern_date(end), day + Duration::days(1));
+        let (start, end) = day.bounds();
+        assert_eq!(SessionDate::at(start), day);
+        assert_eq!(SessionDate::at(end - Duration::seconds(1)), day);
+        assert_eq!(SessionDate::at(end), day.plus_calendar_days(1));
+    }
+
+    /// The case the trainer's artifact identifier depends on. A run that starts at 23:00 UTC and
+    /// takes over an hour finishes on the *next* UTC date but the same Eastern evening, so a
+    /// UTC-formatted identifier names the session after the one it was built for.
+    #[test]
+    fn test_eastern_datetime_names_the_session_the_instant_belongs_to() {
+        // 00:30 UTC on 1 August is 20:30 on 31 July in New York.
+        let after_utc_midnight = "2026-08-01T00:30:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        // The precondition, so this cannot pass by agreeing with UTC: the UTC date is a day later.
+        assert_eq!(after_utc_midnight.date_naive(), date(2026, 8, 1).date());
+
+        assert_eq!(
+            eastern_datetime(after_utc_midnight).date(),
+            date(2026, 7, 31).date()
+        );
+        assert_eq!(
+            eastern_datetime(after_utc_midnight)
+                .format("%Y-%m-%d-%H-%M-%S")
+                .to_string(),
+            "2026-07-31-20-30-00"
+        );
+    }
+
+    /// The two must not be able to disagree — the run identifier's date prefix is read back and
+    /// compared against a date produced by `SessionDate::at`.
+    #[test]
+    fn test_eastern_datetime_agrees_with_eastern_date() {
+        for instant in [
+            "2026-08-01T00:30:00Z",
+            "2026-01-14T13:30:00Z",
+            "2026-03-08T07:00:00Z",
+            "2026-11-01T05:30:00Z",
+        ] {
+            let parsed = instant.parse::<DateTime<Utc>>().unwrap();
+            assert_eq!(
+                eastern_datetime(parsed).date(),
+                SessionDate::at(parsed).date(),
+                "{instant} disagreed"
+            );
+        }
     }
 
     #[test]
     fn test_is_weekend() {
-        assert!(is_weekend(date(2026, 11, 28)));
-        assert!(is_weekend(date(2026, 11, 29)));
-        assert!(!is_weekend(date(2026, 11, 27)));
+        assert!(date(2026, 11, 28).is_weekend());
+        assert!(date(2026, 11, 29).is_weekend());
+        assert!(!date(2026, 11, 27).is_weekend());
     }
 
     #[tokio::test]

--- a/src/data/calendar.rs
+++ b/src/data/calendar.rs
@@ -40,10 +40,17 @@ const HORIZON_DAYS_BACKWARD: i64 = 30;
 /// and its label computed from two separate expressions. None of those is expressible here.
 ///
 /// There are exactly two ways in. [`SessionDate::at`] converts an instant, which is the only
-/// correct way to answer "what trading day is it now". [`SessionDate::from_date`] takes a date that
-/// is *already* a session — parsed from a command-line argument, read from a `DATE` column, or
-/// returned by an exchange API that publishes Eastern dates. A `NaiveDate` obtained any other way
-/// has no business becoming one of these.
+/// correct way to answer "what trading day is it now". [`SessionDate::from_date`] takes a date
+/// already expressed in Eastern terms — parsed from a command-line argument, read from a `DATE`
+/// column, or returned by an exchange API that publishes Eastern dates. A `NaiveDate` obtained any
+/// other way, and a UTC date in particular, has no business becoming one of these.
+///
+/// **What it guarantees is the timezone, not tradability.** A `SessionDate` is a calendar date in
+/// the frame the exchange keeps; it is not proof that the market opens that day. Weekends and
+/// holidays are perfectly representable, and [`SessionDate::plus_calendar_days`] will land on them.
+/// Whether a date trades is [`TradingCalendar::is_trading_day`]'s question, and it is the only
+/// thing that can answer it — the calendar is fetched from Alpaca, and a holiday table in the type
+/// system would be a second source that can disagree.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
 #[serde(transparent)]
 pub struct SessionDate(NaiveDate);

--- a/src/data/export.rs
+++ b/src/data/export.rs
@@ -14,13 +14,13 @@
 
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client as S3Client;
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use polars::prelude::*;
 use sqlx::PgPool;
 use tracing::{info, warn};
 
 use crate::common::aws::date_partitioned_key;
-use crate::data::calendar::eastern_day_bounds;
+use crate::data::calendar::SessionDate;
 
 /// What one nightly export accomplished.
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -51,7 +51,7 @@ pub async fn export_database(
     pool: &PgPool,
     s3_client: &S3Client,
     bucket: &str,
-    date: NaiveDate,
+    date: SessionDate,
 ) -> ExportSummary {
     let mut summary = ExportSummary::default();
 
@@ -59,7 +59,7 @@ pub async fn export_database(
         ($dataset:expr, $prefix:expr, $frame:expr) => {
             match $frame.await {
                 Ok(mut frame) => {
-                    let key = date_partitioned_key($prefix, date);
+                    let key = date_partitioned_key($prefix, date.date());
                     match write_frame(s3_client, bucket, &key, &mut frame).await {
                         Ok(()) => summary
                             .exported
@@ -76,7 +76,7 @@ pub async fn export_database(
 
     // Resolved once and passed to every incremental query. Bounding the timestamp column directly
     // keeps the predicate sargable; see `eastern_day_bounds`.
-    let (start, end) = eastern_day_bounds(date);
+    let (start, end) = date.bounds();
 
     export!("events", "exports/events", events_frame(pool, start, end));
     export!(

--- a/src/data/universe.rs
+++ b/src/data/universe.rs
@@ -15,13 +15,13 @@
 
 use std::collections::HashSet;
 
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 use tracing::info;
 
 use crate::common::alpaca::{ClientError, TradableAssets, TradingClient};
 use crate::common::types::{BarInterval, Ticker, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
-use crate::data::calendar::eastern_date;
+use crate::data::calendar::SessionDate;
 
 /// Trailing window over which liquidity is averaged.
 ///
@@ -149,9 +149,9 @@ impl Universe {
 /// threshold and reject the entire universe.
 pub async fn load_liquidity(
     pool: &PgPool,
-    as_of: NaiveDate,
+    as_of: SessionDate,
 ) -> Result<Vec<LiquidityRow>, sqlx::Error> {
-    let start = as_of - chrono::Duration::days(LIQUIDITY_LOOKBACK_DAYS);
+    let start = as_of.plus_calendar_days(-LIQUIDITY_LOOKBACK_DAYS);
     let rows = sqlx::query!(
         r#"
         SELECT ticker AS "ticker!",
@@ -163,10 +163,7 @@ pub async fn load_liquidity(
         GROUP BY ticker
         "#,
         BarInterval::OneDay.as_str(),
-        start
-            .and_hms_opt(0, 0, 0)
-            .expect("midnight is a valid time")
-            .and_utc(),
+        start.midnight(),
     )
     .fetch_all(pool)
     .await?;
@@ -187,7 +184,7 @@ pub async fn load_liquidity(
 /// restart mid-session repopulates rather than trading an empty universe until the next morning.
 #[derive(Default)]
 pub struct UniverseCache {
-    inner: tokio::sync::Mutex<Option<(NaiveDate, Universe)>>,
+    inner: tokio::sync::Mutex<Option<(SessionDate, Universe)>>,
 }
 
 impl UniverseCache {
@@ -209,7 +206,7 @@ impl UniverseCache {
         pool: &PgPool,
         now: DateTime<Utc>,
     ) -> Result<Universe, UniverseError> {
-        let today = eastern_date(now);
+        let today = SessionDate::at(now);
 
         if let Some((cached_date, universe)) = self.inner.lock().await.as_ref() {
             if *cached_date == today {
@@ -237,7 +234,7 @@ impl UniverseCache {
 
     /// Replaces the cached universe. Used by tests and by the pre-open warm path.
     pub async fn install(&self, now: DateTime<Utc>, universe: Universe) {
-        *self.inner.lock().await = Some((eastern_date(now), universe));
+        *self.inner.lock().await = Some((SessionDate::at(now), universe));
     }
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -10,7 +10,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use chrono::{DateTime, Duration, NaiveDate, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use serde_json::{json, Value};
 use sqlx::PgPool;
 use tracing::{error, info, warn};
@@ -21,7 +21,7 @@ use crate::common::events::{self, Command, EventError};
 use crate::common::massive::MassiveClient;
 use crate::common::types::BarInterval;
 use crate::data::bars::{self, CloseHistoryCache, HISTORY_LOOKBACK_DAYS};
-use crate::data::calendar::{eastern_date, CalendarCache, TradingCalendar};
+use crate::data::calendar::{CalendarCache, SessionDate, TradingCalendar};
 use crate::data::details;
 use crate::data::export;
 use crate::data::purge;
@@ -240,7 +240,7 @@ async fn dispatch(state: &ServiceState, command: Command) -> Result<Value, Handl
 /// rather than on schedules of their own — both only matter immediately before a session.
 async fn handle_predictions(state: &ServiceState) -> Result<Value, HandlerError> {
     let now = Utc::now();
-    let today = eastern_date(now);
+    let today = SessionDate::at(now);
 
     let calendar = state.calendar_cache.get(&state.trading, now).await?;
     if !calendar.is_trading_day(today) {
@@ -282,14 +282,16 @@ async fn handle_predictions(state: &ServiceState) -> Result<Value, HandlerError>
         artifact::download_and_load_model(&state.s3_client, &state.bucket, &artifact_key, None)
             .await?;
 
-    let artifact_age_days = artifact_age_days(model_state.run_id(), today);
-    if artifact_age_days.is_some_and(|age| age >= 1) {
-        // Not an error and not an event of its own. Running on yesterday's model is a normal
-        // outcome of two machines that share no database, and the age is recorded here so a session
-        // that was decided by a stale model says so in its own completion row.
+    let artifact_staleness_sessions =
+        artifact_staleness_sessions(model_state.run_id(), &calendar, today);
+    if artifact_staleness_sessions.is_some_and(|sessions| sessions >= 1) {
+        // Not an error and not an event of its own. Running on an older model is a normal outcome
+        // of two machines that share no database, and the staleness is recorded here so a session
+        // that was decided by one says so in its own completion row.
         warn!(
             run_id = model_state.run_id(),
-            artifact_age_days, "Predictions are running on a model older than today"
+            artifact_staleness_sessions,
+            "Predictions are running on a model that missed at least one session"
         );
     }
 
@@ -301,7 +303,7 @@ async fn handle_predictions(state: &ServiceState) -> Result<Value, HandlerError>
         "correlation_id": correlation_id,
         "model_run_id": model_state.run_id(),
         "artifact_key": artifact_key,
-        "artifact_age_days": artifact_age_days,
+        "artifact_staleness_sessions": artifact_staleness_sessions,
         "predictions": predictions,
         "rows_written": rows,
         "universe": universe.len(),
@@ -355,7 +357,7 @@ async fn run_inference(
 /// Every five minutes: price the book, close what should close, open into vacant slots.
 async fn handle_portfolio_evaluation(state: &ServiceState) -> Result<Value, HandlerError> {
     let now = Utc::now();
-    let today = eastern_date(now);
+    let today = SessionDate::at(now);
 
     let calendar = state.calendar_cache.get(&state.trading, now).await?;
     if !calendar.is_trading_day(today) {
@@ -408,7 +410,7 @@ async fn handle_portfolio_liquidation(state: &ServiceState) -> Result<Value, Han
 /// Post-close: balances, activities, and pair attribution from Alpaca.
 async fn handle_account_sync(state: &ServiceState) -> Result<Value, HandlerError> {
     let now = Utc::now();
-    let today = eastern_date(now);
+    let today = SessionDate::at(now);
 
     let calendar = state.calendar_cache.get(&state.trading, now).await?;
     if !calendar.is_trading_day(today) {
@@ -425,7 +427,7 @@ async fn handle_account_sync(state: &ServiceState) -> Result<Value, HandlerError
 /// half-synced database. The chain is emitted only on success for the same reason.
 async fn handle_market_data_sync(state: &ServiceState) -> Result<Value, HandlerError> {
     let now = Utc::now();
-    let today = eastern_date(now);
+    let today = SessionDate::at(now);
 
     let calendar = state.calendar_cache.get(&state.trading, now).await?;
     if !calendar.is_trading_day(today) {
@@ -445,7 +447,7 @@ async fn handle_market_data_sync(state: &ServiceState) -> Result<Value, HandlerE
     // the previous `unwrap_or(today)` then collapsed the window to a single session — closing none
     // of the gap the constant exists to close, and saying nothing about it.
     let span = calendar.trading_days_in_range(
-        today - Duration::days(BAR_SYNC_LOOKBACK_SESSIONS as i64 * 4),
+        today.plus_calendar_days(-(BAR_SYNC_LOOKBACK_SESSIONS as i64 * 4)),
         today,
     );
     let sessions: Vec<_> = if span.len() > BAR_SYNC_LOOKBACK_SESSIONS {
@@ -501,7 +503,7 @@ async fn handle_market_data_sync(state: &ServiceState) -> Result<Value, HandlerE
 /// partial export deletes rows that never reached S3, and nothing afterwards can tell that it
 /// happened.
 async fn handle_database_export(state: &ServiceState) -> Result<Value, HandlerError> {
-    let today = eastern_date(Utc::now());
+    let today = SessionDate::at(Utc::now());
     let export = export::export_database(&state.pool, &state.s3_client, &state.bucket, today).await;
 
     if !export.is_clean() {
@@ -537,12 +539,12 @@ async fn handle_database_export(state: &ServiceState) -> Result<Value, HandlerEr
 async fn previous_session_gaps(
     state: &ServiceState,
     calendar: &TradingCalendar,
-    today: NaiveDate,
+    today: SessionDate,
 ) -> Result<Vec<String>, HandlerError> {
     let Some(previous) = calendar.previous_trading_day(today) else {
         return Ok(Vec::new());
     };
-    let (start, end) = crate::data::calendar::eastern_day_bounds(previous);
+    let (start, end) = previous.bounds();
 
     let rows = sqlx::query!(
         r#"
@@ -570,14 +572,44 @@ async fn previous_session_gaps(
     Ok(rows.into_iter().map(|row| row.event_type).collect())
 }
 
-/// How many days old the artifact's run identifier is, when it can be read as a date.
+/// How many trading sessions the artifact skipped, when its run identifier can be read as a date.
+///
+/// Zero is the healthy answer, and calendar days cannot express that. The trainer publishes after
+/// one session's close for the *next* session, so a healthy artifact is always dated at least one
+/// calendar day back — one midweek, three across a weekend, four across a long one. Counting days
+/// reported every one of those as stale; counting the sessions strictly between the artifact's date
+/// and today reports none of them, and still reports a genuinely skipped night.
+///
+/// Bounded by the calendar's horizon, so an artifact older than [`HORIZON_DAYS_BACKWARD`] undercounts.
+/// That only understates a number already past the threshold, so the warning still fires.
 ///
 /// `None` rather than a guess when the run identifier is not date-prefixed. The trainer names runs
-/// `YYYY-MM-DD-HH-MM-SS-mmm`, but a hand-uploaded artifact need not, and reporting an age computed
-/// from an unparsed prefix would be worse than reporting none.
-fn artifact_age_days(run_id: &str, today: NaiveDate) -> Option<i64> {
-    let date = NaiveDate::parse_from_str(run_id.get(..10)?, "%Y-%m-%d").ok()?;
-    Some((today - date).num_days())
+/// `YYYY-MM-DD-HH-MM-SS-mmm`, but a hand-uploaded artifact need not, and reporting staleness
+/// computed from an unparsed prefix would be worse than reporting none.
+///
+/// [`HORIZON_DAYS_BACKWARD`]: crate::data::calendar
+fn artifact_staleness_sessions(
+    run_id: &str,
+    calendar: &TradingCalendar,
+    today: SessionDate,
+) -> Option<i64> {
+    // The run identifier's date prefix is an Eastern session, written by the trainer through
+    // `eastern_datetime`, so wrapping it is `from_date`'s case rather than a derivation.
+    let artifact_date =
+        SessionDate::from_date(NaiveDate::parse_from_str(run_id.get(..10)?, "%Y-%m-%d").ok()?);
+    // Half-open on both ends: the artifact's own session is not a session it missed, and today's
+    // has not happened yet. `trading_days_in_range` takes an inclusive range and panics on an
+    // inverted one, so the empty case is answered here rather than passed down.
+    let first_missed = artifact_date.plus_calendar_days(1);
+    let last_missed = today.plus_calendar_days(-1);
+    if first_missed > last_missed {
+        return Some(0);
+    }
+    Some(
+        calendar
+            .trading_days_in_range(first_missed, last_missed)
+            .len() as i64,
+    )
 }
 
 /// Re-runs commands that were requested today and never finished.
@@ -607,39 +639,107 @@ pub async fn recover(state: Arc<ServiceState>) {
 }
 
 /// Reads the current Eastern date, for callers that need it alongside a handler.
-pub fn session_date(now: DateTime<Utc>) -> NaiveDate {
-    eastern_date(now)
+pub fn session_date(now: DateTime<Utc>) -> SessionDate {
+    SessionDate::at(now)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn date(year: i32, month: u32, day: u32) -> NaiveDate {
-        NaiveDate::from_ymd_opt(year, month, day).expect("test date must be valid")
+    fn date(year: i32, month: u32, day: u32) -> SessionDate {
+        SessionDate::from_date(
+            NaiveDate::from_ymd_opt(year, month, day).expect("test date must be valid"),
+        )
     }
 
-    /// The trainer names runs `YYYY-MM-DD-...`, which is what makes the age readable at all.
+    /// Weekday sessions spanning 2026-07-27 to 2026-08-07. 2026-08-01 is a Saturday and
+    /// 2026-08-02 a Sunday, so the weekend is absent.
+    fn weekday_calendar() -> TradingCalendar {
+        use crate::common::alpaca::CalendarDay;
+        let open = chrono::NaiveTime::from_hms_opt(9, 30, 0).expect("valid time");
+        let close = chrono::NaiveTime::from_hms_opt(16, 0, 0).expect("valid time");
+        let days = (0..12)
+            .map(|offset| date(2026, 7, 27).plus_calendar_days(offset))
+            .filter(|day| !day.is_weekend())
+            .map(|day| {
+                CalendarDay::new(day.date(), open, close).expect("test session must be valid")
+            })
+            .collect();
+        TradingCalendar::from_days(days)
+    }
+
+    /// The trainer names runs `YYYY-MM-DD-...`, which is what makes staleness readable at all.
     #[test]
-    fn test_artifact_age_reads_the_date_prefix() {
+    fn test_artifact_staleness_reads_the_date_prefix() {
+        let calendar = weekday_calendar();
+        // 2026-07-30 is a Thursday, 2026-07-31 the Friday after it.
         assert_eq!(
-            artifact_age_days("2026-07-29-16-21-25-195", date(2026, 7, 31)),
-            Some(2)
+            artifact_staleness_sessions("2026-07-30-19-21-25-195", &calendar, date(2026, 7, 31)),
+            Some(0)
+        );
+        // 2026-07-29 is the Wednesday, so Thursday's session was skipped.
+        assert_eq!(
+            artifact_staleness_sessions("2026-07-29-19-21-25-195", &calendar, date(2026, 7, 31)),
+            Some(1)
+        );
+    }
+
+    /// The case a calendar-day count gets wrong, and the reason this is measured in sessions.
+    ///
+    /// The trainer publishes after one session's close for the next session, so Friday evening's
+    /// artifact is what Monday is *supposed* to run on. Three calendar days separate them and zero
+    /// trading sessions do. Counting days warned on every healthy Monday.
+    #[test]
+    fn test_an_artifact_from_friday_is_not_stale_on_monday() {
+        let calendar = weekday_calendar();
+        let friday = date(2026, 7, 31);
+        let monday = date(2026, 8, 3);
+        assert_eq!(
+            (monday.date() - friday.date()).num_days(),
+            3,
+            "three calendar days apart"
         );
         assert_eq!(
-            artifact_age_days("2026-07-31-16-21-25-195", date(2026, 7, 31)),
+            artifact_staleness_sessions("2026-07-31-19-21-25-195", &calendar, monday),
+            Some(0),
+            "the weekend holds no session to have missed"
+        );
+        // And a real skip is still caught across the same weekend.
+        assert_eq!(
+            artifact_staleness_sessions("2026-07-30-19-21-25-195", &calendar, monday),
+            Some(1),
+            "Friday's session was missed"
+        );
+    }
+
+    /// An artifact dated today or later has missed nothing, and must not index an inverted range.
+    #[test]
+    fn test_an_artifact_from_today_has_missed_no_sessions() {
+        let calendar = weekday_calendar();
+        assert_eq!(
+            artifact_staleness_sessions("2026-07-31-19-21-25-195", &calendar, date(2026, 7, 31)),
+            Some(0)
+        );
+        assert_eq!(
+            artifact_staleness_sessions("2026-08-03-19-21-25-195", &calendar, date(2026, 7, 31)),
             Some(0)
         );
     }
 
-    /// A run identifier that is not date-prefixed yields no age. Reporting a number derived from an
-    /// unparsed prefix would put a fabricated staleness into the completion payload, which is worse
-    /// than reporting that it is unknown.
+    /// A run identifier that is not date-prefixed yields no staleness. Reporting a number derived
+    /// from an unparsed prefix would put a fabricated value into the completion payload, which is
+    /// worse than reporting that it is unknown.
     #[test]
-    fn test_an_undatable_run_identifier_has_no_age() {
-        assert_eq!(artifact_age_days("manual-upload", date(2026, 7, 31)), None);
-        assert_eq!(artifact_age_days("short", date(2026, 7, 31)), None);
-        assert_eq!(artifact_age_days("", date(2026, 7, 31)), None);
+    fn test_an_undatable_run_identifier_has_no_staleness() {
+        let calendar = weekday_calendar();
+        let today = date(2026, 7, 31);
+        assert_eq!(
+            artifact_staleness_sessions("manual-upload", &calendar, today),
+            None
+        );
+        assert_eq!(artifact_staleness_sessions("short", &calendar, today), None);
+        assert_eq!(artifact_staleness_sessions("", &calendar, today), None);
     }
 
     #[test]

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -9,6 +9,7 @@ use chrono::Datelike;
 use polars::prelude::*;
 use serde::{Deserialize, Serialize};
 
+use crate::data::calendar::SessionDate;
 use crate::data::details::UNKNOWN as UNKNOWN_SECTOR_OR_INDUSTRY;
 
 pub type CategoryMapping = HashMap<String, i32>;
@@ -181,7 +182,7 @@ impl Data {
         data: DataFrame,
         scaler: &Scaler,
         mappings: &FeatureMappings,
-        target_session: chrono::NaiveDate,
+        target_session: SessionDate,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let data = append_forecast_session_rows(data, target_session)?;
         let data = engineer_features(data)?;
@@ -422,10 +423,9 @@ fn window_frame(
 /// duplicate a real row.
 pub(crate) fn append_forecast_session_rows(
     data: DataFrame,
-    target_session: chrono::NaiveDate,
+    target_session: SessionDate,
 ) -> Result<DataFrame, Box<dyn std::error::Error>> {
-    let target_milliseconds =
-        crate::data::calendar::eastern_midnight(target_session).timestamp_millis();
+    let target_milliseconds = target_session.midnight().timestamp_millis();
 
     let sorted = data
         .sort(
@@ -544,10 +544,15 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn st
         return Err(message.into());
     }
 
-    for (i, &ts) in timestamp_values.iter().enumerate() {
-        let datetime = chrono::DateTime::from_timestamp_millis(ts)
+    for (index, &timestamp_milliseconds) in timestamp_values.iter().enumerate() {
+        let instant = chrono::DateTime::from_timestamp_millis(timestamp_milliseconds)
             .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap());
-        let date = datetime.date_naive();
+        // Through `SessionDate`, not `date_naive()`. These are the covariates describing the
+        // trading day a bar belongs to, so they must come from the Eastern date. Reading the UTC
+        // date agreed only because a daily bar is stamped at Eastern midnight, which lands in the
+        // morning of the same UTC day -- a coincidence of the offset's sign that would reverse if
+        // the stamp ever moved later in the session.
+        let date = SessionDate::at(instant).date();
 
         // Monday = 1 .. Sunday = 7, per polars `dt.weekday()`.
         day_of_week.push(date.weekday().number_from_monday() as i32);
@@ -556,9 +561,11 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn st
         month.push(date.month() as i32);
         year.push(date.year());
 
-        let same_ticker = i > 0 && tickers[i] == tickers[i - 1];
-        if same_ticker && close_prices[i - 1] != 0.0 {
-            daily_return.push(Some(((close_prices[i] / close_prices[i - 1]) - 1.0) as f32));
+        let same_ticker = index > 0 && tickers[index] == tickers[index - 1];
+        if same_ticker && close_prices[index - 1] != 0.0 {
+            daily_return.push(Some(
+                ((close_prices[index] / close_prices[index - 1]) - 1.0) as f32,
+            ));
         } else {
             daily_return.push(None);
         }
@@ -1020,9 +1027,10 @@ mod tests {
         for index in 0..ticker_count {
             for row in 0..rows_per_ticker {
                 ticker.push(names[index]);
-                let date = chrono::NaiveDate::from_ymd_opt(2026, 6, 1).unwrap()
-                    + chrono::Duration::days(row as i64);
-                timestamp.push(crate::data::calendar::eastern_midnight(date).timestamp_millis());
+                let date =
+                    SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 6, 1).unwrap())
+                        .plus_calendar_days(row as i64);
+                timestamp.push(date.midnight().timestamp_millis());
                 close.push(100.0 + row as f64);
             }
         }
@@ -1042,7 +1050,7 @@ mod tests {
     }
 
     /// The session a pre-open run forecasts: the day after the newest bar in the frame.
-    fn forecast_session(frame: &DataFrame) -> chrono::NaiveDate {
+    fn forecast_session(frame: &DataFrame) -> SessionDate {
         let newest = frame
             .column("timestamp")
             .unwrap()
@@ -1050,9 +1058,8 @@ mod tests {
             .unwrap()
             .max()
             .unwrap();
-        crate::data::calendar::eastern_date(
-            chrono::DateTime::from_timestamp_millis(newest).unwrap(),
-        ) + chrono::Duration::days(1)
+        SessionDate::at(chrono::DateTime::from_timestamp_millis(newest).unwrap())
+            .plus_calendar_days(1)
     }
 
     /// Everything `apply_existing_scaler` does to a frame, minus the scaler and mappings.
@@ -1146,8 +1153,7 @@ mod tests {
         let engineered =
             engineer_features(append_forecast_session_rows(frame, session).unwrap()).unwrap();
 
-        let target_milliseconds =
-            crate::data::calendar::eastern_midnight(session).timestamp_millis();
+        let target_milliseconds = session.midnight().timestamp_millis();
         let timestamps: Vec<i64> = engineered
             .column("timestamp")
             .unwrap()
@@ -1169,7 +1175,7 @@ mod tests {
             .collect();
         assert_eq!(
             day_of_week[row],
-            session.weekday().number_from_monday() as i32,
+            session.date().weekday().number_from_monday() as i32,
             "the appended row's calendar must match the forecast session"
         );
     }
@@ -1184,8 +1190,7 @@ mod tests {
         let session = forecast_session(&frame);
         let cleaned = prepared(append_forecast_session_rows(frame, session).unwrap());
 
-        let target_milliseconds =
-            crate::data::calendar::eastern_midnight(session).timestamp_millis();
+        let target_milliseconds = session.midnight().timestamp_millis();
         let surviving = cleaned
             .column("timestamp")
             .unwrap()
@@ -1200,7 +1205,7 @@ mod tests {
         );
 
         // Any instant inside the forecast session must stamp that same session.
-        let noon = crate::data::calendar::eastern_midnight(session) + chrono::Duration::hours(12);
+        let noon = session.midnight() + chrono::Duration::hours(12);
         assert_eq!(
             crate::models::tide::predict::step_timestamp_milliseconds(noon, 0),
             target_milliseconds,
@@ -1219,9 +1224,8 @@ mod tests {
             .unwrap()
             .max()
             .unwrap();
-        let already_present = crate::data::calendar::eastern_date(
-            chrono::DateTime::from_timestamp_millis(newest).unwrap(),
-        );
+        let already_present =
+            SessionDate::at(chrono::DateTime::from_timestamp_millis(newest).unwrap());
         let appended = append_forecast_session_rows(frame.clone(), already_present).unwrap();
         assert_eq!(
             appended.height(),
@@ -1280,18 +1284,17 @@ mod tests {
     #[test]
     fn test_engineer_features_day_of_week_is_monday_based_one_to_seven() {
         // Monday = 1 .. Sunday = 7.
-        let monday = chrono::NaiveDate::from_ymd_opt(2026, 6, 8)
-            .unwrap()
-            .and_hms_opt(0, 0, 0)
-            .unwrap()
-            .and_utc()
-            .timestamp_millis();
-        let sunday = chrono::NaiveDate::from_ymd_opt(2026, 6, 14)
-            .unwrap()
-            .and_hms_opt(0, 0, 0)
-            .unwrap()
-            .and_utc()
-            .timestamp_millis();
+        //
+        // Stamped at Eastern midnight, which is how a daily bar actually arrives. Built at UTC
+        // midnight instead — as this fixture was — every date reads as the previous Eastern day,
+        // and the assertion below became [7, 6]. The fixture, not the feature, was wrong.
+        let session = |year, month, day| {
+            SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(year, month, day).unwrap())
+                .midnight()
+                .timestamp_millis()
+        };
+        let monday = session(2026, 6, 8);
+        let sunday = session(2026, 6, 14);
 
         let frame = DataFrame::new(vec![
             Column::new("ticker".into(), vec!["AAA", "AAA"]),

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -1321,6 +1321,56 @@ mod tests {
         assert_eq!(day_of_week, vec![1, 7]);
     }
 
+    /// The covariates must come from the Eastern date, on an instant where Eastern and UTC disagree.
+    ///
+    /// The fixture above cannot prove this. A daily bar is stamped at Eastern midnight, which is
+    /// 04:00 or 05:00 the *same* UTC day, so `date_naive()` and `SessionDate::at` return the same
+    /// date for it and the assertion holds under either implementation.
+    ///
+    /// 01:00Z on 10 June is 21:00 on 9 June in New York — Wednesday in UTC, Tuesday in Eastern.
+    /// Reading the UTC date here yields 3; the session's own weekday is 2.
+    #[test]
+    fn test_engineer_features_reads_the_eastern_date_where_the_two_disagree() {
+        let late_evening = chrono::DateTime::parse_from_rfc3339("2026-06-10T01:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        // The precondition, so this cannot pass by the two agreeing: the UTC weekday is Wednesday.
+        assert_eq!(
+            late_evening.date_naive().weekday().number_from_monday(),
+            3,
+            "the fixture must sit on an instant where UTC and Eastern name different days"
+        );
+
+        let frame = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["AAA"]),
+            Column::new("timestamp".into(), vec![late_evening.timestamp_millis()]),
+            Column::new("open_price".into(), vec![1.0_f64]),
+            Column::new("high_price".into(), vec![1.0_f64]),
+            Column::new("low_price".into(), vec![1.0_f64]),
+            Column::new("close_price".into(), vec![10.0_f64]),
+            Column::new("volume".into(), vec![1.0_f64]),
+            Column::new("volume_weighted_average_price".into(), vec![1.0_f64]),
+            Column::new("sector".into(), vec!["S"]),
+            Column::new("industry".into(), vec!["I"]),
+        ])
+        .unwrap();
+
+        let engineered = engineer_features(frame).unwrap();
+        let read = |name: &str| {
+            engineered
+                .column(name)
+                .unwrap()
+                .i32()
+                .unwrap()
+                .get(0)
+                .unwrap()
+        };
+        assert_eq!(read("day_of_week"), 2, "Tuesday in Eastern, not Wednesday");
+        assert_eq!(read("day_of_month"), 9);
+        assert_eq!(read("month"), 6);
+    }
+
     #[test]
     fn test_split_by_timestamp_boundary_row_goes_to_train() {
         // Train is date <= split, validation is date > split. With 11 daily rows (0..=10 days)

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -5,13 +5,14 @@
 //! mismatch trains the scaler on dynamics the service never predicts.
 
 use burn::backend::NdArray;
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Utc};
 use polars::prelude::*;
 use sqlx::PgPool;
 use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::common::types::{EquityPrediction, Ticker};
+use crate::data::calendar::SessionDate;
 use crate::models::tide::artifact::ModelState;
 use crate::models::tide::data::Data;
 
@@ -224,8 +225,8 @@ pub(crate) fn unscale_and_sort_quantiles(
 /// Eastern day under daylight time -- so a UTC-stamped forecast lands in the wrong session's
 /// window and the morning's inference run is never read by that day's passes.
 pub(crate) fn step_timestamp_milliseconds(now: chrono::DateTime<Utc>, step: usize) -> i64 {
-    let session = crate::data::calendar::eastern_date(now) + Duration::days(step as i64);
-    crate::data::calendar::eastern_midnight(session).timestamp_millis()
+    let session = SessionDate::at(now).plus_calendar_days(step as i64);
+    session.midnight().timestamp_millis()
 }
 
 pub fn generate_predictions(
@@ -236,7 +237,7 @@ pub fn generate_predictions(
     // the output is stamped with are both derived from it, so the features and the label cannot
     // describe different days -- which is the shape of the bug this replaced.
     let now = Utc::now();
-    let session = crate::data::calendar::eastern_date(now);
+    let session = SessionDate::at(now);
 
     let tide_data =
         Data::apply_existing_scaler(data, model_state.scaler(), model_state.mappings(), session)
@@ -752,7 +753,7 @@ mod tests {
         // rows with `eastern_day_bounds`. A stamp built at UTC midnight falls in the *previous*
         // Eastern day's window -- 20:00 the day before, under EDT -- so the forecast written this
         // morning is never the one read this afternoon.
-        use crate::data::calendar::{eastern_date, eastern_day_bounds};
+        use crate::data::calendar::SessionDate;
 
         for day in [
             "2026-08-03",
@@ -767,7 +768,7 @@ mod tests {
                 .with_timezone(&Utc);
             let stamp = DateTime::<Utc>::from_timestamp_millis(step_timestamp_milliseconds(now, 0))
                 .unwrap();
-            let (start, end) = eastern_day_bounds(eastern_date(now));
+            let (start, end) = SessionDate::at(now).bounds();
             assert!(
                 stamp >= start && stamp < end,
                 "{day}: forecast stamped {stamp} is outside the session window [{start}, {end})"
@@ -779,19 +780,19 @@ mod tests {
     fn test_step_timestamp_step_zero_is_the_current_eastern_session() {
         // Step t is the Eastern session t days out, stamped at Eastern midnight. 15:30Z is 11:30
         // Eastern, so step 0 is that same session rather than the one UTC is already into.
-        use crate::data::calendar::eastern_midnight;
+        use crate::data::calendar::SessionDate;
 
         let now = chrono::DateTime::parse_from_rfc3339("2026-06-09T15:30:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        let session = chrono::NaiveDate::from_ymd_opt(2026, 6, 9).unwrap();
+        let session = SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 6, 9).unwrap());
         assert_eq!(
             step_timestamp_milliseconds(now, 0),
-            eastern_midnight(session).timestamp_millis()
+            session.midnight().timestamp_millis()
         );
         assert_eq!(
             step_timestamp_milliseconds(now, 4),
-            eastern_midnight(session + Duration::days(4)).timestamp_millis()
+            session.plus_calendar_days(4).midnight().timestamp_millis()
         );
     }
 
@@ -799,14 +800,15 @@ mod tests {
     fn test_late_evening_eastern_still_stamps_the_current_session() {
         // 01:00Z is 21:00 the previous Eastern day. Stamping off the UTC date would jump the
         // forecast a session forward, which is the failure this function exists to avoid.
-        use crate::data::calendar::eastern_midnight;
+        use crate::data::calendar::SessionDate;
 
         let now = chrono::DateTime::parse_from_rfc3339("2026-06-10T01:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
         assert_eq!(
             step_timestamp_milliseconds(now, 0),
-            eastern_midnight(chrono::NaiveDate::from_ymd_opt(2026, 6, 9).unwrap())
+            SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 6, 9).unwrap())
+                .midnight()
                 .timestamp_millis()
         );
     }
@@ -1102,16 +1104,20 @@ mod tests {
         // Compared against `eastern_midnight` rather than a fixed 86,400,000 ms stride: successive
         // Eastern midnights are 23 or 25 hours apart across a daylight-saving transition, so a
         // fixed stride asserts something that is only true away from March and November.
-        use crate::data::calendar::eastern_midnight;
+        use crate::data::calendar::SessionDate;
 
         let now = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
-        let session = chrono::NaiveDate::from_ymd_opt(2025, 12, 31).unwrap();
+        let session =
+            SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2025, 12, 31).unwrap());
         for step in [0usize, 1, 7] {
             assert_eq!(
                 step_timestamp_milliseconds(now, step),
-                eastern_midnight(session + Duration::days(step as i64)).timestamp_millis(),
+                session
+                    .plus_calendar_days(step as i64)
+                    .midnight()
+                    .timestamp_millis(),
                 "step {step} did not land on its Eastern session midnight"
             );
         }
@@ -1122,7 +1128,7 @@ mod tests {
         // Eastern time springs forward 2026-03-08 and falls back 2026-11-01. Stepping across either
         // boundary must still land on the session's own midnight, which a fixed day-length stride
         // would miss by an hour in each direction.
-        use crate::data::calendar::eastern_midnight;
+        use crate::data::calendar::SessionDate;
 
         for (start, label) in [
             ("2026-03-06T17:00:00Z", "spring forward"),
@@ -1131,9 +1137,9 @@ mod tests {
             let now = chrono::DateTime::parse_from_rfc3339(start)
                 .unwrap()
                 .with_timezone(&Utc);
-            let session = crate::data::calendar::eastern_date(now);
+            let session = SessionDate::at(now);
             for step in 0..5usize {
-                let expected = eastern_midnight(session + Duration::days(step as i64));
+                let expected = session.plus_calendar_days(step as i64).midnight();
                 assert_eq!(
                     step_timestamp_milliseconds(now, step),
                     expected.timestamp_millis(),

--- a/src/portfolio/account.rs
+++ b/src/portfolio/account.rs
@@ -10,14 +10,14 @@
 
 use std::collections::HashMap;
 
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::common::alpaca::{AccountActivity, AccountSnapshot, ClientError, TradingClient};
-use crate::data::calendar::eastern_day_bounds;
+use crate::data::calendar::SessionDate;
 use crate::portfolio::pairs::{self, ClosedPair, PairsError};
 
 /// The activity type carrying trade fills.
@@ -41,7 +41,7 @@ pub enum AccountError {
 /// What one post-close sync did.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct AccountSyncSummary {
-    pub session_date: NaiveDate,
+    pub session_date: SessionDate,
     pub equity: Decimal,
     pub activities_stored: u64,
     pub pairs_attributed: usize,
@@ -52,17 +52,17 @@ pub struct AccountSyncSummary {
 pub async fn sync_account(
     pool: &PgPool,
     client: &TradingClient,
-    session_date: NaiveDate,
+    session_date: SessionDate,
 ) -> Result<AccountSyncSummary, AccountError> {
     let account = client.fetch_account().await?;
     store_snapshot(pool, session_date, &account).await?;
 
     let activities = client
-        .fetch_activities(FILL_ACTIVITY_TYPE, session_date)
+        .fetch_activities(FILL_ACTIVITY_TYPE, session_date.date())
         .await?;
     let activities_stored = store_activities(pool, &activities).await?;
 
-    let (start, end) = eastern_day_bounds(session_date);
+    let (start, end) = session_date.bounds();
     let closed = pairs::load_closed_between(pool, start, end).await?;
     let attribution = attribute(&closed, &activities);
 
@@ -94,7 +94,7 @@ pub async fn sync_account(
 /// Writes one session's balances, overwriting any existing row for the date.
 pub async fn store_snapshot(
     pool: &PgPool,
-    session_date: NaiveDate,
+    session_date: SessionDate,
     account: &AccountSnapshot,
 ) -> Result<(), AccountError> {
     sqlx::query!(
@@ -110,7 +110,7 @@ pub async fn store_snapshot(
                long_market_value  = EXCLUDED.long_market_value,
                short_market_value = EXCLUDED.short_market_value,
                fetched_at         = now()"#,
-        session_date,
+        session_date.date(),
         account.equity(),
         account.cash(),
         account.buying_power(),
@@ -178,11 +178,11 @@ pub async fn store_activities(
 /// [`crate::portfolio::risk::RiskGate::new`].
 pub async fn load_equity_for(
     pool: &PgPool,
-    session_date: NaiveDate,
+    session_date: SessionDate,
 ) -> Result<Option<Decimal>, AccountError> {
     let row = sqlx::query!(
         r#"SELECT equity AS "equity!" FROM account_snapshots WHERE session_date = $1"#,
-        session_date,
+        session_date.date(),
     )
     .fetch_optional(pool)
     .await?;
@@ -248,8 +248,8 @@ pub fn attribute(closed: &[ClosedPair], activities: &[AccountActivity]) -> Attri
 }
 
 /// The instant bounds of a session date, for callers that need them alongside a sync.
-pub fn session_bounds(session_date: NaiveDate) -> (DateTime<Utc>, DateTime<Utc>) {
-    eastern_day_bounds(session_date)
+pub fn session_bounds(session_date: SessionDate) -> (DateTime<Utc>, DateTime<Utc>) {
+    session_date.bounds()
 }
 
 #[cfg(test)]
@@ -257,6 +257,7 @@ mod tests {
     use super::*;
     use crate::common::types::{PairID, Ticker};
     use crate::portfolio::pairs::CloseReason;
+    use chrono::NaiveDate;
 
     fn ticker(raw: &str) -> Ticker {
         Ticker::new(raw).unwrap()
@@ -382,7 +383,9 @@ mod tests {
 
     #[test]
     fn test_session_bounds_are_half_open_across_the_eastern_day() {
-        let (start, end) = session_bounds(NaiveDate::from_ymd_opt(2026, 7, 30).unwrap());
+        let (start, end) = session_bounds(SessionDate::from_date(
+            NaiveDate::from_ymd_opt(2026, 7, 30).unwrap(),
+        ));
         assert!(start < end);
         assert_eq!((end - start).num_hours(), 24);
     }

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -17,7 +17,7 @@ use tracing::{error, info, warn};
 
 use crate::common::alpaca::{ClientError, MarketDataClient, TradingClient};
 use crate::common::types::{EquityPrediction, Ticker};
-use crate::data::calendar::{eastern_date, eastern_day_bounds, TradingCalendar};
+use crate::data::calendar::{SessionDate, TradingCalendar};
 use crate::data::details::{self, DetailsError};
 use crate::data::universe::Universe;
 use crate::models::tide::predict;
@@ -445,7 +445,7 @@ async fn close_what_should_close(
 async fn current_model_run_id(
     context: &EvaluationContext<'_>,
 ) -> Result<Option<String>, EvaluationError> {
-    let (start, end) = eastern_day_bounds(eastern_date(context.now));
+    let (start, end) = SessionDate::at(context.now).bounds();
     let row = sqlx::query!(
         r#"SELECT model_run_id AS "model_run_id!"
            FROM equity_predictions
@@ -464,7 +464,7 @@ async fn current_model_run_id(
 async fn previous_session_equity(
     context: &EvaluationContext<'_>,
 ) -> Result<Option<rust_decimal::Decimal>, EvaluationError> {
-    let today = eastern_date(context.now);
+    let today = SessionDate::at(context.now);
     let Some(previous) = context.calendar.previous_trading_day(today) else {
         return Ok(None);
     };
@@ -483,7 +483,7 @@ async fn build_screen_inputs(
     held: &HashSet<Ticker>,
     prices: &mut HashMap<Ticker, f64>,
 ) -> Result<ScreenedUniverse, EvaluationError> {
-    let (start, end) = eastern_day_bounds(eastern_date(context.now));
+    let (start, end) = SessionDate::at(context.now).bounds();
     let predictions = predict::load_predictions_between(context.pool, start, end).await?;
     if predictions.is_empty() {
         info!("No predictions for the current session; no entries will be screened");

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -7,7 +7,8 @@
 
 #![allow(dead_code)]
 
-use chrono::{DateTime, Duration, NaiveDate, Utc};
+use chrono::{DateTime, Utc};
+use fund::data::calendar::SessionDate;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -218,21 +219,18 @@ pub async fn reset_tables(pool: &PgPool) {
 /// pairs, which makes every test built on it pass while asserting nothing. That is the trap
 /// recorded in `statistical_arbitrage_test_fixtures`.
 pub async fn seed_correlated_bars(pool: &PgPool, tickers: &[&str], sessions: i64) {
-    let today = Utc::now().date_naive();
+    let today = SessionDate::at(Utc::now());
 
     for (index, ticker) in tickers.iter().enumerate() {
         let mut price = 100.0 + index as f64 * 20.0;
-        let mut session_date = today - Duration::days(sessions - 1);
+        let mut session_date = today.plus_calendar_days(-(sessions - 1));
 
         for step in 0..sessions {
             let common = 0.012 * (step as f64 * 0.7).sin();
             let idiosyncratic = 0.012 * (step as f64 * 1.9 + index as f64).sin();
             price *= (0.8 * common + 0.6 * idiosyncratic).exp();
 
-            let timestamp = session_date
-                .and_hms_opt(0, 0, 0)
-                .expect("midnight is a valid time")
-                .and_utc();
+            let timestamp = session_date.midnight();
 
             sqlx::query(
                 "INSERT INTO equity_bars \
@@ -253,17 +251,14 @@ pub async fn seed_correlated_bars(pool: &PgPool, tickers: &[&str], sessions: i64
             .await
             .expect("Failed to seed an equity bar");
 
-            session_date += Duration::days(1);
+            session_date = session_date.plus_calendar_days(1);
         }
     }
 }
 
 /// Inserts one daily bar for a ticker at a specific date, for gap and alignment tests.
-pub async fn seed_bar(pool: &PgPool, ticker: &str, date: NaiveDate, close: f64) {
-    let timestamp = date
-        .and_hms_opt(0, 0, 0)
-        .expect("midnight is a valid time")
-        .and_utc();
+pub async fn seed_bar(pool: &PgPool, ticker: &str, date: SessionDate, close: f64) {
+    let timestamp = date.midnight();
     sqlx::query(
         "INSERT INTO equity_bars \
          (ticker, bar_interval, timestamp, open_price, high_price, low_price, close_price, volume) \

--- a/tests/test_dashboard.rs
+++ b/tests/test_dashboard.rs
@@ -12,11 +12,12 @@
 
 mod common;
 
-use chrono::{Duration, NaiveDate, Utc};
+use chrono::{Duration, Utc};
 use fund::common::alpaca::AccountSnapshot;
 use fund::common::events::{self, Command, EventType, Outcome};
 use fund::common::types::{PairID, Ticker};
 use fund::dashboard::database::fetch_dashboard_data;
+use fund::data::calendar::SessionDate;
 use fund::portfolio::account;
 use fund::portfolio::pairs::{self, CloseReason, PairEntry};
 use rust_decimal::Decimal;
@@ -50,7 +51,7 @@ async fn fresh_pool() -> PgPool {
     pool
 }
 
-async fn store_equity(pool: &PgPool, session_date: NaiveDate, equity: &str) {
+async fn store_equity(pool: &PgPool, session_date: SessionDate, equity: &str) {
     let snapshot = AccountSnapshot::new(
         decimal(equity),
         decimal("50000"),
@@ -116,10 +117,10 @@ async fn test_the_dashboard_reads_what_the_service_writes() {
             .expect("Failed to attribute realized profit and loss")
     );
 
-    store_equity(&pool, (now - Duration::days(1)).date_naive(), "1000000").await;
-    store_equity(&pool, now.date_naive(), "1010000").await;
+    store_equity(&pool, SessionDate::at(now - Duration::days(1)), "1000000").await;
+    store_equity(&pool, SessionDate::at(now), "1010000").await;
 
-    common::seed_bar(&pool, "AAPL", now.date_naive(), 190.0).await;
+    common::seed_bar(&pool, "AAPL", SessionDate::at(now), 190.0).await;
     common::seed_predictions(
         &pool,
         "run-dashboard",

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -5,8 +5,8 @@
 //! database; the notify trigger only fires in the database; the alignment guarantee in
 //! `load_aligned_closes` depends on how the query is planned, not on how the Rust reads.
 //!
-//! Session windows are always built with `eastern_day_bounds(eastern_date(now))`, never
-//! `eastern_day_bounds(now.date_naive())`. The second is the UTC calendar date, which between 20:00
+//! Session windows are always built with `SessionDate::at(now).bounds()`, never
+//! `SessionDate::at(now).bounds()`. The second is the UTC calendar date, which between 20:00
 //! Eastern and midnight names *tomorrow* — so the window starts four hours in the future and
 //! excludes the rows the test just seeded. It is the trading day these queries are bounded by, and
 //! a test that assumes the two coincide fails for four hours every evening.
@@ -17,7 +17,7 @@ use chrono::{Duration, NaiveDate, Utc};
 use fund::common::events::{self, Command, EventType, Outcome};
 use fund::common::types::{BarInterval, PairID, Ticker};
 use fund::data::bars;
-use fund::data::calendar::{eastern_date, eastern_day_bounds};
+use fund::data::calendar::SessionDate;
 use fund::models::tide::predict;
 use fund::portfolio::account;
 use fund::portfolio::pairs::{self, CloseReason, PairEntry};
@@ -100,7 +100,7 @@ async fn test_closing_an_already_closed_pair_changes_nothing() {
         .await
         .unwrap());
 
-    let (start, end) = eastern_day_bounds(eastern_date(now));
+    let (start, end) = SessionDate::at(now).bounds();
     let closed = pairs::load_closed_between(&pool, start, end).await.unwrap();
     assert_eq!(closed.len(), 1);
     assert_eq!(closed[0].close_reason(), CloseReason::Convergence);
@@ -232,7 +232,7 @@ async fn test_an_account_snapshot_overwrites_the_same_session() {
     use fund::common::alpaca::AccountSnapshot;
 
     let pool = fresh_pool().await;
-    let date = NaiveDate::from_ymd_opt(2026, 7, 30).unwrap();
+    let date = SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 7, 30).unwrap());
     let snapshot = |equity: i64| {
         AccountSnapshot::new(
             Decimal::from(equity),
@@ -262,7 +262,7 @@ async fn test_an_account_snapshot_overwrites_the_same_session() {
 #[serial]
 async fn test_a_session_with_no_snapshot_reads_as_none() {
     let pool = fresh_pool().await;
-    let date = NaiveDate::from_ymd_opt(2026, 7, 30).unwrap();
+    let date = SessionDate::from_date(NaiveDate::from_ymd_opt(2026, 7, 30).unwrap());
     assert_eq!(account::load_equity_for(&pool, date).await.unwrap(), None);
 }
 
@@ -277,10 +277,10 @@ async fn test_a_session_with_no_snapshot_reads_as_none() {
 #[serial]
 async fn test_aligned_closes_drops_a_ticker_with_a_gap() {
     let pool = fresh_pool().await;
-    let today = Utc::now().date_naive();
+    let today = SessionDate::at(Utc::now());
 
     for offset in 0..5 {
-        let date = today - Duration::days(offset);
+        let date = today.plus_calendar_days(offset);
         common::seed_bar(&pool, "AAAA", date, 100.0 + offset as f64).await;
         // BBBB is missing one session in the middle of the window.
         if offset != 2 {
@@ -306,10 +306,10 @@ async fn test_aligned_closes_drops_a_ticker_with_a_gap() {
 #[serial]
 async fn test_aligned_closes_reads_only_the_requested_interval() {
     let pool = fresh_pool().await;
-    let today = Utc::now().date_naive();
+    let today = SessionDate::at(Utc::now());
     common::seed_bar(&pool, "AAAA", today, 100.0).await;
 
-    let timestamp = today.and_hms_opt(0, 0, 0).unwrap().and_utc();
+    let timestamp = today.midnight();
     sqlx::query(
         "INSERT INTO equity_bars \
          (ticker, bar_interval, timestamp, open_price, high_price, low_price, close_price, volume) \
@@ -334,7 +334,7 @@ async fn test_aligned_closes_reads_only_the_requested_interval() {
 async fn test_predictions_are_bounded_to_the_session_window() {
     let pool = fresh_pool().await;
     let now = Utc::now();
-    let (start, end) = eastern_day_bounds(eastern_date(now));
+    let (start, end) = SessionDate::at(now).bounds();
 
     common::seed_predictions(&pool, "run-today", &[("AAAA", 0.03)], now).await;
     common::seed_predictions(
@@ -360,7 +360,7 @@ async fn test_predictions_are_bounded_to_the_session_window() {
 async fn test_predictions_return_the_newest_row_per_ticker() {
     let pool = fresh_pool().await;
     let now = Utc::now();
-    let (start, end) = eastern_day_bounds(eastern_date(now));
+    let (start, end) = SessionDate::at(now).bounds();
 
     common::seed_predictions(
         &pool,

--- a/tests/test_database.rs
+++ b/tests/test_database.rs
@@ -5,11 +5,11 @@
 //! database; the notify trigger only fires in the database; the alignment guarantee in
 //! `load_aligned_closes` depends on how the query is planned, not on how the Rust reads.
 //!
-//! Session windows are always built with `SessionDate::at(now).bounds()`, never
-//! `SessionDate::at(now).bounds()`. The second is the UTC calendar date, which between 20:00
-//! Eastern and midnight names *tomorrow* — so the window starts four hours in the future and
-//! excludes the rows the test just seeded. It is the trading day these queries are bounded by, and
-//! a test that assumes the two coincide fails for four hours every evening.
+//! Session windows are always built with `SessionDate::at(now).bounds()`, never from
+//! `now.date_naive()`. The second is the UTC calendar date, which between 20:00 Eastern and
+//! midnight names *tomorrow* — so the window starts four hours in the future and excludes the rows
+//! the test just seeded. It is the trading day these queries are bounded by, and a test that
+//! assumes the two coincide fails for four hours every evening.
 
 mod common;
 
@@ -279,8 +279,11 @@ async fn test_aligned_closes_drops_a_ticker_with_a_gap() {
     let pool = fresh_pool().await;
     let today = SessionDate::at(Utc::now());
 
+    // Negative: the window this loader serves is trailing history, so the fixture must run
+    // backwards from today. Seeding forwards puts the whole window in the future, and the
+    // alignment assertion then proves nothing about the historical lower bound.
     for offset in 0..5 {
-        let date = today.plus_calendar_days(offset);
+        let date = today.plus_calendar_days(-offset);
         common::seed_bar(&pool, "AAAA", date, 100.0 + offset as f64).await;
         // BBBB is missing one session in the middle of the window.
         if offset != 2 {

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -579,7 +579,17 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
     let pool = fresh_pool().await;
     let mut server = mockito::Server::new_async().await;
 
-    let session_date = SessionDate::at(Utc::now());
+    // A fixed instant on the wrong side of UTC midnight: 00:30Z on 4 August is 20:30 on 3 August in
+    // New York. The session is therefore 2026-08-03, and the activities request below asserts that
+    // date — so a regression sending the UTC date instead of `session_date.date()` fails here
+    // rather than only during the four hours a day when the two disagree.
+    let session_date = SessionDate::at(
+        chrono::DateTime::parse_from_rfc3339("2026-08-04T00:30:00Z")
+            .unwrap()
+            .with_timezone(&Utc),
+    );
+    assert_eq!(session_date.to_string(), "2026-08-03");
+
     let (start, _end) = session_date.bounds();
     let opened = start + Duration::hours(14);
     let closed = start + Duration::hours(18);
@@ -608,6 +618,12 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
             "GET",
             mockito::Matcher::Regex(r"^/v2/account/activities/FILL".into()),
         )
+        // The path prefix alone would match a request carrying any date. Alpaca is asked for one
+        // session, and which session that is comes from the Eastern derivation under test.
+        .match_query(mockito::Matcher::UrlEncoded(
+            "date".into(),
+            "2026-08-03".into(),
+        ))
         .with_status(200)
         .with_body(format!(
             r#"[{{"id":"a1","activity_type":"FILL","transaction_time":"{}",
@@ -747,12 +763,12 @@ fn mean_reverting_short_price(history: &HashMap<Ticker, Vec<f64>>) -> f64 {
 
 /// An instant inside the session, so the risk gate's hold-window check has room.
 ///
-/// Built from the **Eastern** date, not `SessionDate::at(Utc::now())`. Between 20:00 Eastern and
-/// midnight the two name different days, and a fixture anchored to the UTC date lands outside the
-/// session it is meant to sit inside — which is a test that fails for four hours every evening and
-/// passes every time anyone looks at it during the day.
+/// Built from the **Eastern** date via `SessionDate::at`, not from `Utc::now().date_naive()`.
+/// Between 20:00 Eastern and midnight the two name different days, and a fixture anchored to the
+/// UTC date lands outside the session it is meant to sit inside — which is a test that fails for
+/// four hours every evening and passes every time anyone looks at it during the day.
 ///
-/// `eastern_day_bounds` returns UTC instants, so the offset below is from Eastern midnight.
+/// `SessionDate::bounds` returns UTC instants, so the offset below is from Eastern midnight.
 fn session_instant() -> chrono::DateTime<Utc> {
     let today = SessionDate::at(Utc::now());
     let (start, _) = today.bounds();

--- a/tests/test_handlers.rs
+++ b/tests/test_handlers.rs
@@ -9,13 +9,13 @@ mod common;
 
 use std::collections::HashMap;
 
-use chrono::{Duration, NaiveDate, NaiveTime, Utc};
+use chrono::{Duration, NaiveTime, Utc};
 use fund::common::alpaca::{
     AlpacaCredentials, CalendarDay, DataFeed, MarketDataClient, TradingClient,
 };
 use fund::common::types::{BarInterval, Ticker};
 use fund::data::bars;
-use fund::data::calendar::TradingCalendar;
+use fund::data::calendar::{SessionDate, TradingCalendar};
 use fund::data::universe::{LiquidityRow, Universe};
 use fund::portfolio::evaluate::{self, EvaluationContext};
 use fund::portfolio::execute::ExecutionSettings;
@@ -50,12 +50,12 @@ async fn fresh_pool() -> PgPool {
 
 /// A calendar whose session runs 09:30 to 16:00 today, so `minutes_until_close` answers something.
 fn calendar_for_today() -> TradingCalendar {
-    let today = fund::data::calendar::eastern_date(Utc::now());
+    let today = SessionDate::at(Utc::now());
     let days = (0..5)
         .filter_map(|offset| {
-            let date = today - Duration::days(offset);
+            let date = today.plus_calendar_days(-offset);
             CalendarDay::new(
-                date,
+                date.date(),
                 NaiveTime::from_hms_opt(9, 30, 0).unwrap(),
                 NaiveTime::from_hms_opt(16, 0, 0).unwrap(),
             )
@@ -579,8 +579,8 @@ async fn test_the_account_sync_stores_and_attributes_a_session() {
     let pool = fresh_pool().await;
     let mut server = mockito::Server::new_async().await;
 
-    let session_date = fund::data::calendar::eastern_date(Utc::now());
-    let (start, _end) = fund::data::calendar::eastern_day_bounds(session_date);
+    let session_date = SessionDate::at(Utc::now());
+    let (start, _end) = session_date.bounds();
     let opened = start + Duration::hours(14);
     let closed = start + Duration::hours(18);
 
@@ -652,8 +652,8 @@ async fn test_the_account_sync_is_idempotent() {
 
     let pool = fresh_pool().await;
     let mut server = mockito::Server::new_async().await;
-    let session_date = fund::data::calendar::eastern_date(Utc::now());
-    let (start, _end) = fund::data::calendar::eastern_day_bounds(session_date);
+    let session_date = SessionDate::at(Utc::now());
+    let (start, _end) = session_date.bounds();
 
     let _account = server
         .mock("GET", "/v2/account")
@@ -747,14 +747,14 @@ fn mean_reverting_short_price(history: &HashMap<Ticker, Vec<f64>>) -> f64 {
 
 /// An instant inside the session, so the risk gate's hold-window check has room.
 ///
-/// Built from the **Eastern** date, not `Utc::now().date_naive()`. Between 20:00 Eastern and
+/// Built from the **Eastern** date, not `SessionDate::at(Utc::now())`. Between 20:00 Eastern and
 /// midnight the two name different days, and a fixture anchored to the UTC date lands outside the
 /// session it is meant to sit inside — which is a test that fails for four hours every evening and
 /// passes every time anyone looks at it during the day.
 ///
 /// `eastern_day_bounds` returns UTC instants, so the offset below is from Eastern midnight.
 fn session_instant() -> chrono::DateTime<Utc> {
-    let today: NaiveDate = fund::data::calendar::eastern_date(Utc::now());
-    let (start, _) = fund::data::calendar::eastern_day_bounds(today);
+    let today = SessionDate::at(Utc::now());
+    let (start, _) = today.bounds();
     start + Duration::hours(11) // 11:00 Eastern, mid-session
 }

--- a/tests/test_schedules.rs
+++ b/tests/test_schedules.rs
@@ -224,8 +224,25 @@ fn parse_expression(expression: &str, job_name: &str) -> CronExpression {
 }
 
 /// Every Eastern time comparison in the job body.
+///
+/// The connectors between them are not parsed, and [`gate_admits`] applies every bound with `AND`.
+/// A gate joined with `OR` would therefore be modelled as its own intersection: PostgreSQL could
+/// admit both candidate UTC firings while the once-per-session assertion still passed, which is the
+/// one failure this file exists to catch. Disjunction is refused rather than misread, on the same
+/// principle as [`parse_field`].
 fn parse_gate(body: &str, job_name: &str) -> Vec<GateBound> {
     const MARKER: &str = "(now() AT TIME ZONE 'America/New_York')::time";
+
+    let predicate = body
+        .split_once("WHERE")
+        .map_or("", |(_, predicate)| predicate);
+    assert!(
+        !predicate
+            .split(|character: char| !character.is_ascii_alphabetic())
+            .any(|token| token.eq_ignore_ascii_case("or")),
+        "job '{job_name}': disjunctive gates are not modelled by this test"
+    );
+
     let mut bounds = Vec::new();
 
     for segment in body.split(MARKER).skip(1) {
@@ -271,11 +288,11 @@ fn gate_admits(bounds: &[GateBound], moment: NaiveTime) -> bool {
 /// The UTC-to-Eastern conversion is the same `eastern_datetime` production uses, so this checks the
 /// schedule against the conversion the application will really perform rather than a second
 /// implementation that could drift from it.
-fn firings_by_session(
+fn firings_by_eastern_date(
     expression: &CronExpression,
     gate: &[GateBound],
 ) -> BTreeMap<NaiveDate, Vec<NaiveTime>> {
-    let mut by_session: BTreeMap<NaiveDate, Vec<NaiveTime>> = BTreeMap::new();
+    let mut by_eastern_date: BTreeMap<NaiveDate, Vec<NaiveTime>> = BTreeMap::new();
     let mut date = NaiveDate::from_ymd_opt(YEAR, 1, 1).expect("a valid start of year");
     let end = NaiveDate::from_ymd_opt(YEAR, 12, 31).expect("a valid end of year");
 
@@ -292,7 +309,7 @@ fn firings_by_session(
                         .expect("every UTC wall-clock time exists");
                     let eastern = eastern_datetime(instant);
                     if gate_admits(gate, eastern.time()) {
-                        by_session
+                        by_eastern_date
                             .entry(eastern.date())
                             .or_default()
                             .push(eastern.time());
@@ -305,10 +322,10 @@ fn firings_by_session(
             .expect("the year ends before the epoch does");
     }
 
-    for times in by_session.values_mut() {
+    for times in by_eastern_date.values_mut() {
         times.sort_unstable();
     }
-    by_session
+    by_eastern_date
 }
 
 /// Every date in the year the expression's day-of-week field admits.
@@ -317,8 +334,8 @@ fn firings_by_session(
 /// let a job that goes silent for half the year pass: dropping one of the two candidate UTC hours
 /// leaves the surviving hour correct in one daylight-saving regime and outside the gate in the
 /// other, so the missing days vanish from the map rather than disagreeing with it.
-fn expected_sessions(expression: &CronExpression) -> Vec<NaiveDate> {
-    let mut sessions = Vec::new();
+fn expected_eastern_dates(expression: &CronExpression) -> Vec<NaiveDate> {
+    let mut dates = Vec::new();
     let mut date = NaiveDate::from_ymd_opt(YEAR, 1, 1).expect("a valid start of year");
     let end = NaiveDate::from_ymd_opt(YEAR, 12, 31).expect("a valid end of year");
 
@@ -327,13 +344,13 @@ fn expected_sessions(expression: &CronExpression) -> Vec<NaiveDate> {
             .days_of_week
             .contains(&date.weekday().num_days_from_sunday())
         {
-            sessions.push(date);
+            dates.push(date);
         }
         date = date
             .succ_opt()
             .expect("the year ends before the epoch does");
     }
-    sessions
+    dates
 }
 
 /// The whole point: a gated job fires at the same Eastern times on every trading weekday of the
@@ -369,22 +386,22 @@ fn test_every_gated_schedule_keeps_the_same_eastern_clock_all_year() {
             job.name
         );
 
-        let by_session = firings_by_session(&expression, &gate);
+        let by_eastern_date = firings_by_eastern_date(&expression, &gate);
 
         // Checked before the per-day comparison below, because a day with no firing at all is
         // absent from the map rather than present with the wrong times — so comparing only what is
         // there would silently accept a job that stops firing for half the year.
         assert_eq!(
-            by_session.keys().copied().collect::<Vec<NaiveDate>>(),
-            expected_sessions(&expression),
+            by_eastern_date.keys().copied().collect::<Vec<NaiveDate>>(),
+            expected_eastern_dates(&expression),
             "job '{}' does not fire on every day its schedule admits",
             job.name
         );
 
-        for (session, times) in &by_session {
+        for (eastern_date, times) in &by_eastern_date {
             assert_eq!(
                 times, &expected,
-                "job '{}' fires at a different Eastern schedule on {session}",
+                "job '{}' fires at a different Eastern schedule on {eastern_date}",
                 job.name
             );
         }
@@ -409,19 +426,19 @@ fn test_gated_schedules_never_fire_on_a_weekend() {
         let expression = parse_expression(&job.expression, &job.name);
         let gate = parse_gate(&job.body, &job.name);
 
-        let sessions: Vec<NaiveDate> = firings_by_session(&expression, &gate)
+        let weekend_dates: Vec<NaiveDate> = firings_by_eastern_date(&expression, &gate)
             .into_keys()
-            .filter(|session| {
+            .filter(|eastern_date| {
                 matches!(
-                    session.weekday(),
+                    eastern_date.weekday(),
                     chrono::Weekday::Sat | chrono::Weekday::Sun
                 )
             })
             .collect();
 
         assert!(
-            sessions.is_empty(),
-            "job '{}' fires on {sessions:?}, which are not trading days",
+            weekend_dates.is_empty(),
+            "job '{}' fires on {weekend_dates:?}, which are not trading days",
             job.name
         );
     }
@@ -456,11 +473,11 @@ fn test_a_once_daily_job_fires_exactly_once_per_session() {
             job.name
         );
 
-        for (session, times) in firings_by_session(&expression, &gate) {
+        for (eastern_date, times) in firings_by_eastern_date(&expression, &gate) {
             assert_eq!(
                 times.len(),
                 1,
-                "job '{}' passed its gate {} times on {session}",
+                "job '{}' passed its gate {} times on {eastern_date}",
                 job.name,
                 times.len()
             );
@@ -528,4 +545,26 @@ fn test_gate_parsing_reads_bounds_and_their_inclusivity() {
     );
 
     assert!(parse_gate("DELETE FROM cron.job_run_details", "job").is_empty());
+}
+
+/// A disjunctive gate must be refused, not silently read as a conjunction.
+///
+/// `gate_admits` applies every bound with `AND`. Modelling an `OR` gate that way describes a
+/// narrower window than PostgreSQL would evaluate, so both candidate UTC firings could pass in
+/// production while `test_a_once_daily_job_fires_exactly_once_per_session` still saw one.
+#[test]
+fn test_the_gate_parser_refuses_disjunction() {
+    let conjunctive = "SELECT emit_event('x', '{}'::jsonb) \
+                       WHERE (now() AT TIME ZONE 'America/New_York')::time >= TIME '09:00' \
+                         AND (now() AT TIME ZONE 'America/New_York')::time < TIME '09:20'";
+    let disjunctive = conjunctive.replace(" AND ", " OR ");
+
+    // The precondition: the conjunctive form parses, so the rejection below is the OR and not
+    // some other difference between the two strings.
+    assert_eq!(parse_gate(conjunctive, "job").len(), 2);
+
+    assert!(
+        std::panic::catch_unwind(|| parse_gate(&disjunctive, "job")).is_err(),
+        "an OR-joined gate must be refused"
+    );
 }

--- a/tests/test_schedules.rs
+++ b/tests/test_schedules.rs
@@ -1,0 +1,531 @@
+//! The trading schedules in `schema.sql`, checked against the clock they claim to keep.
+//!
+//! Every job that matters fires on a **UTC** cron expression and gates on the **Eastern** wall
+//! clock in its own `WHERE` clause. That pairing is what makes a daylight-saving transition need no
+//! schema re-apply: the expression fires across both candidate UTC hours and the gate discards the
+//! one that is an hour off. It is also entirely a convention — nothing enforced it, and the
+//! reasoning lived in comments. Editing one half without the other produces a job that fires twice
+//! a day for half the year, or not at all for the other half, and neither shows up until it does.
+//!
+//! The test harness in `tests/common/mod.rs` strips `pg_cron` out of the schema before applying it,
+//! so these blocks were not merely untested but deliberately excluded. This file reads `schema.sql`
+//! as text instead, which needs no database and no extension.
+//!
+//! The invariant, stated once: **the set of Eastern times a job fires at is the same on every
+//! trading weekday of the year.** That is precisely what daylight-saving safety means, and it holds
+//! for a job firing once a day and for one firing every five minutes without special-casing either.
+//!
+//! Unrecognized syntax is rejected rather than skipped. A cron form this parser does not understand,
+//! or a job absent from the tables below, fails the test — otherwise the next schedule added here
+//! would be silently unverified, which is the state this file exists to end.
+
+use std::collections::BTreeMap;
+
+use chrono::{Datelike, NaiveDate, NaiveTime, TimeZone, Utc};
+use fund::data::calendar::eastern_datetime;
+
+/// Compiled in, so the test cannot run against a copy that has drifted from the working tree.
+const SCHEMA: &str = include_str!("../schema.sql");
+
+/// The year walked. Any full year exercises both transitions; 2026 springs forward on 8 March and
+/// falls back on 1 November, and both are Sundays, so the weekday sets on either side of each are
+/// what the assertions actually compare.
+const YEAR: i32 = 2026;
+
+/// Jobs that carry no Eastern gate, and why that is correct for each.
+///
+/// Listed explicitly so a *new* ungated job fails rather than being quietly tolerated. Housekeeping
+/// is the only justification: it deletes on an age predicate, so the hour it runs at changes
+/// nothing about the outcome.
+const UNGATED_JOBS: &[&str] = &["cron-run-details-cleanup"];
+
+/// One scheduled job as it appears in the schema.
+#[derive(Debug)]
+struct ScheduledJob {
+    name: String,
+    expression: String,
+    body: String,
+}
+
+/// A parsed five-field cron expression. Only the forms the schema actually uses are accepted.
+#[derive(Debug)]
+struct CronExpression {
+    minutes: Vec<u32>,
+    hours: Vec<u32>,
+    days_of_week: Vec<u32>,
+}
+
+/// One `(now() AT TIME ZONE 'America/New_York')::time OP TIME 'HH:MM'` comparison.
+#[derive(Debug)]
+struct GateBound {
+    operator: String,
+    boundary: NaiveTime,
+}
+
+fn time(text: &str) -> NaiveTime {
+    NaiveTime::parse_from_str(text, "%H:%M").expect("a valid HH:MM literal")
+}
+
+/// The Eastern times each gated job is intended to fire at.
+///
+/// Declared here rather than derived from the schema: a test that recomputed the answer from the
+/// same expression it is checking would agree with any edit, including a wrong one. These are the
+/// times the comments in `schema.sql` promise.
+fn expected_eastern_firings(job_name: &str) -> Option<Vec<NaiveTime>> {
+    let single = |value: &str| Some(vec![time(value)]);
+    match job_name {
+        "predictions-requested" => single("09:00"),
+        "portfolio-liquidation-requested" => single("15:45"),
+        "account-sync-requested" => single("16:15"),
+        "market-data-sync-requested" => single("16:30"),
+        // Every five minutes from the open through 15:40, the last pass before liquidation.
+        "portfolio-evaluation-requested" => Some(
+            (0..)
+                .map(|step| time("09:30") + chrono::Duration::minutes(step * 5))
+                .take_while(|moment| *moment <= time("15:40"))
+                .collect(),
+        ),
+        _ => None,
+    }
+}
+
+/// Reads the quoted string starting at the next `'`, returning it and the remainder.
+fn take_quoted<'a>(text: &'a str, context: &str) -> (String, &'a str) {
+    let start = text
+        .find('\'')
+        .unwrap_or_else(|| panic!("{context}: expected a quoted argument"));
+    let after_open = &text[start + 1..];
+    let end = after_open
+        .find('\'')
+        .unwrap_or_else(|| panic!("{context}: unterminated quoted argument"));
+    let value = &after_open[..end];
+    assert!(
+        !after_open[end..].starts_with("''"),
+        "{context}: doubled quotes are not handled by this parser"
+    );
+    (value.to_string(), &after_open[end + 1..])
+}
+
+/// Reads the `$$`-delimited body, returning it and the remainder.
+fn take_dollar_quoted<'a>(text: &'a str, context: &str) -> (String, &'a str) {
+    let start = text
+        .find("$$")
+        .unwrap_or_else(|| panic!("{context}: expected a $$-quoted command"));
+    let after_open = &text[start + 2..];
+    let end = after_open
+        .find("$$")
+        .unwrap_or_else(|| panic!("{context}: unterminated $$-quoted command"));
+    (after_open[..end].to_string(), &after_open[end + 2..])
+}
+
+/// Every `cron.schedule(...)` call in the schema, in file order.
+///
+/// `cron.unschedule(` does not match: the literal searched for is `cron.schedule(`, and the longer
+/// name breaks it at `cron.un`.
+fn parse_jobs(schema: &str) -> Vec<ScheduledJob> {
+    const MARKER: &str = "cron.schedule(";
+    let mut jobs = Vec::new();
+    let mut remainder = schema;
+
+    while let Some(index) = remainder.find(MARKER) {
+        let after_marker = &remainder[index + MARKER.len()..];
+        let (name, after_name) = take_quoted(after_marker, "cron.schedule name");
+        let context = format!("job '{name}'");
+        let (expression, after_expression) = take_quoted(after_name, &context);
+        let (body, rest) = take_dollar_quoted(after_expression, &context);
+        jobs.push(ScheduledJob {
+            name,
+            expression,
+            body,
+        });
+        remainder = rest;
+    }
+
+    jobs
+}
+
+/// Expands one cron field. Accepts `*`, `*/N`, `A-B`, `A-B/N`, `A,B,...`, and a bare `N`.
+///
+/// Panics on anything else. A field this does not understand must fail loudly: silently treating an
+/// unknown form as "matches nothing" would make the job appear never to fire, and the assertions
+/// below would then report a schedule problem that is really a parser problem.
+fn parse_field(specification: &str, minimum: u32, maximum: u32, context: &str) -> Vec<u32> {
+    let mut values = Vec::new();
+
+    for term in specification.split(',') {
+        let (range_part, step) = match term.split_once('/') {
+            Some((range_part, step_text)) => {
+                let step: u32 = step_text
+                    .parse()
+                    .unwrap_or_else(|_| panic!("{context}: unparseable step in '{term}'"));
+                assert!(step > 0, "{context}: zero step in '{term}'");
+                (range_part, step)
+            }
+            None => (term, 1),
+        };
+
+        let (first, last) = if range_part == "*" {
+            (minimum, maximum)
+        } else if let Some((low, high)) = range_part.split_once('-') {
+            (parse_bound(low, context), parse_bound(high, context))
+        } else {
+            let single = parse_bound(range_part, context);
+            (single, single)
+        };
+
+        assert!(
+            first >= minimum && last <= maximum && first <= last,
+            "{context}: '{term}' is outside {minimum}..={maximum}"
+        );
+        values.extend((first..=last).step_by(step as usize));
+    }
+
+    values.sort_unstable();
+    values.dedup();
+    assert!(!values.is_empty(), "{context}: matched no values");
+    values
+}
+
+fn parse_bound(text: &str, context: &str) -> u32 {
+    text.trim()
+        .parse()
+        .unwrap_or_else(|_| panic!("{context}: unparseable cron value '{text}'"))
+}
+
+/// Parses the five-field expression, requiring day-of-month and month to be unrestricted.
+///
+/// Restricting either would bring in cron's day-of-month/day-of-week OR semantics, which this
+/// parser does not model — so it is refused rather than misread.
+fn parse_expression(expression: &str, job_name: &str) -> CronExpression {
+    let fields: Vec<&str> = expression.split_whitespace().collect();
+    assert_eq!(
+        fields.len(),
+        5,
+        "job '{job_name}': expected five cron fields in '{expression}'"
+    );
+
+    for (field, label) in [(fields[2], "day-of-month"), (fields[3], "month")] {
+        assert_eq!(
+            field, "*",
+            "job '{job_name}': a restricted {label} field is not modelled by this test"
+        );
+    }
+
+    CronExpression {
+        minutes: parse_field(fields[0], 0, 59, job_name),
+        hours: parse_field(fields[1], 0, 23, job_name),
+        // Cron accepts both 0 and 7 for Sunday; normalized so the comparison below is a plain
+        // `contains` against `num_days_from_sunday`.
+        days_of_week: parse_field(fields[4], 0, 7, job_name)
+            .into_iter()
+            .map(|day| day % 7)
+            .collect(),
+    }
+}
+
+/// Every Eastern time comparison in the job body.
+fn parse_gate(body: &str, job_name: &str) -> Vec<GateBound> {
+    const MARKER: &str = "(now() AT TIME ZONE 'America/New_York')::time";
+    let mut bounds = Vec::new();
+
+    for segment in body.split(MARKER).skip(1) {
+        let trimmed = segment.trim_start();
+        let operator = ["<=", ">=", "<", ">", "="]
+            .into_iter()
+            .find(|candidate| trimmed.starts_with(candidate))
+            .unwrap_or_else(|| {
+                panic!("job '{job_name}': unrecognized comparison after the Eastern time cast")
+            });
+
+        let after_operator = trimmed[operator.len()..].trim_start();
+        let literal = after_operator.strip_prefix("TIME '").unwrap_or_else(|| {
+            panic!("job '{job_name}': expected a TIME literal after {operator}")
+        });
+        let end = literal
+            .find('\'')
+            .unwrap_or_else(|| panic!("job '{job_name}': unterminated TIME literal"));
+
+        bounds.push(GateBound {
+            operator: operator.to_string(),
+            boundary: time(&literal[..end]),
+        });
+    }
+
+    bounds
+}
+
+fn gate_admits(bounds: &[GateBound], moment: NaiveTime) -> bool {
+    bounds.iter().all(|bound| match bound.operator.as_str() {
+        ">=" => moment >= bound.boundary,
+        ">" => moment > bound.boundary,
+        "<=" => moment <= bound.boundary,
+        "<" => moment < bound.boundary,
+        "=" => moment == bound.boundary,
+        other => panic!("unhandled comparison '{other}'"),
+    })
+}
+
+/// Walks a year and collects, per Eastern date, the Eastern times the job actually fires and passes
+/// its gate.
+///
+/// The UTC-to-Eastern conversion is the same `eastern_datetime` production uses, so this checks the
+/// schedule against the conversion the application will really perform rather than a second
+/// implementation that could drift from it.
+fn firings_by_session(
+    expression: &CronExpression,
+    gate: &[GateBound],
+) -> BTreeMap<NaiveDate, Vec<NaiveTime>> {
+    let mut by_session: BTreeMap<NaiveDate, Vec<NaiveTime>> = BTreeMap::new();
+    let mut date = NaiveDate::from_ymd_opt(YEAR, 1, 1).expect("a valid start of year");
+    let end = NaiveDate::from_ymd_opt(YEAR, 12, 31).expect("a valid end of year");
+
+    while date <= end {
+        if expression
+            .days_of_week
+            .contains(&date.weekday().num_days_from_sunday())
+        {
+            for &hour in &expression.hours {
+                for &minute in &expression.minutes {
+                    let instant = Utc
+                        .with_ymd_and_hms(date.year(), date.month(), date.day(), hour, minute, 0)
+                        .single()
+                        .expect("every UTC wall-clock time exists");
+                    let eastern = eastern_datetime(instant);
+                    if gate_admits(gate, eastern.time()) {
+                        by_session
+                            .entry(eastern.date())
+                            .or_default()
+                            .push(eastern.time());
+                    }
+                }
+            }
+        }
+        date = date
+            .succ_opt()
+            .expect("the year ends before the epoch does");
+    }
+
+    for times in by_session.values_mut() {
+        times.sort_unstable();
+    }
+    by_session
+}
+
+/// Every date in the year the expression's day-of-week field admits.
+///
+/// A schedule must produce a firing on all of them. Comparing only the days that *did* fire would
+/// let a job that goes silent for half the year pass: dropping one of the two candidate UTC hours
+/// leaves the surviving hour correct in one daylight-saving regime and outside the gate in the
+/// other, so the missing days vanish from the map rather than disagreeing with it.
+fn expected_sessions(expression: &CronExpression) -> Vec<NaiveDate> {
+    let mut sessions = Vec::new();
+    let mut date = NaiveDate::from_ymd_opt(YEAR, 1, 1).expect("a valid start of year");
+    let end = NaiveDate::from_ymd_opt(YEAR, 12, 31).expect("a valid end of year");
+
+    while date <= end {
+        if expression
+            .days_of_week
+            .contains(&date.weekday().num_days_from_sunday())
+        {
+            sessions.push(date);
+        }
+        date = date
+            .succ_opt()
+            .expect("the year ends before the epoch does");
+    }
+    sessions
+}
+
+/// The whole point: a gated job fires at the same Eastern times on every trading weekday of the
+/// year, and those times are the ones the schema's comments promise.
+#[test]
+fn test_every_gated_schedule_keeps_the_same_eastern_clock_all_year() {
+    let jobs = parse_jobs(SCHEMA);
+    assert!(
+        jobs.len() >= 6,
+        "expected the schema's scheduled jobs to be found, got {}",
+        jobs.len()
+    );
+
+    let mut checked = 0;
+    for job in &jobs {
+        if UNGATED_JOBS.contains(&job.name.as_str()) {
+            continue;
+        }
+
+        let expected = expected_eastern_firings(&job.name).unwrap_or_else(|| {
+            panic!(
+                "job '{}' is neither listed as ungated nor given an expected Eastern schedule; \
+                 add it to one of the two tables in this file",
+                job.name
+            )
+        });
+
+        let expression = parse_expression(&job.expression, &job.name);
+        let gate = parse_gate(&job.body, &job.name);
+        assert!(
+            !gate.is_empty(),
+            "job '{}' has no Eastern gate but is not listed as ungated",
+            job.name
+        );
+
+        let by_session = firings_by_session(&expression, &gate);
+
+        // Checked before the per-day comparison below, because a day with no firing at all is
+        // absent from the map rather than present with the wrong times — so comparing only what is
+        // there would silently accept a job that stops firing for half the year.
+        assert_eq!(
+            by_session.keys().copied().collect::<Vec<NaiveDate>>(),
+            expected_sessions(&expression),
+            "job '{}' does not fire on every day its schedule admits",
+            job.name
+        );
+
+        for (session, times) in &by_session {
+            assert_eq!(
+                times, &expected,
+                "job '{}' fires at a different Eastern schedule on {session}",
+                job.name
+            );
+        }
+
+        checked += 1;
+    }
+
+    assert_eq!(
+        checked,
+        jobs.len() - UNGATED_JOBS.len(),
+        "every gated job must have been checked"
+    );
+}
+
+/// A gated job must fire on trading weekdays and never on a weekend.
+#[test]
+fn test_gated_schedules_never_fire_on_a_weekend() {
+    for job in parse_jobs(SCHEMA) {
+        if UNGATED_JOBS.contains(&job.name.as_str()) {
+            continue;
+        }
+        let expression = parse_expression(&job.expression, &job.name);
+        let gate = parse_gate(&job.body, &job.name);
+
+        let sessions: Vec<NaiveDate> = firings_by_session(&expression, &gate)
+            .into_keys()
+            .filter(|session| {
+                matches!(
+                    session.weekday(),
+                    chrono::Weekday::Sat | chrono::Weekday::Sun
+                )
+            })
+            .collect();
+
+        assert!(
+            sessions.is_empty(),
+            "job '{}' fires on {sessions:?}, which are not trading days",
+            job.name
+        );
+    }
+}
+
+/// The specific defect the gate exists to prevent: a job firing twice on the same Eastern day.
+///
+/// Each once-daily job is scheduled across two UTC hours so that one of them is correct in either
+/// daylight-saving regime. Widen a gate past sixty minutes and both firings pass, and the job runs
+/// twice — the failure the comment in `schema.sql` warns about, asserted here rather than trusted.
+#[test]
+fn test_a_once_daily_job_fires_exactly_once_per_session() {
+    let once_daily = [
+        "predictions-requested",
+        "portfolio-liquidation-requested",
+        "account-sync-requested",
+        "market-data-sync-requested",
+    ];
+
+    for job in parse_jobs(SCHEMA) {
+        if !once_daily.contains(&job.name.as_str()) {
+            continue;
+        }
+        let expression = parse_expression(&job.expression, &job.name);
+        let gate = parse_gate(&job.body, &job.name);
+
+        // The precondition that makes this meaningful: the expression really does fire more than
+        // once a day, so passing is the gate's doing and not the expression's.
+        assert!(
+            expression.hours.len() * expression.minutes.len() > 1,
+            "job '{}' fires once before gating, so this proves nothing",
+            job.name
+        );
+
+        for (session, times) in firings_by_session(&expression, &gate) {
+            assert_eq!(
+                times.len(),
+                1,
+                "job '{}' passed its gate {} times on {session}",
+                job.name,
+                times.len()
+            );
+        }
+    }
+}
+
+/// The parser refuses what it does not model, rather than reading it as "never fires".
+#[test]
+fn test_the_parser_rejects_syntax_it_does_not_model() {
+    assert!(
+        std::panic::catch_unwind(|| parse_expression("0 13 1 * 1-5", "restricted-day")).is_err(),
+        "a restricted day-of-month must be refused"
+    );
+    assert!(
+        std::panic::catch_unwind(|| parse_field("13~14", 0, 23, "job")).is_err(),
+        "an unrecognized field form must be refused"
+    );
+    assert!(
+        std::panic::catch_unwind(|| parse_field("61", 0, 59, "job")).is_err(),
+        "an out-of-range value must be refused"
+    );
+    assert!(
+        std::panic::catch_unwind(|| parse_expression("0 13 * *", "too-few")).is_err(),
+        "an expression with the wrong field count must be refused"
+    );
+}
+
+/// The parser reads the schema's real forms correctly.
+#[test]
+fn test_the_parser_reads_the_forms_the_schema_uses() {
+    assert_eq!(parse_field("0", 0, 59, "job"), vec![0]);
+    assert_eq!(parse_field("13,14", 0, 23, "job"), vec![13, 14]);
+    assert_eq!(
+        parse_field("13-20", 0, 23, "job"),
+        (13..=20).collect::<Vec<u32>>()
+    );
+    assert_eq!(
+        parse_field("*/5", 0, 59, "job"),
+        (0..=55).step_by(5).collect::<Vec<u32>>()
+    );
+    // Sunday is expressible as either 0 or 7, and both must normalize to the same day.
+    assert_eq!(parse_expression("0 3 * * 0", "job").days_of_week, vec![0]);
+    assert_eq!(parse_expression("0 3 * * 7", "job").days_of_week, vec![0]);
+}
+
+/// Gate parsing, including that an ungated body yields no bounds rather than a spurious one.
+#[test]
+fn test_gate_parsing_reads_bounds_and_their_inclusivity() {
+    let body = "SELECT emit_event('x', '{}'::jsonb) \
+                WHERE (now() AT TIME ZONE 'America/New_York')::time >= TIME '09:00' \
+                  AND (now() AT TIME ZONE 'America/New_York')::time < TIME '09:20'";
+    let gate = parse_gate(body, "job");
+    assert_eq!(gate.len(), 2);
+
+    assert!(!gate_admits(&gate, time("08:59")));
+    assert!(
+        gate_admits(&gate, time("09:00")),
+        "the lower bound is inclusive"
+    );
+    assert!(gate_admits(&gate, time("09:19")));
+    assert!(
+        !gate_admits(&gate, time("09:20")),
+        "the upper bound is exclusive"
+    );
+
+    assert!(parse_gate("DELETE FROM cron.job_run_details", "job").is_empty());
+}


### PR DESCRIPTION
# Overview

A sweep of every place the system expresses a time, a timezone, or a schedule — schema schedules, cron entries, struct fields, storage semantics, display — followed by remediation of what it turned up.

The five pg_cron trading schedules were already correct. Each fires on a UTC expression and gates on the Eastern wall clock, so a daylight-saving transition needs no schema re-apply. I verified the arithmetic on all five in both regimes. But that correctness was argued entirely in comments, and four gaps sat around it.

## Changes

**Gap 1 — the trainer's crontab hour was the only schedule not pinned to a timezone.** `0 23 * * 1-5` runs in the VM's system timezone, and nothing in `bootstrap-machine`, `provision-trainer-vm`, or the cron shim set or asserted it. The comment's claim of "19:00 Eastern in summer, 18:00 in winter" rested on host state nobody controlled. `CRON_TZ=UTC` now pins it in the crontab itself. The check is independent of the training-entry guard and prepends rather than appends — a machine provisioned before the pin existed already has the entry, so a check riding along with it would never run there.

**Gap 2 — the trainer derived "today" three different ways in one binary.** `eastern_date(Utc::now())` for the fetch stage, `Utc::now().date_naive()` for the archive load and the run metadata. They agree at 23:00 UTC and diverge the moment a run crosses UTC midnight, so a long run read a window shifted a day off the one it had just written, silently dropping its oldest session. One `now`, resolved once, threaded through all three.

**Gap 3 — the artifact staleness metric was meaningless.** The run identifier was stamped in UTC but compared against an Eastern date, so the same artifact reported age 0 or 1 depending only on how long training took. Worse: the trainer publishes after one session's close for the *next* session, so a healthy artifact is always at least one calendar day old — three across a weekend — and the `>= 1` threshold warned on every healthy morning. The identifier is now stamped from `eastern_datetime`, and `artifact_staleness_sessions` counts trading *sessions* between the artifact and today, using the calendar the handler already holds. Zero is healthy.

**Gap 4 — the schedules had no executable cover at all.** `tests/common/mod.rs` strips `pg_cron` out of the schema before applying it, so those blocks were not merely untested but deliberately excluded. `tests/test_schedules.rs` reads `schema.sql` as text instead — no database, no extension — and asserts the invariant that daylight-saving safety actually means: **the set of Eastern times a job fires at is identical on every trading weekday of the year.** That holds for a once-daily job and a five-minute job without special-casing either.

**Dashboard timestamps are now Eastern with an explicit `ET` suffix.** Two columns previously carried no timezone at all, and a page rendered in UTC disagreed with the session it described for the last hours of every evening — exactly when an operator checks whether the post-close jobs ran.

**`SessionDate`.** Underneath all four gaps: a session and an instant were both spelled `NaiveDate`/`DateTime` with nothing telling them apart, and every timekeeping bug this system has had was that confusion. The type has exactly two constructors — `at` (from an instant, via `America/New_York`) and `from_date` (for dates that already *are* sessions: a parsed argument, a `DATE` column, an exchange calendar entry) — and `midnight`/`bounds`/`plus_calendar_days` replace the free functions, so there is one path from a session to an instant. Transport modules (`common::alpaca`, `common::massive`, `common::aws`) keep `NaiveDate`; the wrap happens at the domain boundary, in `TradingCalendar::from_days`.

**CLAUDE.md** gains the instant/session rule, the transport-boundary rule, and the fixture-stamping rule.

## Context

### Three further defects the type surfaced

Threading `SessionDate` through was expected to be mechanical. It was not.

- **`engineer_features` derived the model's calendar covariates from the UTC date.** `day_of_week`, `month`, `year` all came from `datetime.date_naive()`. It produces the right answer today *only* because Eastern midnight lands in the morning of the same UTC day. If the bar stamp ever moved later in the session, every calendar feature would silently shift a day.
- **Both test fixtures seeded bars at UTC midnight** while production stamps Eastern. A bar seeded for session D fell in session D-1's window — the same round-trip defect as #1041, living in `tests/common/mod.rs`.
- **`load_liquidity` bounded on UTC midnight** against Eastern-stamped bars. Harmless in outcome, since the offset only widens the window across hours that hold no bars, but it is the idiom.

The covariate fix is not cosmetic. With the fixture left on UTC midnight, `test_engineer_features_day_of_week_is_monday_based_one_to_seven` fails `[7, 6]` against the expected `[1, 7]` — Monday and Sunday reading as Sunday and Saturday. The fixture was corrected, not the assertion.

### Verification

The schedule test was mutation-tested rather than trusted. An earlier version of it **passed** when a candidate UTC hour was deleted: the broken days produced no firing at all, so they were absent from the map rather than disagreeing with it, and "all present days agree" is vacuous over the days that survived. `expected_sessions` was added to assert the key set first. All three mutations now fail correctly:

| Mutation | Caught by |
|---|---|
| Drop one candidate UTC hour | `does not fire on every day its schedule admits` |
| Widen a gate past 60 minutes | `passed its gate 2 times on 2026-03-09` |
| Shift a gate time by 5 minutes | `does not fire on every day its schedule admits` |

`schema.sql` was verified unmodified afterwards.

`checks:rust` passes at **80.8%** line coverage, `checks:nix` and `checks:markdown` clean, and the `.sqlx` offline cache verified unchanged with `cargo sqlx prepare --check`.

### On the size of this diff

This is one commit covering both the bug fixes and a wide mechanical refactor, which makes the review surface mostly rename churn with the real fixes distributed through it. Splitting it after the fact was not practical: `SessionDate` touches nearly every file the bug fixes touch, and `data/calendar.rs` carries both the new `eastern_datetime` helper and the type that supersedes it, so no whole-file staging produces a set of commits that each compile. The section order above is the suggested reading order — `data/calendar.rs` first for the type, then `handlers.rs` and `bin/tide_model_trainer.rs` for the behaviour changes, then the rest as propagation.

### Deferred

Two items remain out of scope and unchanged: cross-sectional normalization of the model signal, and integrating more model outputs into risk management. Both still need a model retrained at `output_length = 1` before they can be decided.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Eastern trading-session dates across market data, dashboards, predictions, portfolios, and exports.
  * Dashboard timestamps now display Eastern Time with an `ET` label.
  * Artifact freshness is reported in missed trading sessions, improving weekend and holiday accuracy.
  * Scheduling behavior now consistently accounts for UTC execution and Eastern-time trading windows.

* **Tests**
  * Added comprehensive schedule validation, including daylight-saving, weekends, boundaries, and once-daily execution checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->