### PR TITLE
Admit the liquidity threshold itself, and let the metrics suite fail

### DIFF
--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -16,6 +16,12 @@ use uuid::Uuid;
 ///
 /// Training applies them per row and inference per ticker average; both sides must use the same
 /// values, or the scaler and model learn dynamics the service never predicts.
+///
+/// The *comparison* has to match too, and matching values are not enough on their own. All three
+/// readers — `filter_training_bars`, `filter_equity_bars`, and `Universe::is_liquid` — admit the
+/// threshold itself, so a ticker averaging exactly $10.00 is in the universe, in the training set,
+/// and predicted for. Each has a boundary test, because this is the kind of skew that costs one
+/// character and shows up only at the edge of the population.
 pub const MINIMUM_CLOSE_PRICE: f64 = 10.0;
 pub const MINIMUM_VOLUME: f64 = 1_000_000.0;
 

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 /// values, or the scaler and model learn dynamics the service never predicts.
 ///
 /// The *comparison* has to match too, and matching values are not enough on their own. All three
-/// readers — `filter_training_bars`, `filter_equity_bars`, and `Universe::is_liquid` — admit the
+/// readers — `filter_training_bars`, `filter_equity_bars`, and `LiquidityRow::is_liquid` — admit the
 /// threshold itself, so a ticker averaging exactly $10.00 is in the universe, in the training set,
 /// and predicted for. Each has a boundary test, because this is the kind of skew that costs one
 /// character and shows up only at the edge of the population.

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -30,6 +30,80 @@ impl EvalMetrics {
     }
 }
 
+/// The three positions in the quantile list the metrics read, resolved once per evaluation.
+///
+/// The quantiles arrive from the artifact in whatever order training wrote them, so "lowest",
+/// "highest", and "the median" are positions to be found rather than indices 0, 1, and 2.
+#[derive(Debug, Clone, Copy)]
+struct QuantileIndices {
+    lower: usize,
+    median: usize,
+    upper: usize,
+}
+
+impl QuantileIndices {
+    fn locate(quantiles: &[f64]) -> Self {
+        Self {
+            lower: argmin(quantiles),
+            median: closest_to(quantiles, 0.5),
+            upper: argmax(quantiles),
+        }
+    }
+}
+
+/// Running totals behind the three metrics.
+///
+/// This exists so the tests can reach the arithmetic without running the network. They used to
+/// assert against their own copy of the loop below, which meant a change to the pinball split, the
+/// median selection, or the coverage bounds left every one of them green — a suite that named the
+/// thing it could not detect a regression in. One implementation, two callers.
+#[derive(Debug, Default, Clone, Copy)]
+struct MetricAccumulator {
+    pinball_sum: f64,
+    directional_matches: usize,
+    covered: usize,
+    row_count: usize,
+}
+
+impl MetricAccumulator {
+    /// Adds one horizon step: its predictions ordered to match `quantiles`, and the realized target.
+    ///
+    /// `row` must be exactly as long as `quantiles`; both callers slice it that way.
+    fn add_row(&mut self, row: &[f64], target: f64, quantiles: &[f64], indices: QuantileIndices) {
+        for (index, &quantile) in quantiles.iter().enumerate() {
+            let error = target - row[index];
+            self.pinball_sum += if error >= 0.0 {
+                quantile * error
+            } else {
+                (quantile - 1.0) * error
+            };
+        }
+
+        if (row[indices.median] >= 0.0) == (target >= 0.0) {
+            self.directional_matches += 1;
+        }
+
+        if target >= row[indices.lower] && target <= row[indices.upper] {
+            self.covered += 1;
+        }
+
+        self.row_count += 1;
+    }
+
+    /// Averages the totals over the rows added, or returns zeros when none were.
+    fn finish(self) -> EvalMetrics {
+        if self.row_count == 0 {
+            return EvalMetrics::zero();
+        }
+        let rows = self.row_count as f64;
+        EvalMetrics {
+            crps: self.pinball_sum / rows,
+            directional_accuracy: self.directional_matches as f64 / rows,
+            quantile_coverage: self.covered as f64 / rows,
+        }
+    }
+}
+
 /// Run the (inner, non-autodiff) model over the validation dataset and compute
 /// the metrics. Returns zeros for an empty or target-less dataset.
 pub fn evaluate(
@@ -50,15 +124,13 @@ pub fn evaluate(
         return Ok(EvalMetrics::zero());
     }
 
-    let lower_index = argmin(quantiles);
-    let upper_index = argmax(quantiles);
-    let median_index = closest_to(quantiles, 0.5);
+    let indices = QuantileIndices::locate(quantiles);
 
     let device = Default::default();
     let mut predictions: Vec<f32> =
         Vec::with_capacity(sample_count * output_length * quantile_count);
-    let indices: Vec<usize> = (0..sample_count).collect();
-    for chunk in indices.chunks(EVAL_BATCH) {
+    let sample_indices: Vec<usize> = (0..sample_count).collect();
+    for chunk in sample_indices.chunks(EVAL_BATCH) {
         let input = build_input_tensor::<NdArray>(
             dataset,
             chunk,
@@ -89,54 +161,25 @@ pub fn evaluate(
         .into());
     }
 
-    let mut crps_sum = 0.0_f64;
-    let mut directional_matches = 0_usize;
-    let mut covered = 0_usize;
-    let mut row_count = 0_usize;
+    let mut accumulator = MetricAccumulator::default();
+    // Reused across rows: the model emits `f32` and the metrics are computed in `f64`, so each row
+    // is widened once into this buffer rather than allocating one per horizon step.
+    let mut row = Vec::with_capacity(quantile_count);
 
     for sample in 0..sample_count {
-        for t in 0..output_length {
-            let target = targets[[sample, t, 0]] as f64;
-            let base = (sample * output_length + t) * quantile_count;
-
-            let mut row_loss = 0.0_f64;
-            for (q_index, &quantile) in quantiles.iter().enumerate() {
-                let prediction = predictions[base + q_index] as f64;
-                let error = target - prediction;
-                let pinball = if error >= 0.0 {
-                    quantile * error
-                } else {
-                    (quantile - 1.0) * error
-                };
-                row_loss += pinball;
-            }
-            crps_sum += row_loss;
-
-            let q_median = predictions[base + median_index] as f64;
-            if (q_median >= 0.0) == (target >= 0.0) {
-                directional_matches += 1;
-            }
-
-            let q_lower = predictions[base + lower_index] as f64;
-            let q_upper = predictions[base + upper_index] as f64;
-            if target >= q_lower && target <= q_upper {
-                covered += 1;
-            }
-
-            row_count += 1;
+        for step in 0..output_length {
+            let base = (sample * output_length + step) * quantile_count;
+            row.clear();
+            row.extend(
+                predictions[base..base + quantile_count]
+                    .iter()
+                    .map(|&prediction| prediction as f64),
+            );
+            accumulator.add_row(&row, targets[[sample, step, 0]] as f64, quantiles, indices);
         }
     }
 
-    if row_count == 0 {
-        return Ok(EvalMetrics::zero());
-    }
-
-    let rows = row_count as f64;
-    Ok(EvalMetrics {
-        crps: crps_sum / rows,
-        directional_accuracy: directional_matches as f64 / rows,
-        quantile_coverage: covered as f64 / rows,
-    })
+    Ok(accumulator.finish())
 }
 
 fn argmin(values: &[f64]) -> usize {
@@ -247,41 +290,52 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------------
-    // metrics_from: helper that mirrors evaluate()'s row-level arithmetic so we
-    // can verify the math without running the neural network.
+    // metrics_from: feeds a fixed prediction table through the shipped accumulator
+    // so the math can be checked without running the neural network.
     // ---------------------------------------------------------------------------
 
-    /// Replicates the per-row accumulation in `evaluate` for a fixed prediction
-    /// table where each row has exactly `quantiles.len()` predictions ordered
-    /// lowest to highest quantile.
+    /// Runs `predictions` and `targets` through `MetricAccumulator`, the same type `evaluate` uses.
+    ///
+    /// This deliberately reimplements nothing: it lays out the fixture and hands each row to the
+    /// production accumulator. Every assertion below therefore fails if the pinball split, the
+    /// median selection, or the coverage bounds change in the shipped code.
     fn metrics_from(predictions: &[[f64; 3]], targets: &[f64], quantiles: &[f64]) -> EvalMetrics {
-        let mut crps_sum = 0.0;
-        let mut directional = 0;
-        let mut covered = 0;
-        for (row, &target) in targets.iter().enumerate() {
-            let mut row_loss = 0.0;
-            for (qi, &q) in quantiles.iter().enumerate() {
-                let error = target - predictions[row][qi];
-                row_loss += if error >= 0.0 {
-                    q * error
-                } else {
-                    (q - 1.0) * error
-                };
-            }
-            crps_sum += row_loss;
-            if (predictions[row][1] >= 0.0) == (target >= 0.0) {
-                directional += 1;
-            }
-            if target >= predictions[row][0] && target <= predictions[row][2] {
-                covered += 1;
-            }
+        let indices = QuantileIndices::locate(quantiles);
+        let mut accumulator = MetricAccumulator::default();
+        for (row, &target) in predictions.iter().zip(targets) {
+            accumulator.add_row(row, target, quantiles, indices);
         }
-        let n = targets.len() as f64;
-        EvalMetrics {
-            crps: crps_sum / n,
-            directional_accuracy: directional as f64 / n,
-            quantile_coverage: covered as f64 / n,
-        }
+        accumulator.finish()
+    }
+
+    /// The quantile list is whatever training wrote, so the three positions are found rather than
+    /// assumed. The old test helper hardcoded 0, 1, and 2, which is why it could not have caught
+    /// this: an artifact listing its quantiles in any other order would have had its coverage
+    /// measured between the wrong two bounds.
+    #[test]
+    fn test_quantile_indices_are_located_not_assumed() {
+        let indices = QuantileIndices::locate(&[0.9, 0.1, 0.5]);
+        assert_eq!(indices.lower, 1, "0.1 is at position 1");
+        assert_eq!(indices.median, 2, "0.5 is at position 2");
+        assert_eq!(indices.upper, 0, "0.9 is at position 0");
+    }
+
+    /// Coverage is read from the located bounds, so a shuffled quantile list must produce the same
+    /// answer as a sorted one over the correspondingly shuffled predictions.
+    #[test]
+    fn test_coverage_is_unchanged_by_the_order_of_the_quantile_list() {
+        let sorted = metrics_from(&[[-0.5, 0.0, 0.5]], &[0.3], &[0.1, 0.5, 0.9]);
+        let shuffled = metrics_from(&[[0.5, -0.5, 0.0]], &[0.3], &[0.9, 0.1, 0.5]);
+
+        assert_eq!(sorted.quantile_coverage, 1.0);
+        assert_eq!(shuffled.quantile_coverage, sorted.quantile_coverage);
+        assert_eq!(shuffled.directional_accuracy, sorted.directional_accuracy);
+        assert!(
+            (shuffled.crps - sorted.crps).abs() < 1e-9,
+            "pinball loss pairs each quantile with its own prediction: {} vs {}",
+            shuffled.crps,
+            sorted.crps
+        );
     }
 
     #[test]

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -299,10 +299,28 @@ mod tests {
     /// This deliberately reimplements nothing: it lays out the fixture and hands each row to the
     /// production accumulator. Every assertion below therefore fails if the pinball split, the
     /// median selection, or the coverage bounds change in the shipped code.
+    ///
+    /// The two length assertions are the point of the helper as much as the accumulator call is.
+    /// Every metric here is a mean, so a fixture with more prediction rows than targets would zip
+    /// short, divide by a smaller row count, and produce a plausible number for a table nobody
+    /// wrote — the failure this whole change exists to remove, reintroduced in the fixture instead
+    /// of the code.
     fn metrics_from(predictions: &[[f64; 3]], targets: &[f64], quantiles: &[f64]) -> EvalMetrics {
+        assert_eq!(
+            predictions.len(),
+            targets.len(),
+            "fixture must give every prediction row a target"
+        );
+        assert_eq!(
+            quantiles.len(),
+            3,
+            "rows are [f64; 3], so a shorter list would leave predictions unscored and a longer one \
+             would index past the row"
+        );
+
         let indices = QuantileIndices::locate(quantiles);
         let mut accumulator = MetricAccumulator::default();
-        for (row, &target) in predictions.iter().zip(targets) {
+        for (row, &target) in predictions.iter().zip(targets.iter()) {
             accumulator.add_row(row, target, quantiles, indices);
         }
         accumulator.finish()

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -114,6 +114,13 @@ pub fn consolidate_data(
     Ok(selected)
 }
 
+/// Drops tickers whose trailing averages fall below the liquidity thresholds.
+///
+/// **Both bounds are inclusive**, matching [`crate::models::tide::fit::filter_training_bars`] and
+/// [`crate::data::universe::Universe::is_liquid`]. The three read the same two constants, so a
+/// difference in the comparison alone is enough to reopen the train/serve gap those constants were
+/// introduced to close: an exclusive test here would admit a ticker to the universe, train on it,
+/// and then refuse to predict for it at exactly the threshold.
 pub fn filter_equity_bars(
     data: DataFrame,
     minimum_average_close_price: f64,
@@ -134,8 +141,8 @@ pub fn filter_equity_bars(
         ])
         .filter(
             col("average_close_price")
-                .gt(lit(minimum_average_close_price))
-                .and(col("average_volume").gt(lit(minimum_average_volume))),
+                .gt_eq(lit(minimum_average_close_price))
+                .and(col("average_volume").gt_eq(lit(minimum_average_volume))),
         )
         .select([col("ticker")])
         .collect()
@@ -674,6 +681,39 @@ mod tests {
             .into_no_null_iter()
             .collect();
         assert!(tickers.iter().all(|t| *t == "GOOG"));
+    }
+
+    /// The threshold itself must pass, because the other two sites that read these constants let it
+    /// pass. `filter_training_bars` and `Universe::is_liquid` both compare inclusively and both have
+    /// a boundary test; this one had neither, and was the site that diverged. A ticker averaging
+    /// exactly $10.00 was admitted to the universe, trained on, and dropped at inference.
+    #[test]
+    fn test_filter_equity_bars_keeps_a_ticker_exactly_at_both_thresholds() {
+        use crate::common::types::{MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME};
+
+        // Two bars either side of each threshold, so the averages land on it exactly rather than
+        // near it: (9 + 11)/2 = 10.00 and (500k + 1.5M)/2 = 1,000,000.
+        let data = DataFrame::new(vec![
+            Column::new("ticker".into(), vec!["EDGE", "EDGE"]),
+            Column::new("timestamp".into(), vec![1000i64, 2000]),
+            Column::new(
+                "close_price".into(),
+                vec![MINIMUM_CLOSE_PRICE - 1.0, MINIMUM_CLOSE_PRICE + 1.0],
+            ),
+            Column::new(
+                "volume".into(),
+                vec![(MINIMUM_VOLUME / 2.0) as i64, (MINIMUM_VOLUME * 1.5) as i64],
+            ),
+        ])
+        .unwrap();
+
+        let result = filter_equity_bars(data, MINIMUM_CLOSE_PRICE, MINIMUM_VOLUME).unwrap();
+
+        assert_eq!(
+            result.height(),
+            2,
+            "a ticker sitting exactly on both thresholds must survive inference filtering"
+        );
     }
 
     #[test]

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -117,7 +117,7 @@ pub fn consolidate_data(
 /// Drops tickers whose trailing averages fall below the liquidity thresholds.
 ///
 /// **Both bounds are inclusive**, matching [`crate::models::tide::fit::filter_training_bars`] and
-/// [`crate::data::universe::Universe::is_liquid`]. The three read the same two constants, so a
+/// [`crate::data::universe::LiquidityRow`]'s liquidity test. The three read the same two constants, so a
 /// difference in the comparison alone is enough to reopen the train/serve gap those constants were
 /// introduced to close: an exclusive test here would admit a ticker to the universe, train on it,
 /// and then refuse to predict for it at exactly the threshold.
@@ -684,7 +684,7 @@ mod tests {
     }
 
     /// The threshold itself must pass, because the other two sites that read these constants let it
-    /// pass. `filter_training_bars` and `Universe::is_liquid` both compare inclusively and both have
+    /// pass. `filter_training_bars` and `LiquidityRow::is_liquid` both compare inclusively and both have
     /// a boundary test; this one had neither, and was the site that diverged. A ticker averaging
     /// exactly $10.00 was admitted to the universe, trained on, and dropped at inference.
     #[test]


### PR DESCRIPTION
# Overview

Two of the model-hardening findings deferred from #1035. Both are cases where a check reads as
covered and is not: one threshold that three sites disagree about, and a test suite that measures
its own copy of the code it names.

No behaviour change to the strategy. Nothing here needs a retrained artifact.

## Changes

- Compare the liquidity thresholds inclusively in `filter_equity_bars`, matching
  `filter_training_bars` and `Universe::is_liquid`, and add the boundary test that site was missing
- State the inclusive-comparison invariant on `MINIMUM_CLOSE_PRICE` / `MINIMUM_VOLUME`, where the
  matching-values invariant already lives
- Extract the per-row metric arithmetic in `evaluate` into `MetricAccumulator`, and call it from the
  test helper that previously reimplemented it
- Resolve the three quantile positions through `QuantileIndices`, and test that they are located
  rather than assumed
- Rename `evaluate`'s sample-index list, which shadowed the quantile indices

## Context

**The threshold skew.** All three readers take their values from `common::types`, and the doc
comment there exists because training and inference were historically given *different* values —
the scaler ended up fitted on penny-stock dynamics the service never predicts. The values agree
now. The comparisons did not: `filter_training_bars` and `Universe::is_liquid` use `>=`, while
`filter_equity_bars` used `gt`.

So a ticker whose trailing average close was exactly $10.00 was admitted to the universe, trained
on, and then dropped at inference. That is the same train/serve gap the constants were introduced
to close, reopened by one character.

The two inclusive sites each have an explicit boundary test. The exclusive one had neither the
comparison nor the test, and the six other `filter_equity_bars` tests all pass with the operator
wrong — they only ever probe values well clear of the boundary.

**The metrics suite.** `metrics_from` was a test-local reimplementation of the per-row accumulation
in `evaluate`, and every CRPS, directional-accuracy, and coverage assertion ran against it. The
shipped arithmetic had no cover at all.

Verified rather than assumed. Breaking the shipped median selection under the old structure —
reading the lowest quantile where the median belongs — leaves all 25 tests passing. After this
change the same mutation fails `test_directional_accuracy_both_positive`, the test named for the
behaviour.

Worth recording: mutating the pinball split instead *was* caught on the old structure, but only by
`test_evaluate_with_samples_returns_valid_metrics` asserting `crps >= 0.0` against a randomly
initialised model. That is an incidental catch by a range check, and it depends on the random
weights producing a negative-error row. Every test named for the pinball loss stayed green.

Extracting the accumulator surfaced two things that were invisible while the code was inline. The
loop shadowed `indices` — the located quantile positions — with the sample-index list built for
chunking, which the compiler only flagged once the two had different types. And the three quantile
positions are *located* in production (`argmin`, `argmax`, `closest_to`) but were *hardcoded* as 0,
1, 2 in the test copy, so an artifact writing its quantiles in any other order would have had its
coverage measured between the wrong two bounds with the suite green. Both now have tests.

Local: `checks:rust` passes at 80.89% line coverage against the 75% floor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assets meeting the exact minimum average price and volume thresholds are now consistently included.
  * Improved prediction evaluation for quantile ordering, coverage, directional accuracy, and CRPS metrics.
  * Added safer handling for evaluations with no prediction rows.

* **Documentation**
  * Clarified that liquidity threshold comparisons are inclusive across training, filtering, and liquidity checks.
  * Added coverage for boundary conditions and metric calculations to help ensure consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->