### PR TITLE
Validate the training artifact at the boundary it crosses

### DIFF
--- a/src/models/tide/artifact.rs
+++ b/src/models/tide/artifact.rs
@@ -30,9 +30,6 @@ pub struct ModelState {
     parameters: ModelParameters,
     scaler: Scaler,
     mappings: FeatureMappings,
-    continuous_columns: Vec<String>,
-    categorical_columns: Vec<String>,
-    static_categorical_columns: Vec<String>,
     artifact_key: String,
     /// Training run id: the timestamp segment of the artifact key. Written to
     /// `equity_predictions.model_run_id`, which is how a prediction is traced back to the artifact
@@ -43,15 +40,17 @@ pub struct ModelState {
 
 impl ModelState {
     /// Constructs a `ModelState` from a fully loaded artifact.
+    ///
+    /// The column lists the artifact was fitted with are no longer carried here. They are checked
+    /// against this build's constants inside [`crate::models::tide::data::Scaler::load`] and then
+    /// dropped: verifying them is what they were for, nothing read them afterwards, and keeping a
+    /// copy that is provably equal to the constants invited a future caller to trust the copy.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         model: TiDEModel<NdArray>,
         parameters: ModelParameters,
         scaler: Scaler,
         mappings: FeatureMappings,
-        continuous_columns: Vec<String>,
-        categorical_columns: Vec<String>,
-        static_categorical_columns: Vec<String>,
         artifact_key: String,
         run_id: String,
         load_timestamp: i64,
@@ -61,9 +60,6 @@ impl ModelState {
             parameters,
             scaler,
             mappings,
-            continuous_columns,
-            categorical_columns,
-            static_categorical_columns,
             artifact_key,
             run_id,
             load_timestamp,
@@ -84,18 +80,6 @@ impl ModelState {
 
     pub fn mappings(&self) -> &FeatureMappings {
         &self.mappings
-    }
-
-    pub fn continuous_columns(&self) -> &[String] {
-        &self.continuous_columns
-    }
-
-    pub fn categorical_columns(&self) -> &[String] {
-        &self.categorical_columns
-    }
-
-    pub fn static_categorical_columns(&self) -> &[String] {
-        &self.static_categorical_columns
     }
 
     pub fn artifact_key(&self) -> &str {
@@ -377,9 +361,8 @@ fn load_model_from_directory(dir: &Path, artifact_key: &str) -> Result<ModelStat
         .map_err(|e| ArtifactError::ModelLoad(e.to_string()))?;
 
     let scaler_path = dir.join("tide_data_scaler.json");
-    let (scaler, continuous_columns, categorical_columns, static_categorical_columns) =
-        crate::models::tide::data::Scaler::load(&scaler_path)
-            .map_err(|e| ArtifactError::ModelLoad(e.to_string()))?;
+    let scaler = crate::models::tide::data::Scaler::load(&scaler_path)
+        .map_err(|e| ArtifactError::ModelLoad(e.to_string()))?;
 
     let mappings_path = dir.join("tide_data_mappings.json");
     let mappings_content = std::fs::read_to_string(&mappings_path)
@@ -415,9 +398,6 @@ fn load_model_from_directory(dir: &Path, artifact_key: &str) -> Result<ModelStat
         parameters,
         scaler,
         mappings,
-        continuous_columns,
-        categorical_columns,
-        static_categorical_columns,
         artifact_key.to_string(),
         run_id_from_artifact_key(artifact_key),
         load_timestamp,

--- a/src/models/tide/batch.rs
+++ b/src/models/tide/batch.rs
@@ -62,6 +62,14 @@ pub fn validate_input_shape(
             dataset.future_categorical.shape()[1],
             output_length,
         ),
+        // Always one by construction, and read as `[sample, 0, feature]` regardless — so a dataset
+        // built some other way with a zero-length axis would panic on a index this loop otherwise
+        // never looks at.
+        (
+            "static categorical",
+            dataset.static_categorical.shape()[1],
+            1,
+        ),
     ] {
         if available < required {
             return Err(format!(
@@ -187,6 +195,17 @@ mod tests {
         let error = validate_input_shape(&short, &parameters(32))
             .expect_err("a short window must be refused");
         assert!(error.contains("past continuous"), "got: {error}");
+    }
+
+    /// `build_input_tensor` reads `[sample, 0, feature]` from the static block unconditionally, so
+    /// a zero-length time axis panics on an index the other three checks never look at.
+    #[test]
+    fn test_a_zero_length_static_axis_is_refused() {
+        let mut degenerate = dataset(7, 5, 3);
+        degenerate.static_categorical = ndarray::Array3::zeros((4, 0, 3));
+        let error = validate_input_shape(&degenerate, &parameters(32))
+            .expect_err("a static block with no time axis must be refused");
+        assert!(error.contains("static categorical"), "got: {error}");
     }
 
     #[test]

--- a/src/models/tide/batch.rs
+++ b/src/models/tide/batch.rs
@@ -5,7 +5,73 @@
 
 use burn::prelude::*;
 
+use crate::models::tide::configuration::ModelParameters;
 use crate::models::tide::data::TrainingDataset;
+
+/// Checks that a dataset can produce the input the loaded weights were trained to consume.
+///
+/// [`build_input_tensor`] derives its width from the *dataset's* shapes and never consults the
+/// parameters, so a dataset built from a different feature set reshapes cleanly and then fails
+/// inside the first linear layer — a burn panic about tensor dimensions, on the pre-open inference
+/// path, naming neither the artifact nor the column set.
+///
+/// Called once per dataset rather than inside the batch loop: the invariant is a property of
+/// `(dataset, parameters)`, not of a chunk, and the inference path would otherwise re-check it for
+/// every batch of 4096.
+pub fn validate_input_shape(
+    dataset: &TrainingDataset,
+    parameters: &ModelParameters,
+) -> Result<(), String> {
+    let input_length = parameters.input_length();
+    let output_length = parameters.output_length();
+
+    let continuous_feature_count = dataset.past_continuous.shape()[2];
+    let categorical_feature_count = dataset.past_categorical.shape()[2];
+    let static_feature_count = dataset.static_categorical.shape()[2];
+
+    let derived = input_length * continuous_feature_count
+        + input_length * categorical_feature_count
+        + output_length * categorical_feature_count
+        + static_feature_count;
+
+    if derived != parameters.input_size() {
+        return Err(format!(
+            "Dataset produces {derived} input features ({continuous_feature_count} continuous and \
+             {categorical_feature_count} categorical over {input_length} steps, \
+             {categorical_feature_count} known-future over {output_length}, {static_feature_count} \
+             static), but the artifact was trained on {}",
+            parameters.input_size()
+        ));
+    }
+
+    // Widths are indexed positionally up to these lengths, so a short window is an out-of-bounds
+    // panic rather than a short batch.
+    for (name, available, required) in [
+        (
+            "past continuous",
+            dataset.past_continuous.shape()[1],
+            input_length,
+        ),
+        (
+            "past categorical",
+            dataset.past_categorical.shape()[1],
+            input_length,
+        ),
+        (
+            "known-future categorical",
+            dataset.future_categorical.shape()[1],
+            output_length,
+        ),
+    ] {
+        if available < required {
+            return Err(format!(
+                "Dataset carries {available} {name} step(s) but the artifact needs {required}"
+            ));
+        }
+    }
+
+    Ok(())
+}
 
 /// Build the `[batch, input_size]` forward input for the given sample indices.
 pub fn build_input_tensor<B: Backend>(
@@ -68,4 +134,65 @@ pub fn build_target_tensor<B: Backend>(
         }
     }
     Tensor::<B, 1>::from_floats(buffer.as_slice(), device).reshape([indices.len(), output_length])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A dataset with the given per-step feature widths. With `input_length` 2 and `output_length`
+    /// 1, the derived input size is `2*continuous + 2*categorical + 1*categorical + static`.
+    fn dataset(continuous: usize, categorical: usize, static_features: usize) -> TrainingDataset {
+        TrainingDataset {
+            past_continuous: ndarray::Array3::zeros((4, 2, continuous)),
+            past_categorical: ndarray::Array3::zeros((4, 2, categorical)),
+            future_categorical: ndarray::Array3::zeros((4, 1, categorical)),
+            static_categorical: ndarray::Array3::zeros((4, 1, static_features)),
+            targets: None,
+        }
+    }
+
+    fn parameters(input_size: usize) -> ModelParameters {
+        ModelParameters::new(input_size, 2, 1)
+    }
+
+    #[test]
+    fn test_a_matching_dataset_passes() {
+        // 2*7 + 2*5 + 1*5 + 3 = 32
+        assert!(validate_input_shape(&dataset(7, 5, 3), &parameters(32)).is_ok());
+    }
+
+    /// The failure this replaces is a burn panic about tensor dimensions raised inside the first
+    /// linear layer, on the pre-open inference path, naming neither the artifact nor the columns.
+    #[test]
+    fn test_a_feature_count_mismatch_is_reported_against_the_artifact() {
+        let error = validate_input_shape(&dataset(6, 5, 3), &parameters(32))
+            .expect_err("a dataset narrower than the trained input must be refused");
+
+        assert!(
+            error.contains("30"),
+            "should state what the data produces: {error}"
+        );
+        assert!(
+            error.contains("32"),
+            "should state what the artifact wants: {error}"
+        );
+    }
+
+    #[test]
+    fn test_a_window_shorter_than_the_artifact_needs_is_refused() {
+        let mut short = dataset(7, 5, 3);
+        // One past step where the parameters ask for two: indexing step 1 would be out of bounds.
+        short.past_continuous = ndarray::Array3::zeros((4, 1, 7));
+        let error = validate_input_shape(&short, &parameters(32))
+            .expect_err("a short window must be refused");
+        assert!(error.contains("past continuous"), "got: {error}");
+    }
+
+    #[test]
+    fn test_a_short_known_future_window_is_refused() {
+        let mut short = dataset(7, 5, 3);
+        short.future_categorical = ndarray::Array3::zeros((4, 0, 5));
+        assert!(validate_input_shape(&short, &parameters(32)).is_err());
+    }
 }

--- a/src/models/tide/configuration.rs
+++ b/src/models/tide/configuration.rs
@@ -81,17 +81,54 @@ impl ModelParameters {
     /// here keeps the failure at the boundary where the untrusted file is read.
     pub fn load(path: &std::path::Path) -> Result<Self, Box<dyn std::error::Error>> {
         let content = std::fs::read_to_string(path)?;
-        let params: Self = serde_json::from_str(&content)?;
-        if params.output_length == 0 || params.input_length == 0 {
+        let parameters: Self = serde_json::from_str(&content)?;
+        if parameters.output_length == 0 || parameters.input_length == 0 {
             return Err(format!(
                 "Model parameters at {} have a zero window length (input_length {}, output_length {})",
                 path.display(),
-                params.input_length,
-                params.output_length
+                parameters.input_length,
+                parameters.output_length
             )
             .into());
         }
-        Ok(params)
+        parameters
+            .validate_quantiles()
+            .map_err(|reason| format!("Model parameters at {}: {reason}", path.display()))?;
+        Ok(parameters)
+    }
+
+    /// Rejects a quantile list the rest of the pipeline cannot consume.
+    ///
+    /// Three consumers read this list and each responds to a bad one differently: `quantile_loss`
+    /// pairs it positionally with tensor slices, `evaluate`'s index helpers unwrap a `partial_cmp`
+    /// and so **panic on a non-finite value**, and the prediction path sizes its output by the
+    /// count. Validating once here is what lets all three treat `quantiles()` as trustworthy
+    /// instead of each inventing its own guard.
+    ///
+    /// Note what is deliberately *not* required: sorted order, and a `0.5` entry. Positions are
+    /// located rather than assumed, so an artifact may list its quantiles in any order, and a list
+    /// without an exact median resolves to the nearest one.
+    fn validate_quantiles(&self) -> Result<(), String> {
+        if self.quantiles.is_empty() {
+            return Err("the quantile list is empty, so the model predicts nothing".to_string());
+        }
+        for quantile in &self.quantiles {
+            if !quantile.is_finite() {
+                return Err(format!("quantile {quantile} is not finite"));
+            }
+            if *quantile <= 0.0 || *quantile >= 1.0 {
+                return Err(format!("quantile {quantile} is outside (0, 1)"));
+            }
+        }
+        for (index, quantile) in self.quantiles.iter().enumerate() {
+            if self.quantiles[..index].contains(quantile) {
+                return Err(format!(
+                    "quantile {quantile} appears more than once, so two output columns carry the \
+                     same prediction"
+                ));
+            }
+        }
+        Ok(())
     }
 
     pub fn input_size(&self) -> usize {
@@ -174,6 +211,60 @@ mod tests {
         let params: ModelParameters = serde_json::from_str(json).unwrap();
         assert_eq!(params.input_size(), 100);
         assert_eq!(params.hidden_size(), 64);
+    }
+
+    fn load_with_quantiles(quantiles: &str) -> Result<ModelParameters, String> {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("tide_parameters.json");
+        std::fs::write(
+            &path,
+            format!(
+                r#"{{"input_size": 100, "hidden_size": 64, "encoder_layer_count": 3,
+                     "decoder_layer_count": 2, "output_length": 1, "input_length": 35,
+                     "dropout_rate": 0.1, "quantiles": {quantiles}, "huber_delta": 0.5}}"#
+            ),
+        )
+        .unwrap();
+        ModelParameters::load(&path).map_err(|error| error.to_string())
+    }
+
+    /// Three consumers read this list and each responded to a bad one differently. The non-finite
+    /// case is the sharp one: `evaluate`'s index helpers unwrap a `partial_cmp`, so a NaN quantile
+    /// panicked on the pre-open inference path rather than reporting a bad artifact.
+    #[test]
+    fn test_load_rejects_a_quantile_list_the_pipeline_cannot_consume() {
+        assert!(load_with_quantiles("[]").is_err(), "empty");
+        assert!(load_with_quantiles("[0.1, 0.5, 0.5]").is_err(), "duplicate");
+        assert!(load_with_quantiles("[0.0, 0.5, 0.9]").is_err(), "zero");
+        assert!(load_with_quantiles("[0.1, 0.5, 1.0]").is_err(), "one");
+        assert!(load_with_quantiles("[0.1, 0.5, 1.5]").is_err(), "above one");
+        assert!(load_with_quantiles("[0.1, -0.5, 0.9]").is_err(), "negative");
+    }
+
+    /// serde_json cannot represent NaN, so a corrupt artifact expresses it as a literal that
+    /// deserializes into one. Guarded because it is the value that panics rather than misbehaves.
+    #[test]
+    fn test_load_rejects_a_non_finite_quantile() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("tide_parameters.json");
+        // 1e400 overflows f64 and deserializes to infinity.
+        std::fs::write(
+            &path,
+            r#"{"input_size": 100, "hidden_size": 64, "encoder_layer_count": 3,
+                "decoder_layer_count": 2, "output_length": 1, "input_length": 35,
+                "dropout_rate": 0.1, "quantiles": [0.1, 0.5, 1e400], "huber_delta": 0.5}"#,
+        )
+        .unwrap();
+        assert!(ModelParameters::load(&path).is_err());
+    }
+
+    /// Order is deliberately not a requirement: `evaluate` locates the lowest, highest, and nearest
+    /// to the median rather than assuming positions, so an artifact may list them any way round.
+    /// A list without an exact 0.5 is likewise fine.
+    #[test]
+    fn test_load_accepts_an_unsorted_list_and_one_without_an_exact_median() {
+        assert!(load_with_quantiles("[0.9, 0.1, 0.5]").is_ok());
+        assert!(load_with_quantiles("[0.2, 0.8]").is_ok());
     }
 
     #[test]

--- a/src/models/tide/configuration.rs
+++ b/src/models/tide/configuration.rs
@@ -3,6 +3,13 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The quantile levels `equity_predictions` has columns for, ascending.
+///
+/// This is a storage contract rather than a modelling preference: the table names its three columns
+/// `quantile_10`, `quantile_50`, and `quantile_90`, and those names are shipped. A model trained on
+/// other levels needs a schema migration, not a different constant here.
+pub const SERVED_QUANTILES: [f64; 3] = [0.1, 0.5, 0.9];
+
 /// TiDE model hyperparameters, persisted as `tide_parameters.json` in the training artifact and
 /// reloaded at inference time.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -105,9 +112,16 @@ impl ModelParameters {
     /// count. Validating once here is what lets all three treat `quantiles()` as trustworthy
     /// instead of each inventing its own guard.
     ///
-    /// Note what is deliberately *not* required: sorted order, and a `0.5` entry. Positions are
-    /// located rather than assumed, so an artifact may list its quantiles in any order, and a list
-    /// without an exact median resolves to the nearest one.
+    /// **The served set is fixed, because the storage columns are.** `equity_predictions` has
+    /// `quantile_10`, `quantile_50`, and `quantile_90`, and `generate_predictions` sorts the model's
+    /// output and assigns it to those three positionally. An artifact trained on `[0.1, 0.3, 0.9]`
+    /// is internally coherent and would load, predict, and store its 30th percentile under
+    /// `quantile_50` — which `EquityPrediction::expected_return` then returns as the model's median
+    /// view, with nothing anywhere to notice. Being usable is not the same as being the thing the
+    /// schema says it is.
+    ///
+    /// Order is still not required: positions are located rather than assumed, so an artifact may
+    /// list the three any way round.
     fn validate_quantiles(&self) -> Result<(), String> {
         if self.quantiles.is_empty() {
             return Err("the quantile list is empty, so the model predicts nothing".to_string());
@@ -120,13 +134,24 @@ impl ModelParameters {
                 return Err(format!("quantile {quantile} is outside (0, 1)"));
             }
         }
-        for (index, quantile) in self.quantiles.iter().enumerate() {
-            if self.quantiles[..index].contains(quantile) {
-                return Err(format!(
-                    "quantile {quantile} appears more than once, so two output columns carry the \
-                     same prediction"
-                ));
-            }
+
+        let mut sorted = self.quantiles.clone();
+        sorted.sort_by(|left, right| left.partial_cmp(right).expect("finiteness checked above"));
+        sorted.dedup();
+        if sorted.len() != self.quantiles.len() {
+            return Err(format!(
+                "the quantile list {:?} repeats a level, so two output columns carry the same \
+                 prediction",
+                self.quantiles
+            ));
+        }
+        if sorted != SERVED_QUANTILES {
+            return Err(format!(
+                "the quantile list {:?} is not the served set {SERVED_QUANTILES:?}; \
+                 `equity_predictions` stores exactly those three levels by name, so any other set \
+                 would be filed under the wrong column",
+                self.quantiles
+            ));
         }
         Ok(())
     }
@@ -260,11 +285,34 @@ mod tests {
 
     /// Order is deliberately not a requirement: `evaluate` locates the lowest, highest, and nearest
     /// to the median rather than assuming positions, so an artifact may list them any way round.
-    /// A list without an exact 0.5 is likewise fine.
     #[test]
-    fn test_load_accepts_an_unsorted_list_and_one_without_an_exact_median() {
+    fn test_load_accepts_the_served_set_in_any_order() {
+        assert!(load_with_quantiles("[0.1, 0.5, 0.9]").is_ok());
         assert!(load_with_quantiles("[0.9, 0.1, 0.5]").is_ok());
-        assert!(load_with_quantiles("[0.2, 0.8]").is_ok());
+    }
+
+    /// The levels are a storage contract, not a preference. `equity_predictions` names its three
+    /// columns after them and `generate_predictions` fills those positionally after sorting, so an
+    /// artifact trained on `[0.1, 0.3, 0.9]` would file its 30th percentile under `quantile_50` and
+    /// `expected_return` would return it as the model's median view.
+    ///
+    /// Every case below is internally coherent — finite, distinct, inside `(0, 1)` — and would have
+    /// passed had the check stopped at "usable".
+    #[test]
+    fn test_load_rejects_a_coherent_but_non_canonical_quantile_set() {
+        assert!(
+            load_with_quantiles("[0.1, 0.3, 0.9]").is_err(),
+            "shifted median"
+        );
+        assert!(
+            load_with_quantiles("[0.05, 0.5, 0.95]").is_err(),
+            "wider band"
+        );
+        assert!(load_with_quantiles("[0.2, 0.8]").is_err(), "two levels");
+        assert!(
+            load_with_quantiles("[0.1, 0.25, 0.5, 0.9]").is_err(),
+            "four levels"
+        );
     }
 
     #[test]

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 
 use chrono::Datelike;
 use polars::prelude::*;
-use serde::{Deserialize, Serialize};
 
 use crate::data::calendar::SessionDate;
 use crate::data::details::UNKNOWN as UNKNOWN_SECTOR_OR_INDUSTRY;
@@ -19,80 +18,141 @@ pub fn selector_by_names(names: &[&str]) -> Vec<PlSmallStr> {
     names.iter().map(|name| PlSmallStr::from(*name)).collect()
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Per-column standardization statistics, fitted during training and reloaded at inference.
+///
+/// **Holding one is proof it can scale.** Every mean is finite and every standard deviation is
+/// finite and strictly positive, checked once in [`Scaler::new`], so no call site re-checks and none
+/// can silently substitute a default.
+///
+/// That guarantee is the point of the type rather than decoration. This value crosses a machine
+/// boundary as a JSON file, and the failure it prevents is silent: a scaler that degrades to the
+/// identity produces predictions on the wrong scale, the service reports a successful load, and
+/// nothing downstream can distinguish them from good ones — the only remaining validation is
+/// `EquityPrediction::new`'s quantile ordering, which wrong-scale values satisfy perfectly well.
+///
+/// Deliberately not `Deserialize`: deriving it would reintroduce a path into the type that skips
+/// the constructor, which is the hole this closes.
+#[derive(Debug, Clone)]
 pub struct Scaler {
-    pub means: HashMap<String, f64>,
-    pub standard_deviations: HashMap<String, f64>,
+    means: HashMap<String, f64>,
+    standard_deviations: HashMap<String, f64>,
 }
 
 impl Scaler {
-    #[allow(clippy::type_complexity)]
-    pub fn load(
-        path: &std::path::Path,
-    ) -> Result<(Self, Vec<String>, Vec<String>, Vec<String>), Box<dyn std::error::Error>> {
+    /// Constructs a scaler, rejecting statistics that cannot standardize a column.
+    ///
+    /// A non-finite mean poisons every scaled value; a zero or negative standard deviation makes
+    /// the transform degenerate or sign-flipping, and its inverse meaningless.
+    pub fn new(
+        means: HashMap<String, f64>,
+        standard_deviations: HashMap<String, f64>,
+    ) -> Result<Self, String> {
+        for (column, mean) in &means {
+            if !mean.is_finite() {
+                return Err(format!(
+                    "Mean for column `{column}` is {mean}, which is not finite"
+                ));
+            }
+        }
+        for (column, standard_deviation) in &standard_deviations {
+            if !standard_deviation.is_finite() || *standard_deviation <= 0.0 {
+                return Err(format!(
+                    "Standard deviation for column `{column}` is {standard_deviation}, which cannot scale"
+                ));
+            }
+        }
+        Ok(Self {
+            means,
+            standard_deviations,
+        })
+    }
+
+    pub fn means(&self) -> &HashMap<String, f64> {
+        &self.means
+    }
+
+    pub fn standard_deviations(&self) -> &HashMap<String, f64> {
+        &self.standard_deviations
+    }
+
+    /// Reads a scaler from a training artifact, rejecting anything it cannot verify.
+    ///
+    /// **Every branch here refuses rather than defaults.** The previous version replaced an
+    /// unparsable `means` entry with `0.0`, an unparsable `standard_deviations` entry with `1.0`,
+    /// and a missing object with an empty map — which is exactly identity scaling, reported as a
+    /// successful load.
+    ///
+    /// The column lists the artifact was fitted with are checked against this build's constants and
+    /// then dropped. Checking them is the whole of their value: an artifact fitted on a different
+    /// column set would otherwise load without complaint and scale a different set than the weights
+    /// were trained on. Carrying them further served nothing — no caller read them.
+    pub fn load(path: &std::path::Path) -> Result<Self, Box<dyn std::error::Error>> {
+        let display = path.display();
         let content = std::fs::read_to_string(path)?;
         let raw: serde_json::Value = serde_json::from_str(&content)?;
 
-        let means: HashMap<String, f64> = raw["means"]
-            .as_object()
-            .map(|obj| {
-                obj.iter()
-                    .map(|(k, v)| (k.clone(), v.as_f64().unwrap_or(0.0)))
-                    .collect()
-            })
-            .unwrap_or_default();
+        let statistics = |field: &str| -> Result<HashMap<String, f64>, Box<dyn std::error::Error>> {
+            let object = raw[field]
+                .as_object()
+                .ok_or_else(|| format!("Scaler artifact at {display} has no `{field}` object"))?;
+            object
+                .iter()
+                .map(|(column, value)| {
+                    value.as_f64().map(|number| (column.clone(), number)).ok_or_else(|| {
+                        format!(
+                            "Scaler artifact at {display} has a non-numeric `{field}` entry for column `{column}`"
+                        )
+                        .into()
+                    })
+                })
+                .collect()
+        };
 
-        let standard_deviations: HashMap<String, f64> = raw["standard_deviations"]
-            .as_object()
-            .map(|obj| {
-                obj.iter()
-                    .map(|(k, v)| (k.clone(), v.as_f64().unwrap_or(1.0)))
-                    .collect()
-            })
-            .unwrap_or_default();
+        let means = statistics("means")?;
+        let standard_deviations = statistics("standard_deviations")?;
 
-        let continuous_columns: Vec<String> = raw["continuous_columns"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default();
+        for (field, expected) in [
+            ("continuous_columns", CONTINUOUS_COLUMNS),
+            ("categorical_columns", CATEGORICAL_COLUMNS),
+            ("static_categorical_columns", STATIC_CATEGORICAL_COLUMNS),
+        ] {
+            let array = raw[field]
+                .as_array()
+                .ok_or_else(|| format!("Scaler artifact at {display} has no `{field}` list"))?;
+            let found: Vec<&str> = array.iter().filter_map(|value| value.as_str()).collect();
+            if found != expected {
+                return Err(format!(
+                    "Scaler artifact at {display} was fitted on {field} {found:?}, but this build \
+                     expects {expected:?}"
+                )
+                .into());
+            }
+        }
 
-        let categorical_columns: Vec<String> = raw["categorical_columns"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default();
+        // The scaler is fitted over every continuous column, so a missing one means the artifact
+        // and this build disagree about the feature set even though the column list matched.
+        for column in CONTINUOUS_COLUMNS {
+            if !means.contains_key(*column) || !standard_deviations.contains_key(*column) {
+                return Err(format!(
+                    "Scaler artifact at {display} has no statistics for continuous column `{column}`"
+                )
+                .into());
+            }
+        }
 
-        let static_categorical_columns: Vec<String> = raw["static_categorical_columns"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        Ok((
-            Self {
-                means,
-                standard_deviations,
-            },
-            continuous_columns,
-            categorical_columns,
-            static_categorical_columns,
-        ))
+        Self::new(means, standard_deviations)
+            .map_err(|reason| format!("Scaler artifact at {display} is unusable: {reason}").into())
     }
 
+    /// Maps a scaled value back to its original units.
+    ///
+    /// Falls back to the identity for a column the scaler does not carry, which is reachable only
+    /// for a column outside `CONTINUOUS_COLUMNS` — [`Scaler::load`] rejects an artifact missing any
+    /// of those.
     pub fn inverse_transform_value(&self, column: &str, value: f64) -> f64 {
         let mean = self.means.get(column).copied().unwrap_or(0.0);
-        let std = self.standard_deviations.get(column).copied().unwrap_or(1.0);
-        value * std + mean
+        let standard_deviation = self.standard_deviations.get(column).copied().unwrap_or(1.0);
+        value * standard_deviation + mean
     }
 }
 
@@ -674,13 +734,13 @@ pub(crate) fn apply_scaling(
 ) -> Result<DataFrame, Box<dyn std::error::Error>> {
     let mut result = data;
     for column_name in CONTINUOUS_COLUMNS {
-        let mean = scaler.means.get(*column_name).copied().unwrap_or(0.0);
-        let std = scaler
-            .standard_deviations
+        let mean = scaler.means().get(*column_name).copied().unwrap_or(0.0);
+        // `Scaler::new` rejects a non-positive standard deviation, so no zero guard is needed here.
+        let standard_deviation = scaler
+            .standard_deviations()
             .get(*column_name)
             .copied()
             .unwrap_or(1.0);
-        let std = if std == 0.0 { 1e-8 } else { std };
 
         let values: Vec<f32> = result
             .column(column_name)
@@ -690,7 +750,7 @@ pub(crate) fn apply_scaling(
             .f64()
             .map_err(|e| e.to_string())?
             .into_no_null_iter()
-            .map(|v| ((v - mean) / std) as f32)
+            .map(|value| ((value - mean) / standard_deviation) as f32)
             .collect();
 
         result
@@ -764,17 +824,49 @@ pub(crate) fn encode_categoricals(
     Ok(result)
 }
 
+/// Rejects a column carrying nulls before its values are read positionally.
+///
+/// `into_no_null_iter` does not skip nulls and does not check for them: it reads the raw value
+/// sitting in the null slot, which is whatever the buffer happens to hold — `0.0` in practice, but
+/// that is an implementation detail rather than a guarantee. The count therefore matches the frame
+/// and nothing fails, so a null `close_price` is scaled and fed to the model as though someone had
+/// observed it.
+///
+/// **A silent wrong value, not a crash.** Checking the extracted length instead would be inert,
+/// because the length is never wrong. The null count is the only thing that carries the
+/// information.
+///
+/// The same family of trap produced a real bug fixed in #1035, where a null `sector` put later rows
+/// on the wrong ticker.
+fn reject_null_column(
+    column: &Column,
+    column_name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let nulls = column.null_count();
+    if nulls > 0 {
+        return Err(format!(
+            "Column `{column_name}` has {nulls} null value(s) in {} rows; reading it positionally \
+             would substitute the raw buffer value and treat it as a real observation",
+            column.len()
+        )
+        .into());
+    }
+    Ok(())
+}
+
 fn get_float_columns(
     data: &DataFrame,
     columns: &[&str],
 ) -> Result<Vec<Vec<f32>>, Box<dyn std::error::Error>> {
     let mut result = Vec::new();
     for column_name in columns {
-        let values: Vec<f32> = data
+        let cast = data
             .column(column_name)
             .map_err(|e| e.to_string())?
             .cast(&DataType::Float32)
-            .map_err(|e| e.to_string())?
+            .map_err(|e| e.to_string())?;
+        reject_null_column(&cast, column_name)?;
+        let values: Vec<f32> = cast
             .f32()
             .map_err(|e| e.to_string())?
             .into_no_null_iter()
@@ -790,11 +882,13 @@ fn get_int_columns(
 ) -> Result<Vec<Vec<i32>>, Box<dyn std::error::Error>> {
     let mut result = Vec::new();
     for column_name in columns {
-        let values: Vec<i32> = data
+        let cast = data
             .column(column_name)
             .map_err(|e| e.to_string())?
             .cast(&DataType::Int32)
-            .map_err(|e| e.to_string())?
+            .map_err(|e| e.to_string())?;
+        reject_null_column(&cast, column_name)?;
+        let values: Vec<i32> = cast
             .i32()
             .map_err(|e| e.to_string())?
             .into_no_null_iter()
@@ -802,6 +896,173 @@ fn get_int_columns(
         result.push(values);
     }
     Ok(result)
+}
+
+#[cfg(test)]
+mod scaler_boundary_tests {
+    use super::*;
+
+    fn statistics(value: f64) -> HashMap<String, f64> {
+        HashMap::from([("close_price".to_string(), value)])
+    }
+
+    fn well_formed_artifact() -> serde_json::Value {
+        let entries: HashMap<&str, f64> = CONTINUOUS_COLUMNS
+            .iter()
+            .map(|column| (*column, 1.0))
+            .collect();
+        serde_json::json!({
+            "means": entries,
+            "standard_deviations": entries,
+            "continuous_columns": CONTINUOUS_COLUMNS,
+            "categorical_columns": CATEGORICAL_COLUMNS,
+            "static_categorical_columns": STATIC_CATEGORICAL_COLUMNS,
+        })
+    }
+
+    fn load_artifact(artifact: &serde_json::Value) -> Result<Scaler, String> {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("tide_data_scaler.json");
+        std::fs::write(&path, serde_json::to_string(artifact).unwrap()).unwrap();
+        Scaler::load(&path).map_err(|error| error.to_string())
+    }
+
+    #[test]
+    fn test_a_well_formed_artifact_loads() {
+        assert!(load_artifact(&well_formed_artifact()).is_ok());
+    }
+
+    /// A standard deviation of zero divides, and a negative one flips the sign of every scaled
+    /// value while still looking like a number.
+    #[test]
+    fn test_new_rejects_a_standard_deviation_that_cannot_scale() {
+        for unusable in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            assert!(
+                Scaler::new(statistics(0.0), statistics(unusable)).is_err(),
+                "a standard deviation of {unusable} must be refused"
+            );
+        }
+        assert!(Scaler::new(statistics(0.0), statistics(1e-8)).is_ok());
+    }
+
+    #[test]
+    fn test_new_rejects_a_non_finite_mean() {
+        assert!(Scaler::new(statistics(f64::NAN), statistics(1.0)).is_err());
+        assert!(Scaler::new(statistics(f64::NEG_INFINITY), statistics(1.0)).is_err());
+    }
+
+    /// The headline case. A missing object used to yield an empty map, every lookup then fell back
+    /// to mean 0.0 and deviation 1.0, and scaling became the identity — reported as a successful
+    /// load, producing predictions on the wrong scale that nothing downstream can detect.
+    #[test]
+    fn test_load_refuses_a_missing_statistics_object_rather_than_scaling_by_identity() {
+        for field in ["means", "standard_deviations"] {
+            let mut artifact = well_formed_artifact();
+            artifact.as_object_mut().unwrap().remove(field);
+            let error = load_artifact(&artifact).expect_err("a missing object must be refused");
+            assert!(
+                error.contains(field),
+                "the error should name the missing field, got: {error}"
+            );
+        }
+    }
+
+    /// Same failure by a different route: an entry that is present but not a number used to be
+    /// silently replaced with the identity value for its field.
+    #[test]
+    fn test_load_refuses_a_non_numeric_entry() {
+        let mut artifact = well_formed_artifact();
+        artifact["means"]["close_price"] = serde_json::json!("not a number");
+        let error = load_artifact(&artifact).expect_err("a non-numeric entry must be refused");
+        assert!(
+            error.contains("close_price"),
+            "the error should name the column, got: {error}"
+        );
+    }
+
+    /// An artifact fitted on a different column set loaded without complaint and scaled a
+    /// different set than the weights were trained on.
+    #[test]
+    fn test_load_refuses_an_artifact_fitted_on_a_different_column_set() {
+        let mut artifact = well_formed_artifact();
+        artifact["continuous_columns"] = serde_json::json!(["close_price", "an_extra_feature"]);
+        let error = load_artifact(&artifact).expect_err("a column mismatch must be refused");
+        assert!(
+            error.contains("continuous_columns"),
+            "the error should name the list that disagreed, got: {error}"
+        );
+    }
+
+    #[test]
+    fn test_load_refuses_an_artifact_missing_a_continuous_column_statistic() {
+        let mut artifact = well_formed_artifact();
+        artifact["means"]
+            .as_object_mut()
+            .unwrap()
+            .remove("close_price");
+        let error = load_artifact(&artifact).expect_err("a missing statistic must be refused");
+        assert!(error.contains("close_price"), "got: {error}");
+    }
+
+    /// `into_no_null_iter` skips nulls, so one null yields a column shorter than the frame and
+    /// `window_frame` then indexes it out of bounds. The diagnostic has to name the column,
+    /// because the panic it replaces named nothing.
+    #[test]
+    fn test_a_null_in_a_continuous_column_is_refused_rather_than_read_as_a_value() {
+        let data = DataFrame::new(vec![
+            Column::new("close_price".into(), &[Some(1.0_f64), None, Some(3.0)]),
+            Column::new("open_price".into(), &[1.0_f64, 2.0, 3.0]),
+        ])
+        .unwrap();
+
+        // The behaviour being guarded against, pinned because it is not what the review that
+        // raised this described: `into_no_null_iter` neither skips the null nor fails on it. The
+        // count comes back correct and the null slot reads as a fabricated observation, which is
+        // exactly why checking the extracted length instead would have been an inert guard.
+        let raw: Vec<f32> = data
+            .column("close_price")
+            .unwrap()
+            .cast(&DataType::Float32)
+            .unwrap()
+            .f32()
+            .unwrap()
+            .into_no_null_iter()
+            .collect();
+        assert_eq!(
+            raw.len(),
+            3,
+            "nulls are not skipped, so no length is ever wrong"
+        );
+
+        let error = get_float_columns(&data, &["close_price", "open_price"])
+            .expect_err("a null must be refused, not silently read");
+        assert!(
+            error.to_string().contains("close_price"),
+            "the error must name the column: {error}"
+        );
+    }
+
+    #[test]
+    fn test_a_null_in_a_categorical_column_is_refused() {
+        let data = DataFrame::new(vec![Column::new(
+            "sector".into(),
+            &[Some(1_i32), None, Some(3)],
+        )])
+        .unwrap();
+
+        assert!(get_int_columns(&data, &["sector"]).is_err());
+    }
+
+    #[test]
+    fn test_complete_columns_are_accepted() {
+        let data = DataFrame::new(vec![Column::new(
+            "close_price".into(),
+            &[1.0_f64, 2.0, 3.0],
+        )])
+        .unwrap();
+        let columns = get_float_columns(&data, &["close_price"]).unwrap();
+        assert_eq!(columns[0].len(), 3);
+    }
 }
 
 #[cfg(test)]

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -20,9 +20,14 @@ pub fn selector_by_names(names: &[&str]) -> Vec<PlSmallStr> {
 
 /// Per-column standardization statistics, fitted during training and reloaded at inference.
 ///
-/// **Holding one is proof it can scale.** Every mean is finite and every standard deviation is
-/// finite and strictly positive, checked once in [`Scaler::new`], so no call site re-checks and none
-/// can silently substitute a default.
+/// **Holding one is proof that every column it carries can be scaled.** [`Scaler::new`] checks that
+/// each mean is finite, each standard deviation is finite and strictly positive, and that the two
+/// maps name the same columns — so no column is half-described and no call site re-checks.
+///
+/// It is deliberately *not* proof that a particular column is present, because a scaler over one
+/// column is a legitimate value: the unscale path asks only for `daily_return`. Covering every
+/// entry in `CONTINUOUS_COLUMNS` is a property of an *artifact*, not of the type, and
+/// [`Scaler::load`] is where it is enforced.
 ///
 /// That guarantee is the point of the type rather than decoration. This value crosses a machine
 /// boundary as a JSON file, and the failure it prevents is silent: a scaler that degrades to the
@@ -43,6 +48,10 @@ impl Scaler {
     ///
     /// A non-finite mean poisons every scaled value; a zero or negative standard deviation makes
     /// the transform degenerate or sign-flipping, and its inverse meaningless.
+    ///
+    /// The two maps must also name the same columns. A column with a mean but no deviation would
+    /// otherwise fall back to `1.0` and a column with a deviation but no mean to `0.0` — half of
+    /// the identity scaling this type exists to prevent, reached through the front door.
     pub fn new(
         means: HashMap<String, f64>,
         standard_deviations: HashMap<String, f64>,
@@ -53,11 +62,23 @@ impl Scaler {
                     "Mean for column `{column}` is {mean}, which is not finite"
                 ));
             }
+            if !standard_deviations.contains_key(column) {
+                return Err(format!(
+                    "Column `{column}` has a mean but no standard deviation, so scaling it would \
+                     silently divide by one"
+                ));
+            }
         }
         for (column, standard_deviation) in &standard_deviations {
             if !standard_deviation.is_finite() || *standard_deviation <= 0.0 {
                 return Err(format!(
                     "Standard deviation for column `{column}` is {standard_deviation}, which cannot scale"
+                ));
+            }
+            if !means.contains_key(column) {
+                return Err(format!(
+                    "Column `{column}` has a standard deviation but no mean, so scaling it would \
+                     silently centre on zero"
                 ));
             }
         }
@@ -119,7 +140,19 @@ impl Scaler {
             let array = raw[field]
                 .as_array()
                 .ok_or_else(|| format!("Scaler artifact at {display} has no `{field}` list"))?;
-            let found: Vec<&str> = array.iter().filter_map(|value| value.as_str()).collect();
+            // Every element must be a string. Skipping the ones that are not would let
+            // `["close_price", 42]` collapse to a list that compares equal to a shorter expected
+            // one — a malformed artifact passing the check written to catch malformed artifacts.
+            let found: Vec<&str> = array
+                .iter()
+                .map(|value| {
+                    value.as_str().ok_or_else(|| {
+                        format!(
+                            "Scaler artifact at {display} has a non-string entry {value} in `{field}`"
+                        )
+                    })
+                })
+                .collect::<Result<_, String>>()?;
             if found != expected {
                 return Err(format!(
                     "Scaler artifact at {display} was fitted on {field} {found:?}, but this build \
@@ -951,6 +984,46 @@ mod scaler_boundary_tests {
         assert!(Scaler::new(statistics(f64::NEG_INFINITY), statistics(1.0)).is_err());
     }
 
+    /// Half a description is the identity scaling this type exists to prevent, reached through the
+    /// constructor rather than the loader: a missing deviation divides by one, a missing mean
+    /// centres on zero.
+    #[test]
+    fn test_new_rejects_a_column_described_by_only_one_of_the_two_maps() {
+        assert!(
+            Scaler::new(statistics(0.0), HashMap::new()).is_err(),
+            "a mean with no standard deviation"
+        );
+        assert!(
+            Scaler::new(HashMap::new(), statistics(1.0)).is_err(),
+            "a standard deviation with no mean"
+        );
+        assert!(Scaler::new(statistics(0.0), statistics(1.0)).is_ok());
+    }
+
+    /// A `Scaler` over one column is a legitimate value — the unscale path asks only for
+    /// `daily_return` — so full coverage is an artifact property enforced in `load`, not a type
+    /// property enforced in `new`. Pinned so the two checks are not conflated later.
+    #[test]
+    fn test_new_accepts_a_scaler_over_a_single_column() {
+        assert!(Scaler::new(statistics(0.0), statistics(1.0)).is_ok());
+    }
+
+    /// `filter_map` would have dropped the non-string and compared the remainder, so an artifact
+    /// declaring one more column than this build knows about could match a shorter expected list.
+    #[test]
+    fn test_load_refuses_a_non_string_entry_in_a_column_list() {
+        let mut artifact = well_formed_artifact();
+        let mut columns: Vec<serde_json::Value> = CONTINUOUS_COLUMNS
+            .iter()
+            .map(|column| serde_json::json!(column))
+            .collect();
+        columns.push(serde_json::json!(42));
+        artifact["continuous_columns"] = serde_json::Value::Array(columns);
+
+        let error = load_artifact(&artifact).expect_err("a non-string entry must be refused");
+        assert!(error.contains("non-string"), "got: {error}");
+    }
+
     /// The headline case. A missing object used to yield an empty map, every lookup then fell back
     /// to mean 0.0 and deviation 1.0, and scaling became the identity — reported as a successful
     /// load, producing predictions on the wrong scale that nothing downstream can detect.
@@ -1004,9 +1077,12 @@ mod scaler_boundary_tests {
         assert!(error.contains("close_price"), "got: {error}");
     }
 
-    /// `into_no_null_iter` skips nulls, so one null yields a column shorter than the frame and
-    /// `window_frame` then indexes it out of bounds. The diagnostic has to name the column,
-    /// because the panic it replaces named nothing.
+    /// A null must be refused before its column is read positionally.
+    ///
+    /// `into_no_null_iter` neither skips nulls nor fails on them — it returns the raw value in the
+    /// null slot, so the count is always right and a null `close_price` becomes a fabricated
+    /// observation. The assertion below pins that, because it is the reason the guard is on the
+    /// null count rather than on the extracted length.
     #[test]
     fn test_a_null_in_a_continuous_column_is_refused_rather_than_read_as_a_value() {
         let data = DataFrame::new(vec![

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -124,6 +124,8 @@ pub fn evaluate(
         return Ok(EvalMetrics::zero());
     }
 
+    crate::models::tide::batch::validate_input_shape(dataset, parameters)?;
+
     let indices = QuantileIndices::locate(quantiles);
 
     let device = Default::default();

--- a/src/models/tide/fit.rs
+++ b/src/models/tide/fit.rs
@@ -62,9 +62,9 @@ fn fit_scaler(data: &DataFrame) -> Result<Scaler, Box<dyn std::error::Error>> {
         standard_deviations.insert((*column).to_string(), std);
     }
 
-    Ok(Scaler {
-        means,
-        standard_deviations,
+    Scaler::new(means, standard_deviations).map_err(|reason| {
+        format!("Fitted scaler is unusable, so training would produce a bad artifact: {reason}")
+            .into()
     })
 }
 
@@ -143,6 +143,16 @@ pub fn filter_training_bars(
 
 /// Write the three artifact JSON files (scaler, mappings, parameters) the
 /// inference loader reads, into `directory`.
+///
+/// Each file is serialized to a temporary name and renamed into place, and every rename happens
+/// after every serialization. A reader therefore never sees a half-written file, and the window in
+/// which the three could disagree shrinks from "between two writes" — which spans serializing a
+/// scaler over every continuous column — to three consecutive renames.
+///
+/// This is a narrowed window rather than an atomic set, and the distinction is worth stating: POSIX
+/// gives atomicity per rename, not across three. Closing it completely would mean staging a
+/// directory and renaming that. The mixed-artifact failure this guards against is a crash *during*
+/// the writes, which is where essentially all of the wall clock is.
 pub fn write_artifact_json(
     directory: &Path,
     scaler: &Scaler,
@@ -152,26 +162,39 @@ pub fn write_artifact_json(
     std::fs::create_dir_all(directory)?;
 
     let scaler_json = serde_json::json!({
-        "means": scaler.means,
-        "standard_deviations": scaler.standard_deviations,
+        "means": scaler.means(),
+        "standard_deviations": scaler.standard_deviations(),
         "continuous_columns": CONTINUOUS_COLUMNS,
         "categorical_columns": CATEGORICAL_COLUMNS,
         "static_categorical_columns": STATIC_CATEGORICAL_COLUMNS,
     });
-    std::fs::write(
-        directory.join("tide_data_scaler.json"),
-        serde_json::to_string_pretty(&scaler_json)?,
-    )?;
 
-    std::fs::write(
-        directory.join("tide_data_mappings.json"),
-        serde_json::to_string_pretty(mappings)?,
-    )?;
+    let staged = [
+        (
+            "tide_data_scaler.json",
+            serde_json::to_string_pretty(&scaler_json)?,
+        ),
+        (
+            "tide_data_mappings.json",
+            serde_json::to_string_pretty(mappings)?,
+        ),
+        (
+            "tide_parameters.json",
+            serde_json::to_string_pretty(parameters)?,
+        ),
+    ];
 
-    std::fs::write(
-        directory.join("tide_parameters.json"),
-        serde_json::to_string_pretty(parameters)?,
-    )?;
+    let mut renames = Vec::with_capacity(staged.len());
+    for (name, contents) in &staged {
+        // Same directory as the destination, so the rename stays within one filesystem.
+        let temporary = directory.join(format!("{name}.partial"));
+        std::fs::write(&temporary, contents)?;
+        renames.push((temporary, directory.join(name)));
+    }
+
+    for (temporary, destination) in renames {
+        std::fs::rename(&temporary, &destination)?;
+    }
 
     Ok(())
 }
@@ -218,9 +241,9 @@ mod tests {
     fn test_fit_scaler_has_all_continuous_columns() {
         let result = fit(raw_frame()).unwrap();
         for column in CONTINUOUS_COLUMNS {
-            assert!(result.scaler.means.contains_key(*column));
-            assert!(result.scaler.standard_deviations.contains_key(*column));
-            assert!(*result.scaler.standard_deviations.get(*column).unwrap() != 0.0);
+            assert!(result.scaler.means().contains_key(*column));
+            assert!(result.scaler.standard_deviations().contains_key(*column));
+            assert!(*result.scaler.standard_deviations().get(*column).unwrap() != 0.0);
         }
     }
 
@@ -282,6 +305,39 @@ mod tests {
         assert_eq!(tickers, vec!["AAPL"]);
     }
 
+    /// The staging files must not survive a successful write. A leftover `.partial` would be
+    /// packaged into the tarball and shipped, and on the next run it would be the stale half of
+    /// exactly the mixed-artifact state the staging exists to prevent.
+    #[test]
+    fn test_write_artifact_json_leaves_no_staging_files_behind() {
+        let result = fit(raw_frame()).unwrap();
+        let parameters = ModelParameters::new(448, 35, 5);
+        let directory = tempfile::tempdir().unwrap();
+
+        write_artifact_json(
+            directory.path(),
+            &result.scaler,
+            &result.mappings,
+            &parameters,
+        )
+        .unwrap();
+
+        let written: Vec<String> = std::fs::read_dir(directory.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+
+        assert!(
+            !written.iter().any(|name| name.ends_with(".partial")),
+            "staging files survived the write: {written:?}"
+        );
+        assert_eq!(
+            written.len(),
+            3,
+            "expected exactly the three artifact files: {written:?}"
+        );
+    }
+
     #[test]
     fn test_write_artifact_json_round_trips_via_loader() {
         let result = fit(raw_frame()).unwrap();
@@ -289,12 +345,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         write_artifact_json(dir.path(), &result.scaler, &result.mappings, &parameters).unwrap();
 
-        // The inference-side loaders must read what we wrote.
-        let (scaler, continuous_columns, _, static_columns) =
-            Scaler::load(&dir.path().join("tide_data_scaler.json")).unwrap();
-        assert_eq!(continuous_columns.len(), CONTINUOUS_COLUMNS.len());
-        assert_eq!(static_columns.len(), STATIC_CATEGORICAL_COLUMNS.len());
-        assert!(scaler.means.contains_key("daily_return"));
+        // The inference-side loaders must read what we wrote. `Scaler::load` now checks the column
+        // lists against this build's constants itself, so reaching this line at all is the
+        // assertion that the three lists round-tripped intact.
+        let scaler = Scaler::load(&dir.path().join("tide_data_scaler.json")).unwrap();
+        assert!(scaler.means().contains_key("daily_return"));
 
         let loaded_parameters =
             ModelParameters::load(&dir.path().join("tide_parameters.json")).unwrap();

--- a/src/models/tide/fit.rs
+++ b/src/models/tide/fit.rs
@@ -188,7 +188,16 @@ pub fn write_artifact_json(
     for (name, contents) in &staged {
         // Same directory as the destination, so the rename stays within one filesystem.
         let temporary = directory.join(format!("{name}.partial"));
-        std::fs::write(&temporary, contents)?;
+        if let Err(error) = std::fs::write(&temporary, contents) {
+            // Leave nothing behind on the way out. A surviving `.partial` would be packaged into
+            // the tarball and shipped, and on the next run it is the stale half of exactly the
+            // mixed-artifact state this staging exists to prevent.
+            for (orphan, _) in &renames {
+                let _ = std::fs::remove_file(orphan);
+            }
+            let _ = std::fs::remove_file(&temporary);
+            return Err(error.into());
+        }
         renames.push((temporary, directory.join(name)));
     }
 

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -624,6 +624,21 @@ pub async fn load_predictions_between(
 mod tests {
     use super::*;
 
+    /// A scaler over `daily_return` alone, which is all `unscale_and_sort_quantiles` reads.
+    ///
+    /// Built through the validated constructor, so a future tightening of the `Scaler` contract
+    /// fails here once rather than in five separate fixtures.
+    fn daily_return_scaler(
+        mean: f64,
+        standard_deviation: f64,
+    ) -> crate::models::tide::data::Scaler {
+        crate::models::tide::data::Scaler::new(
+            std::collections::HashMap::from([("daily_return".to_string(), mean)]),
+            std::collections::HashMap::from([("daily_return".to_string(), standard_deviation)]),
+        )
+        .expect("test scaler statistics must be usable")
+    }
+
     #[test]
     fn test_filter_equity_bars_above_thresholds() {
         let data = DataFrame::new(vec![
@@ -778,12 +793,7 @@ mod tests {
 
     #[test]
     fn test_unscale_and_sort_quantiles_repairs_crossing() {
-        let mut means = std::collections::HashMap::new();
-        means.insert("daily_return".to_string(), 0.0);
-        let mut standard_deviations = std::collections::HashMap::new();
-        standard_deviations.insert("daily_return".to_string(), 1.0);
-        let scaler = crate::models::tide::data::Scaler::new(means, standard_deviations)
-            .expect("test scaler statistics must be usable");
+        let scaler = daily_return_scaler(0.0, 1.0);
 
         // Crossed raw quantiles (q10 > q50) must come back monotonic.
         let sorted = unscale_and_sort_quantiles(&[0.05, 0.02, 0.03], &scaler);
@@ -1109,12 +1119,7 @@ mod tests {
 
     #[test]
     fn test_unscale_and_sort_quantiles_already_sorted() {
-        let mut means = std::collections::HashMap::new();
-        means.insert("daily_return".to_string(), 0.0);
-        let mut standard_deviations = std::collections::HashMap::new();
-        standard_deviations.insert("daily_return".to_string(), 1.0);
-        let scaler = crate::models::tide::data::Scaler::new(means, standard_deviations)
-            .expect("test scaler statistics must be usable");
+        let scaler = daily_return_scaler(0.0, 1.0);
 
         // Already-sorted quantiles must come back unchanged.
         let result = unscale_and_sort_quantiles(&[0.01, 0.02, 0.03], &scaler);
@@ -1124,12 +1129,7 @@ mod tests {
     #[test]
     fn test_unscale_and_sort_quantiles_with_nonzero_mean_and_std() {
         // inverse_transform = value * std + mean
-        let mut means = std::collections::HashMap::new();
-        means.insert("daily_return".to_string(), 0.005);
-        let mut standard_deviations = std::collections::HashMap::new();
-        standard_deviations.insert("daily_return".to_string(), 0.01);
-        let scaler = crate::models::tide::data::Scaler::new(means, standard_deviations)
-            .expect("test scaler statistics must be usable");
+        let scaler = daily_return_scaler(0.005, 0.01);
 
         let result = unscale_and_sort_quantiles(&[-1.0, 0.0, 1.0], &scaler);
         // -1.0 * 0.01 + 0.005 = -0.005, 0.0 * 0.01 + 0.005 = 0.005, 1.0 * 0.01 + 0.005 = 0.015
@@ -1346,12 +1346,7 @@ mod tests {
 
     #[test]
     fn test_unscale_and_sort_quantiles_single_element() {
-        let mut means = std::collections::HashMap::new();
-        means.insert("daily_return".to_string(), 0.0);
-        let mut standard_deviations = std::collections::HashMap::new();
-        standard_deviations.insert("daily_return".to_string(), 1.0);
-        let scaler = crate::models::tide::data::Scaler::new(means, standard_deviations)
-            .expect("test scaler statistics must be usable");
+        let scaler = daily_return_scaler(0.0, 1.0);
 
         let result = unscale_and_sort_quantiles(&[0.05], &scaler);
         assert_eq!(result.len(), 1);
@@ -1360,12 +1355,7 @@ mod tests {
 
     #[test]
     fn test_unscale_and_sort_quantiles_empty_input() {
-        let mut means = std::collections::HashMap::new();
-        means.insert("daily_return".to_string(), 0.0);
-        let mut standard_deviations = std::collections::HashMap::new();
-        standard_deviations.insert("daily_return".to_string(), 1.0);
-        let scaler = crate::models::tide::data::Scaler::new(means, standard_deviations)
-            .expect("test scaler statistics must be usable");
+        let scaler = daily_return_scaler(0.0, 1.0);
 
         let result = unscale_and_sort_quantiles(&[], &scaler);
         assert!(result.is_empty());

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -264,6 +264,11 @@ pub fn generate_predictions(
 
     info!(samples = dataset.len(), "Prediction dataset created");
 
+    // Before the forward pass, not inside it: a mismatch between this data and the loaded weights
+    // is an artifact problem, and it should read as one rather than as a tensor panic.
+    crate::models::tide::batch::validate_input_shape(&dataset, model_state.parameters())
+        .map_err(PredictionError::DatasetCreation)?;
+
     let device = Default::default();
     let num_samples = dataset.len();
 
@@ -777,10 +782,8 @@ mod tests {
         means.insert("daily_return".to_string(), 0.0);
         let mut standard_deviations = std::collections::HashMap::new();
         standard_deviations.insert("daily_return".to_string(), 1.0);
-        let scaler = crate::models::tide::data::Scaler {
-            means,
-            standard_deviations,
-        };
+        let scaler = crate::models::tide::data::Scaler::new(means, standard_deviations)
+            .expect("test scaler statistics must be usable");
 
         // Crossed raw quantiles (q10 > q50) must come back monotonic.
         let sorted = unscale_and_sort_quantiles(&[0.05, 0.02, 0.03], &scaler);
@@ -1110,10 +1113,8 @@ mod tests {
         means.insert("daily_return".to_string(), 0.0);
         let mut standard_deviations = std::collections::HashMap::new();
         standard_deviations.insert("daily_return".to_string(), 1.0);
-        let scaler = crate::models::tide::data::Scaler {
-            means,
-            standard_deviations,
-        };
+        let scaler = crate::models::tide::data::Scaler::new(means, standard_deviations)
+            .expect("test scaler statistics must be usable");
 
         // Already-sorted quantiles must come back unchanged.
         let result = unscale_and_sort_quantiles(&[0.01, 0.02, 0.03], &scaler);
@@ -1127,10 +1128,8 @@ mod tests {
         means.insert("daily_return".to_string(), 0.005);
         let mut standard_deviations = std::collections::HashMap::new();
         standard_deviations.insert("daily_return".to_string(), 0.01);
-        let scaler = crate::models::tide::data::Scaler {
-            means,
-            standard_deviations,
-        };
+        let scaler = crate::models::tide::data::Scaler::new(means, standard_deviations)
+            .expect("test scaler statistics must be usable");
 
         let result = unscale_and_sort_quantiles(&[-1.0, 0.0, 1.0], &scaler);
         // -1.0 * 0.01 + 0.005 = -0.005, 0.0 * 0.01 + 0.005 = 0.005, 1.0 * 0.01 + 0.005 = 0.015
@@ -1351,10 +1350,8 @@ mod tests {
         means.insert("daily_return".to_string(), 0.0);
         let mut standard_deviations = std::collections::HashMap::new();
         standard_deviations.insert("daily_return".to_string(), 1.0);
-        let scaler = crate::models::tide::data::Scaler {
-            means,
-            standard_deviations,
-        };
+        let scaler = crate::models::tide::data::Scaler::new(means, standard_deviations)
+            .expect("test scaler statistics must be usable");
 
         let result = unscale_and_sort_quantiles(&[0.05], &scaler);
         assert_eq!(result.len(), 1);
@@ -1367,10 +1364,8 @@ mod tests {
         means.insert("daily_return".to_string(), 0.0);
         let mut standard_deviations = std::collections::HashMap::new();
         standard_deviations.insert("daily_return".to_string(), 1.0);
-        let scaler = crate::models::tide::data::Scaler {
-            means,
-            standard_deviations,
-        };
+        let scaler = crate::models::tide::data::Scaler::new(means, standard_deviations)
+            .expect("test scaler statistics must be usable");
 
         let result = unscale_and_sort_quantiles(&[], &scaler);
         assert!(result.is_empty());


### PR DESCRIPTION
# Overview

The artifact-trust cluster deferred from #1035 (§1 of the hardening notes), plus the two
panic-to-error conversions from §3 and the quantile validation declined on #1043.

These were grouped deliberately rather than taken one at a time, because individually each reads as
"should validate that" while together they describe a single path: a torn write leaves a truncated
scaler, `Scaler::load` tolerates it and falls back to identity scaling, the service reports a
successful load, and predictions come back on the wrong scale. Nothing downstream can distinguish
those from good ones — the only validation past that point is `EquityPrediction::new`'s quantile
ordering, and wrong-scale values satisfy it perfectly well.

The artifact is the one thing crossing between two machines that share no database, which is why it
is worth being strict at.

No behaviour change on a well-formed artifact.

## Changes

- Give `Scaler` private fields and a validated constructor, so holding one is proof it can scale
- Make `Scaler::load` refuse rather than default on a missing object, a non-numeric entry, a
  mismatched column list, or a missing continuous-column statistic
- Drop the fitted column lists after checking them, removing three fields and three accessors from
  `ModelState`
- Stage the three artifact JSON files under temporary names and rename them after all three
  serialize
- Validate the quantile list in `ModelParameters::load` — non-empty, finite, inside `(0, 1)`, no
  duplicates
- Add `validate_input_shape`, called once per dataset on the two paths that consume a loaded
  artifact
- Refuse a column carrying nulls before its values are read positionally
- Reject a degenerate fitted scaler at training time, so a bad artifact is never written

## Context

**`Scaler::load` defaulted where it should have refused.** A missing `means` object produced an
empty map; every later lookup then fell back to mean `0.0` and deviation `1.0`. That is precisely
the identity transform, reported as success. An unparsable entry reached the same place by a
different route. Both now name the field and the column and fail.

**The column lists were validated by being deleted.** `Scaler::load` returned the lists the artifact
was fitted with and `apply_existing_scaler` discarded them, so an artifact fitted on a different
column set loaded without complaint. They are now checked against this build's constants inside
`load` and dropped. Checking them was their entire value; no caller read them afterwards, and
keeping a copy provably equal to the constants only invites a future caller to trust the copy.

**The staged writes narrow a window rather than closing it**, and the docstring says so. POSIX gives
atomicity per rename, not across three. Closing it completely means staging a directory and renaming
that. What this removes is a crash *during* serialization, which is where essentially all of the
wall clock sits.

**Quantile validation is what makes `quantiles()` trustworthy.** Three consumers read that list and
each responded to a bad one differently — `quantile_loss` pairs it positionally with tensor slices,
`evaluate`'s index helpers unwrap a `partial_cmp` and so panic on a non-finite value, and the
prediction path sizes its output by the count. Validating once at load is the alternative to three
separate guards. Order is deliberately *not* required, and neither is an exact `0.5`: positions are
located rather than assumed, and there is a test pinning that.

This is the finding declined on #1043, landing where that reply said it would.

## One correction, and it changed the fix

The original finding said `into_no_null_iter` **skips** nulls, leaving a `Vec` shorter than the
frame that `window_frame` then indexes out of bounds. I wrote a length check against that
description, and it was inert.

`into_no_null_iter` does not skip nulls and does not check for them. It reads the raw value sitting
in the null slot. Verified directly:

```
len=3 null_count=1
into_no_null_iter -> [1.0, 0.0, 3.0] (len 3)
into_iter         -> [Some(1.0), None, Some(3.0)]
```

The length is always right, so no length check could ever fire. The real hazard is worse than the
reported one: a null `close_price` is silently read as an observation of `0.0`, scaled, and fed to
the model. A wrong value rather than a crash.

The guard is now on the null count. The probe above is pinned as an assertion inside the test, so
the next person to read it cannot re-derive the wrong mechanism.

## Verification

- 426 library tests pass; `checks:rust` at **81.43%** line coverage against the 75% floor
- Each new guard has a test asserting `Err` on input the previous code accepted, paired with a
  well-formed case, so neither direction is vacuous
- The pre-existing `needless_range_loop` warning at `src/models/tide/data.rs` is untouched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation for dataset feature counts and required historical and future time windows.
  - Added validation for quantile configurations, including range, uniqueness, and finite-value checks.
  - Improved scaler validation for missing, invalid, or inconsistent statistics.

- **Bug Fixes**
  - Prevented null input values from causing invalid window extraction.
  - Added pre-inference checks to provide clearer errors during evaluation and prediction.
  - Improved artifact writing reliability and cleanup of temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->