### PR TITLE
Constrain sector concentration across the book, not within each pair

### DIFF
--- a/src/bin/seed_equity_details.rs
+++ b/src/bin/seed_equity_details.rs
@@ -3,7 +3,7 @@
 //! Bootstrap tooling, not a scheduled job. Nothing in the running service writes `equity_details`:
 //! Alpaca does not publish sector or industry, so the metadata has one source and it is compiled
 //! into the binary. A fresh database therefore has no sector information until this runs, and the
-//! pair screen's different-sector rule silently admits nothing without it.
+//! pair screen's per-sector cap silently constrains nothing without it.
 //!
 //! Usage: `seed_equity_details`
 //!

--- a/src/data/details.rs
+++ b/src/data/details.rs
@@ -1,7 +1,7 @@
 //! Ticker metadata: sector and industry.
 //!
-//! The pair screen requires the two legs to come from different sectors, so without this every pair
-//! is same-sector and the strategy is a bet on one industry rather than on a spread.
+//! The pair screen caps how many legs the book may hold in one sector, so without this every ticker
+//! is uncategorized, the cap binds on nothing, and ten pairs can be one industry bet held ten times.
 //!
 //! Seeded from `data/equity_details.csv`, embedded at compile time so a fresh database needs no
 //! network. Alpaca does not publish sector or industry, so the post-close sync refreshes only

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -196,7 +196,8 @@ pub async fn run_pass(
     let candidates = screen::score_candidates(&screened.inputs);
     summary.candidates_screened = candidates.len();
 
-    let selected = screen::select_disjoint(&candidates, gate.vacant_slots(), &held);
+    let selected =
+        screen::select_disjoint(&candidates, gate.vacant_slots(), &held, &screened.sectors);
     let sized = size::size_pairs(&selected, account.equity(), &context.sizing);
     let (approved, refusals) = gate.admit_all(&sized);
     summary.entries_refused = refusals
@@ -475,6 +476,9 @@ async fn previous_session_equity(
 struct ScreenedUniverse {
     inputs: Vec<ScreenInput>,
     model_run_id: Option<String>,
+    /// Every ticker's sector, not just the screened ones. `select_disjoint` needs the held legs
+    /// too, and those are filtered out of `inputs` before it ever sees them.
+    sectors: HashMap<Ticker, String>,
 }
 
 /// Assembles the screen's inputs, fetching only the prices the exit half did not already have.
@@ -490,6 +494,7 @@ async fn build_screen_inputs(
         return Ok(ScreenedUniverse {
             inputs: Vec::new(),
             model_run_id: None,
+            sectors: HashMap::new(),
         });
     }
 
@@ -549,6 +554,7 @@ async fn build_screen_inputs(
     Ok(ScreenedUniverse {
         inputs,
         model_run_id,
+        sectors,
     })
 }
 

--- a/src/portfolio/evaluate.rs
+++ b/src/portfolio/evaluate.rs
@@ -510,6 +510,13 @@ async fn build_screen_inputs(
     // Only forecasts that can produce a candidate: in the universe, with a sector, with enough
     // history, and not already on the book. Every test here is a set lookup, because this runs once
     // per forecast on a pass that runs every five minutes.
+    //
+    // The sector test survives the removal of the different-sector rule, for a new reason. A ticker
+    // whose sector is unknown cannot be counted against `MAXIMUM_LEGS_PER_SECTOR`, so admitting one
+    // would let missing metadata quietly become unbounded concentration. Refusing to *open* what
+    // cannot be measured is the conservative side of that trade; `select_disjoint` still tolerates
+    // an unknown sector on a *held* leg, because a position already on the book cannot be
+    // retroactively declined.
     let eligible: Vec<&EquityPrediction> = predictions
         .iter()
         .filter(|prediction| {
@@ -536,7 +543,6 @@ async fn build_screen_inputs(
                 ticker.clone(),
                 context.close_history.get(ticker)?.clone(),
                 *prices.get(ticker)?,
-                sectors.get(ticker)?.clone(),
                 prediction.expected_return(),
                 prediction.confidence(),
                 context.universe.is_shortable(ticker),

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -84,7 +84,6 @@ pub struct ScreenInput {
     ticker: Ticker,
     closes: Vec<f64>,
     price: f64,
-    sector: String,
     expected_return: f64,
     confidence: f64,
     is_shortable: bool,
@@ -100,7 +99,6 @@ impl ScreenInput {
         ticker: Ticker,
         closes: Vec<f64>,
         price: f64,
-        sector: String,
         expected_return: f64,
         confidence: f64,
         is_shortable: bool,
@@ -124,7 +122,6 @@ impl ScreenInput {
             ticker,
             closes,
             price,
-            sector,
             expected_return,
             confidence,
             is_shortable,
@@ -137,10 +134,6 @@ impl ScreenInput {
 
     pub fn price(&self) -> f64 {
         self.price
-    }
-
-    pub fn sector(&self) -> &str {
-        &self.sector
     }
 
     pub fn expected_return(&self) -> f64 {
@@ -514,22 +507,27 @@ pub fn select_disjoint(
             continue;
         }
 
-        // Both legs at once: a same-sector pair asks for two of that sector's allowance, and
-        // admitting it one leg at a time could take a sector past the cap.
-        let mut requested: HashMap<&str, usize> = HashMap::new();
-        for ticker in [candidate.long_ticker(), candidate.short_ticker()] {
-            if let Some(sector) = sectors.get(ticker) {
-                *requested.entry(sector.as_str()).or_default() += 1;
+        let long_sector = sectors.get(candidate.long_ticker()).map(String::as_str);
+        let short_sector = sectors.get(candidate.short_ticker()).map(String::as_str);
+        let taken = |sector: &str| legs_per_sector.get(sector).copied().unwrap_or(0);
+
+        // Both legs are weighed together, and the same-sector case is why: asking twice for one
+        // allowance, a leg at a time, would let such a pair take its sector one past the cap.
+        let fits = match (long_sector, short_sector) {
+            (Some(long), Some(short)) if long == short => {
+                taken(long) + 2 <= MAXIMUM_LEGS_PER_SECTOR
             }
-        }
-        let over_cap = requested.iter().any(|(sector, legs)| {
-            legs_per_sector.get(sector).copied().unwrap_or(0) + legs > MAXIMUM_LEGS_PER_SECTOR
-        });
-        if over_cap {
+            (Some(long), Some(short)) => {
+                taken(long) < MAXIMUM_LEGS_PER_SECTOR && taken(short) < MAXIMUM_LEGS_PER_SECTOR
+            }
+            (Some(sector), None) | (None, Some(sector)) => taken(sector) < MAXIMUM_LEGS_PER_SECTOR,
+            (None, None) => true,
+        };
+        if !fits {
             continue;
         }
-        for (sector, legs) in requested {
-            *legs_per_sector.entry(sector).or_default() += legs;
+        for sector in [long_sector, short_sector].into_iter().flatten() {
+            *legs_per_sector.entry(sector).or_default() += 1;
         }
         used.insert(candidate.long_ticker().clone());
         used.insert(candidate.short_ticker().clone());
@@ -712,23 +710,9 @@ mod tests {
         );
     }
 
-    fn input(
-        name: &str,
-        closes: Vec<f64>,
-        price: f64,
-        sector: &str,
-        expected_return: f64,
-    ) -> ScreenInput {
-        ScreenInput::new(
-            ticker(name),
-            closes,
-            price,
-            sector.to_string(),
-            expected_return,
-            0.9,
-            true,
-        )
-        .expect("test input must be constructible")
+    fn input(name: &str, closes: Vec<f64>, price: f64, expected_return: f64) -> ScreenInput {
+        ScreenInput::new(ticker(name), closes, price, expected_return, 0.9, true)
+            .expect("test input must be constructible")
     }
 
     // --- the spread model ---
@@ -882,14 +866,8 @@ mod tests {
         let (leader, follower) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
         let stretched = follower.last().unwrap() * 1.5;
         vec![
-            input(
-                "AAAA",
-                leader.clone(),
-                *leader.last().unwrap(),
-                "Technology",
-                0.03,
-            ),
-            input("BBBB", follower.clone(), stretched, "Utilities", -0.02),
+            input("AAAA", leader.clone(), *leader.last().unwrap(), 0.03),
+            input("BBBB", follower.clone(), stretched, -0.02),
         ]
     }
 
@@ -921,14 +899,8 @@ mod tests {
         let (leader, follower) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
         let stretched = follower.last().unwrap() * 1.5;
         let inputs = vec![
-            input(
-                "AAAA",
-                leader.clone(),
-                *leader.last().unwrap(),
-                "Technology",
-                -0.02,
-            ),
-            input("BBBB", follower, stretched, "Utilities", 0.03),
+            input("AAAA", leader.clone(), *leader.last().unwrap(), -0.02),
+            input("BBBB", follower, stretched, 0.03),
         ];
         assert!(score_candidates(&inputs).is_empty());
     }
@@ -953,37 +925,29 @@ mod tests {
 
         let stretched = mirrored.last().unwrap() * 1.5;
         let inputs = vec![
-            input(
-                "AAAA",
-                leader.clone(),
-                *leader.last().unwrap(),
-                "Technology",
-                0.03,
-            ),
-            input("BBBB", mirrored, stretched, "Utilities", -0.02),
+            input("AAAA", leader.clone(), *leader.last().unwrap(), 0.03),
+            input("BBBB", mirrored, stretched, -0.02),
         ];
         assert!(score_candidates(&inputs).is_empty());
     }
 
-    /// The screen must produce same-sector pairs, not refuse them.
+    /// Two cointegrated names are a candidate, whatever sectors they are in.
     ///
-    /// This asserts the reverse of what it used to. A same-sector spread is the canonical
-    /// statistical arbitrage trade, and within-sector correlation is where the `[0.5, 0.95]` band is
-    /// most densely populated — so the old rule removed disproportionately many of the best
-    /// candidates. Concentration is now bounded in `select_disjoint` instead.
+    /// This replaces a test asserting the reverse. A same-sector spread is the canonical statistical
+    /// arbitrage trade, and within-sector correlation is where the `[0.5, 0.95]` band is most
+    /// densely populated, so the old rule removed disproportionately many of the best candidates.
+    ///
+    /// Sector cannot even be *expressed* here any more: `ScreenInput` no longer carries one, because
+    /// nothing in scoring reads it. That is the strongest statement of the change — the screen has
+    /// no sector to consider. Concentration is bounded in `select_disjoint` instead, and the tests
+    /// for it are below.
     #[test]
-    fn test_same_sector_pairs_are_screened_rather_than_refused() {
+    fn test_scoring_does_not_consider_sector() {
         let (leader, follower) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
         let stretched = follower.last().unwrap() * 1.5;
         let inputs = vec![
-            input(
-                "AAAA",
-                leader.clone(),
-                *leader.last().unwrap(),
-                "Technology",
-                0.03,
-            ),
-            input("BBBB", follower, stretched, "Technology", -0.02),
+            input("AAAA", leader.clone(), *leader.last().unwrap(), 0.03),
+            input("BBBB", follower, stretched, -0.02),
         ];
 
         let candidates = score_candidates(&inputs);
@@ -991,7 +955,7 @@ mod tests {
         assert_eq!(
             candidates.len(),
             1,
-            "two cointegrated names in one sector are a candidate"
+            "two cointegrated names are a candidate"
         );
         assert_eq!(candidates[0].long_ticker().as_str(), "AAAA");
         assert_eq!(candidates[0].short_ticker().as_str(), "BBBB");
@@ -1003,16 +967,8 @@ mod tests {
         let (leader, follower) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
         let stretched = follower.last().unwrap() * 1.5;
         let mut inputs = screenable_inputs();
-        inputs[1] = ScreenInput::new(
-            ticker("BBBB"),
-            follower,
-            stretched,
-            "Utilities".to_string(),
-            -0.02,
-            0.9,
-            false,
-        )
-        .unwrap();
+        inputs[1] =
+            ScreenInput::new(ticker("BBBB"), follower, stretched, -0.02, 0.9, false).unwrap();
         let _ = leader;
         assert!(score_candidates(&inputs).is_empty());
     }
@@ -1022,18 +978,11 @@ mod tests {
         let (leader, follower) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
         let stretched = follower.last().unwrap() * 1.5;
         let inputs = vec![
-            input(
-                "AAAA",
-                leader.clone(),
-                *leader.last().unwrap(),
-                "Technology",
-                0.03,
-            ),
+            input("AAAA", leader.clone(), *leader.last().unwrap(), 0.03),
             ScreenInput::new(
                 ticker("BBBB"),
                 follower,
                 stretched,
-                "Utilities".to_string(),
                 -0.02,
                 CONFIDENCE_FLOOR - 0.01,
                 true,
@@ -1049,25 +998,15 @@ mod tests {
             ticker("AAAA"),
             vec![100.0; CORRELATION_WINDOW_SESSIONS - 1],
             100.0,
-            "Technology".to_string(),
             0.01,
             0.9,
-            true,
+            true
         )
         .is_none());
 
         let mut with_zero = vec![100.0; CORRELATION_WINDOW_SESSIONS];
         with_zero[3] = 0.0;
-        assert!(ScreenInput::new(
-            ticker("AAAA"),
-            with_zero,
-            100.0,
-            "Technology".to_string(),
-            0.01,
-            0.9,
-            true,
-        )
-        .is_none());
+        assert!(ScreenInput::new(ticker("AAAA"), with_zero, 100.0, 0.01, 0.9, true).is_none());
     }
 
     // --- selection ---
@@ -1082,7 +1021,7 @@ mod tests {
 
     /// The nth distinct pair of symbols: `("LAAA", "SAAA")`, `("LBBB", "SBBB")`, and so on.
     /// `Ticker` admits letters only, so the index is spelled rather than numbered.
-    fn nth_pair(index: usize) -> (String, String) {
+    fn pair_for_index(index: usize) -> (String, String) {
         let letter = (b'A' + index as u8) as char;
         (
             format!("L{letter}{letter}{letter}"),
@@ -1095,7 +1034,7 @@ mod tests {
         count: usize,
         sector: &str,
     ) -> (Vec<PairCandidate>, HashMap<Ticker, String>) {
-        let symbols: Vec<(String, String)> = (0..count).map(nth_pair).collect();
+        let symbols: Vec<(String, String)> = (0..count).map(pair_for_index).collect();
         let candidates = symbols
             .iter()
             .enumerate()
@@ -1131,7 +1070,7 @@ mod tests {
     /// A cross-sector pair spends one leg in each sector, so the same allowance goes twice as far.
     #[test]
     fn test_a_cross_sector_pair_costs_one_leg_in_each_sector() {
-        let symbols: Vec<(String, String)> = (0..6).map(nth_pair).collect();
+        let symbols: Vec<(String, String)> = (0..6).map(pair_for_index).collect();
         let candidates: Vec<PairCandidate> = symbols
             .iter()
             .enumerate()
@@ -1191,8 +1130,12 @@ mod tests {
         assert_eq!(selected.len(), MAXIMUM_LEGS_PER_SECTOR / 2);
     }
 
-    /// An empty sector map caps nothing, which is what a database with no `equity_details` rows
-    /// looks like. Recorded so the seeding requirement is visible rather than assumed.
+    /// An empty sector map caps nothing.
+    ///
+    /// Recorded as a property of this function, not as a claim about the system: `build_screen_inputs`
+    /// refuses a ticker with no sector before it can become a candidate, precisely so an unmeasurable
+    /// name cannot slip past the cap. What this pins is that the *cap* is the only thing doing the
+    /// capping — remove the upstream filter and concentration becomes unbounded, silently.
     #[test]
     fn test_an_empty_sector_map_constrains_nothing() {
         let (candidates, _) = same_sector_candidates(5, "Technology");

--- a/src/portfolio/screen.rs
+++ b/src/portfolio/screen.rs
@@ -1,8 +1,10 @@
 //! Pair selection: which two symbols, which way round, and how strong the signal.
 //!
 //! The screen is quadratic in the eligible universe, so everything cheap runs first: the confidence
-//! floor, the shortable check, and the different-sector rule all shrink the input before a single
-//! correlation is computed.
+//! floor and the shortable check shrink the input before a single correlation is computed.
+//!
+//! Sector is not one of those tests. It constrains the *book* rather than the pair, so it is applied
+//! during selection — see [`MAXIMUM_LEGS_PER_SECTOR`].
 //!
 //! [`SpreadModel`] is load-bearing. An open pair's model is rebuilt from its *stored* hedge ratio
 //! rather than refitted, so entry and exit measure the same spread.
@@ -46,6 +48,22 @@ pub const STOP_LOSS_Z_SCORE: f64 = 4.0;
 
 /// Minimum model confidence for a ticker to be eligible for either leg.
 pub const CONFIDENCE_FLOOR: f64 = 0.5;
+
+/// Legs the book may hold in one sector at once.
+///
+/// This is the constraint the different-sector rule was reaching for, applied where it belongs. A
+/// reservoir of same-sector spreads ranks by the same industry factor at the top, so ten selected
+/// pairs can be one bet held ten times. That is a property of the *selection across the book*, not
+/// of any individual candidate — a single same-sector pair is a perfectly good trade, and is in
+/// fact the classic one.
+///
+/// Counted in legs rather than pairs so held and candidate positions measure the same way from a
+/// flat ticker set, and because a same-sector pair genuinely sits entirely inside one sector while
+/// a cross-sector pair only half does. Against a ten-pair book, six legs is a little under a third
+/// of the twenty on offer: enough for three same-sector pairs in one industry, not enough for the
+/// book to become an industry bet. Note it is absolute, so lowering
+/// [`crate::portfolio::size::MAXIMUM_CONCURRENT_PAIRS`] far enough would make it inert.
+pub const MAXIMUM_LEGS_PER_SECTOR: usize = 6;
 
 /// Tickers needed before a screen can produce anything.
 const MINIMUM_ELIGIBLE_TICKERS: usize = 2;
@@ -340,14 +358,20 @@ impl PairCandidate {
 ///
 /// A pair survives four tests, in increasing order of cost:
 ///
-/// 1. Both legs clear the confidence floor, the short leg is shortable, and the two come from
-///    different sectors.
+/// 1. Both legs clear the confidence floor and at least one is shortable.
 /// 2. Their log returns correlate *positively*, within `[CORRELATION_MINIMUM, CORRELATION_MAXIMUM]`.
 /// 3. The spread, oriented so the short leg is the expensive one, is at or above `ENTRY_Z_SCORE`.
 /// 4. The model agrees with that orientation — it expects the long leg to out-return the short.
 ///
 /// Test four is the model doing more than gating eligibility: without it a pair can open whose
 /// spread says buy A and sell B while the forecast says the opposite.
+///
+/// **Sector is not tested here.** A same-sector spread is the canonical statistical arbitrage
+/// trade — two companies facing the same demand, the same input costs, and the same regulator,
+/// whose relative price has something to mean-revert toward — and refusing those removes exactly
+/// the pairs most likely to cointegrate, which is the property the whole strategy rests on. The
+/// real concern was never the pair but the book, so it is answered in [`select_disjoint`] by
+/// [`MAXIMUM_LEGS_PER_SECTOR`].
 ///
 /// No disjointness constraint is applied — the returned list is the full reservoir and pairs may
 /// share tickers. [`select_disjoint`] is the cheap second half.
@@ -372,12 +396,6 @@ pub fn score_candidates(inputs: &[ScreenInput]) -> Vec<PairCandidate> {
             let first = eligible[first_index];
             let second = eligible[second_index];
 
-            // Different sectors. This is a constraint on the book rather than on the pair: a
-            // reservoir of same-sector spreads ranks by the same industry factor at the top, and
-            // ten such pairs is one bet held ten times.
-            if first.sector == second.sector {
-                continue;
-            }
             // At least one leg has to be shortable or there is no orientation to take.
             if !first.is_shortable && !second.is_shortable {
                 continue;
@@ -455,15 +473,24 @@ fn orient(first: &ScreenInput, second: &ScreenInput) -> Option<PairCandidate> {
     None
 }
 
-/// Greedily takes up to `limit` candidates that share no ticker with each other or with `held`.
+/// Greedily takes up to `limit` candidates that share no ticker with each other or with `held`,
+/// and that keep every sector within [`MAXIMUM_LEGS_PER_SECTOR`].
 ///
 /// Disjointness is why rejecting a candidate changes what is available below it: excluding one pair
 /// frees both of its tickers, so a pair further down that was skipped for a collision becomes
-/// selectable. Re-selecting is therefore not the same as taking the next item off the list.
+/// selectable. Re-selecting is therefore not the same as taking the next item off the list. The
+/// sector cap behaves the same way and for the same reason.
+///
+/// **The cap is seeded from the book, not from this pass.** `held` carries the legs already open,
+/// so a sector at its limit stays at its limit rather than admitting a fresh allocation every time
+/// the evaluator runs. A held ticker whose sector is unknown — a name whose `equity_details` row
+/// went away, say — contributes to no sector rather than to a fabricated one; it still blocks
+/// re-entry through `used`.
 pub fn select_disjoint(
     candidates: &[PairCandidate],
     limit: usize,
     held: &HashSet<Ticker>,
+    sectors: &HashMap<Ticker, String>,
 ) -> Vec<PairCandidate> {
     if limit == 0 {
         return Vec::new();
@@ -472,12 +499,37 @@ pub fn select_disjoint(
     let mut used: HashSet<Ticker> = held.clone();
     let mut selected: Vec<PairCandidate> = Vec::with_capacity(limit);
 
+    let mut legs_per_sector: HashMap<&str, usize> = HashMap::new();
+    for ticker in held {
+        if let Some(sector) = sectors.get(ticker) {
+            *legs_per_sector.entry(sector.as_str()).or_default() += 1;
+        }
+    }
+
     for candidate in candidates {
         if selected.len() == limit {
             break;
         }
         if used.contains(candidate.long_ticker()) || used.contains(candidate.short_ticker()) {
             continue;
+        }
+
+        // Both legs at once: a same-sector pair asks for two of that sector's allowance, and
+        // admitting it one leg at a time could take a sector past the cap.
+        let mut requested: HashMap<&str, usize> = HashMap::new();
+        for ticker in [candidate.long_ticker(), candidate.short_ticker()] {
+            if let Some(sector) = sectors.get(ticker) {
+                *requested.entry(sector.as_str()).or_default() += 1;
+            }
+        }
+        let over_cap = requested.iter().any(|(sector, legs)| {
+            legs_per_sector.get(sector).copied().unwrap_or(0) + legs > MAXIMUM_LEGS_PER_SECTOR
+        });
+        if over_cap {
+            continue;
+        }
+        for (sector, legs) in requested {
+            *legs_per_sector.entry(sector).or_default() += legs;
         }
         used.insert(candidate.long_ticker().clone());
         used.insert(candidate.short_ticker().clone());
@@ -913,8 +965,14 @@ mod tests {
         assert!(score_candidates(&inputs).is_empty());
     }
 
+    /// The screen must produce same-sector pairs, not refuse them.
+    ///
+    /// This asserts the reverse of what it used to. A same-sector spread is the canonical
+    /// statistical arbitrage trade, and within-sector correlation is where the `[0.5, 0.95]` band is
+    /// most densely populated — so the old rule removed disproportionately many of the best
+    /// candidates. Concentration is now bounded in `select_disjoint` instead.
     #[test]
-    fn test_same_sector_pairs_are_rejected() {
+    fn test_same_sector_pairs_are_screened_rather_than_refused() {
         let (leader, follower) = cointegrated_series(CORRELATION_WINDOW_SESSIONS);
         let stretched = follower.last().unwrap() * 1.5;
         let inputs = vec![
@@ -927,7 +985,16 @@ mod tests {
             ),
             input("BBBB", follower, stretched, "Technology", -0.02),
         ];
-        assert!(score_candidates(&inputs).is_empty());
+
+        let candidates = score_candidates(&inputs);
+
+        assert_eq!(
+            candidates.len(),
+            1,
+            "two cointegrated names in one sector are a candidate"
+        );
+        assert_eq!(candidates[0].long_ticker().as_str(), "AAAA");
+        assert_eq!(candidates[0].short_ticker().as_str(), "BBBB");
     }
 
     /// Without a shortable short leg there is no position to take, whatever the spread says.
@@ -1005,6 +1072,136 @@ mod tests {
 
     // --- selection ---
 
+    /// Assigns every named ticker to one sector, for the selection tests.
+    fn sector_map(assignments: &[(&str, &str)]) -> HashMap<Ticker, String> {
+        assignments
+            .iter()
+            .map(|(symbol, sector)| (ticker(symbol), (*sector).to_string()))
+            .collect()
+    }
+
+    /// The nth distinct pair of symbols: `("LAAA", "SAAA")`, `("LBBB", "SBBB")`, and so on.
+    /// `Ticker` admits letters only, so the index is spelled rather than numbered.
+    fn nth_pair(index: usize) -> (String, String) {
+        let letter = (b'A' + index as u8) as char;
+        (
+            format!("L{letter}{letter}{letter}"),
+            format!("S{letter}{letter}{letter}"),
+        )
+    }
+
+    /// `count` distinct pairs, both legs of each in `sector`, ranked best first.
+    fn same_sector_candidates(
+        count: usize,
+        sector: &str,
+    ) -> (Vec<PairCandidate>, HashMap<Ticker, String>) {
+        let symbols: Vec<(String, String)> = (0..count).map(nth_pair).collect();
+        let candidates = symbols
+            .iter()
+            .enumerate()
+            .map(|(index, (long, short))| candidate(long, short, (count - index) as f64))
+            .collect();
+        let assignments: Vec<(&str, &str)> = symbols
+            .iter()
+            .flat_map(|(long, short)| [(long.as_str(), sector), (short.as_str(), sector)])
+            .collect();
+        (candidates, sector_map(&assignments))
+    }
+
+    /// The cap is what stops a reservoir of same-sector spreads becoming one bet held ten times.
+    /// Both legs sit in the sector, so each pair spends two of the six legs on offer.
+    #[test]
+    fn test_selection_stops_at_the_sector_cap() {
+        let (candidates, sectors) = same_sector_candidates(6, "Technology");
+
+        let selected = select_disjoint(&candidates, 10, &HashSet::new(), &sectors);
+
+        assert_eq!(
+            selected.len(),
+            MAXIMUM_LEGS_PER_SECTOR / 2,
+            "six legs allows three same-sector pairs, not six"
+        );
+        assert_eq!(
+            selected[0].long_ticker().as_str(),
+            "LAAA",
+            "the best candidates are the ones kept"
+        );
+    }
+
+    /// A cross-sector pair spends one leg in each sector, so the same allowance goes twice as far.
+    #[test]
+    fn test_a_cross_sector_pair_costs_one_leg_in_each_sector() {
+        let symbols: Vec<(String, String)> = (0..6).map(nth_pair).collect();
+        let candidates: Vec<PairCandidate> = symbols
+            .iter()
+            .enumerate()
+            .map(|(index, (long, short))| candidate(long, short, (6 - index) as f64))
+            .collect();
+        let assignments: Vec<(&str, &str)> = symbols
+            .iter()
+            .flat_map(|(long, short)| {
+                [
+                    (long.as_str(), "Technology"),
+                    (short.as_str(), "Healthcare"),
+                ]
+            })
+            .collect();
+        let sectors = sector_map(&assignments);
+
+        let selected = select_disjoint(&candidates, 10, &HashSet::new(), &sectors);
+
+        assert_eq!(
+            selected.len(),
+            MAXIMUM_LEGS_PER_SECTOR,
+            "one leg per sector per pair, so six pairs fit inside a six-leg cap"
+        );
+    }
+
+    /// Seeded from the book, not from the pass. Otherwise a sector at its limit would be handed a
+    /// fresh allowance every five minutes.
+    #[test]
+    fn test_the_cap_counts_legs_already_held() {
+        let (candidates, mut sectors) = same_sector_candidates(3, "Technology");
+        let held: HashSet<Ticker> = ["HELDA", "HELDB", "HELDC", "HELDD"]
+            .iter()
+            .map(|symbol| ticker(symbol))
+            .collect();
+        for symbol in ["HELDA", "HELDB", "HELDC", "HELDD"] {
+            sectors.insert(ticker(symbol), "Technology".to_string());
+        }
+
+        let selected = select_disjoint(&candidates, 10, &held, &sectors);
+
+        assert_eq!(
+            selected.len(),
+            1,
+            "four legs held leaves room for one more pair, not three"
+        );
+    }
+
+    /// A held ticker with no sector row contributes to no sector rather than to a fabricated one,
+    /// and still blocks re-entry through the disjointness check.
+    #[test]
+    fn test_a_held_ticker_without_a_sector_does_not_consume_an_allowance() {
+        let (candidates, sectors) = same_sector_candidates(3, "Technology");
+        let held: HashSet<Ticker> = ["ZZZZ"].iter().map(|symbol| ticker(symbol)).collect();
+
+        let selected = select_disjoint(&candidates, 10, &held, &sectors);
+
+        assert_eq!(selected.len(), MAXIMUM_LEGS_PER_SECTOR / 2);
+    }
+
+    /// An empty sector map caps nothing, which is what a database with no `equity_details` rows
+    /// looks like. Recorded so the seeding requirement is visible rather than assumed.
+    #[test]
+    fn test_an_empty_sector_map_constrains_nothing() {
+        let (candidates, _) = same_sector_candidates(5, "Technology");
+
+        let selected = select_disjoint(&candidates, 10, &HashSet::new(), &HashMap::new());
+
+        assert_eq!(selected.len(), 5);
+    }
+
     fn candidate(long: &str, short: &str, rank: f64) -> PairCandidate {
         PairCandidate::new(
             PairID::new(ticker(long), ticker(short)),
@@ -1041,7 +1238,7 @@ mod tests {
             candidate("AAAA", "CCCC", 3.0),
             candidate("DDDD", "EEEE", 2.0),
         ];
-        let selected = select_disjoint(&candidates, 3, &HashSet::new());
+        let selected = select_disjoint(&candidates, 3, &HashSet::new(), &HashMap::new());
         assert_eq!(selected.len(), 2);
         assert_eq!(selected[0].short_ticker().as_str(), "BBBB");
         assert_eq!(selected[1].long_ticker().as_str(), "DDDD");
@@ -1056,7 +1253,7 @@ mod tests {
             candidate("CCCC", "DDDD", 3.0),
         ];
         let held: HashSet<Ticker> = [ticker("BBBB")].into_iter().collect();
-        let selected = select_disjoint(&candidates, 3, &held);
+        let selected = select_disjoint(&candidates, 3, &held, &HashMap::new());
         assert_eq!(selected.len(), 1);
         assert_eq!(selected[0].long_ticker().as_str(), "CCCC");
     }
@@ -1067,8 +1264,11 @@ mod tests {
             candidate("AAAA", "BBBB", 4.0),
             candidate("CCCC", "DDDD", 3.0),
         ];
-        assert_eq!(select_disjoint(&candidates, 1, &HashSet::new()).len(), 1);
-        assert!(select_disjoint(&candidates, 0, &HashSet::new()).is_empty());
+        assert_eq!(
+            select_disjoint(&candidates, 1, &HashSet::new(), &HashMap::new()).len(),
+            1
+        );
+        assert!(select_disjoint(&candidates, 0, &HashSet::new(), &HashMap::new()).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
# Overview

Item 2 of the model sequence: the different-sector rule, replaced by a per-sector cap on the book.

`score_candidates` refused any pair whose legs shared a sector. The justification carried into the
rebuild was that without it every pair is same-sector and the strategy becomes a bet on one
industry. That reasoning does not hold — and the rule was costing the strategy its best candidates.

**A same-sector spread is the canonical statistical arbitrage trade.** Two companies facing the same
demand, the same input costs, and the same regulator have a relative price with something to
mean-revert toward. Within-sector correlation is also exactly where the `[0.5, 0.95]` band is most
densely populated, so the filter removed disproportionately many of the pairs most likely to
cointegrate — the property the whole strategy rests on.

The real concern is not a property of any individual pair. It is that a reservoir of same-sector
spreads ranks by the same industry factor at the top, so ten selected pairs can be one bet held ten
times. That is a constraint on *selection across the book*, and it now lives where it belongs.

## Changes

- Remove the different-sector predicate from `score_candidates`
- Add `MAXIMUM_LEGS_PER_SECTOR` and enforce it in `select_disjoint`, seeded from the open book
- Thread the sector map through `ScreenedUniverse` so selection can see held legs, not just screened
  ones
- Replace the test asserting same-sector pairs are rejected with one asserting they are screened
- Correct the module docs in `data/details.rs` and `bin/seed_equity_details.rs`, which justified
  seeding sector metadata by a rule that no longer exists

## Why legs rather than pairs

Two reasons, and the second is the substantive one.

The book is *stored* as pairs but reaches selection as a flat `HashSet<Ticker>`, so counting pairs
would mean reconstructing the pairing. Counting legs lets held and candidate positions measure
identically from what is already there.

More importantly, a same-sector pair genuinely sits entirely inside one sector while a cross-sector
pair only half does. Legs is the more honest measure of how much of the book a sector carries: a
same-sector pair spends two of its sector's allowance, a cross-sector pair one in each of two.

Six legs against a ten-pair book is a little under a third of the twenty on offer — room for three
same-sector pairs in one industry, not enough for the book to become an industry bet. The constant
is absolute rather than a fraction of the pair cap, which the docstring notes: `vacant_slots` varies
per pass and is the wrong basis, but lowering `MAXIMUM_CONCURRENT_PAIRS` far enough would make the
cap inert.

## Two details worth flagging

**The cap is seeded from the book, not the pass.** Otherwise a sector already at its limit would be
handed a fresh allowance every five minutes, and the constraint would only ever bind within a single
evaluation.

**Both legs are checked together.** Admitting a same-sector pair one leg at a time would let it take
a sector one past the cap.

A held ticker whose `equity_details` row has gone contributes to no sector rather than a fabricated
one. It still blocks re-entry through the disjointness check it already passes.

## Verification

`checks:rust` passes at **81.65%** line coverage against the 75% floor, 436 tests.

Proved non-vacuous by mutation rather than assumed:

- Raising `MAXIMUM_LEGS_PER_SECTOR` to 100 fails four of the five new tests. The fifth is
  `test_an_empty_sector_map_constrains_nothing`, which correctly still passes — an empty map caps
  nothing whatever the constant says.
- Removing *only* the seeding from the held book fails exactly one test, the one named for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-sector holding caps to pair selection, including positions already held.
  * Same-sector pairs can now be scored while still respecting sector limits.
  * Improved handling of candidates with known or missing sector metadata.

* **Documentation**
  * Updated documentation to describe sector-based caps and metadata requirements accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->