### PR TITLE
Make ModelState's thread-safety a property rather than an assertion

### DIFF
--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -30,7 +30,7 @@ use fund::models::tide::artifact::{
     candidate_folders_descending, list_run_folders, package_dir_to_tar_gz, upload_artifact,
 };
 use fund::models::tide::configuration::ModelParameters;
-use fund::models::tide::data::{input_feature_size, DatasetKind, ValidationSplit};
+use fund::models::tide::data::{input_feature_size, DatasetKind, TrainingFraction};
 use fund::models::tide::drift::{check_drift, DriftStatus};
 use fund::models::tide::evaluate::evaluate;
 use fund::models::tide::fit::{filter_training_bars, fit, write_artifact_json};
@@ -40,7 +40,7 @@ use fund::models::tide::train::{train, TrainBackend, TrainConfiguration};
 
 const INPUT_LENGTH: usize = 35;
 const OUTPUT_LENGTH: usize = 1;
-const VALIDATION_SPLIT: f64 = 0.8;
+const TRAINING_FRACTION: f64 = 0.8;
 
 /// S3 prefix for the trainer's own bar archive.
 ///
@@ -139,14 +139,14 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let fit_result = fit(filtered)?;
 
-    let validation_split = ValidationSplit::new(VALIDATION_SPLIT)?;
+    let training_fraction = TrainingFraction::new(TRAINING_FRACTION)?;
     let train_dataset = fit_result.data.get_dataset(
-        DatasetKind::Train(validation_split),
+        DatasetKind::Train(training_fraction),
         INPUT_LENGTH,
         OUTPUT_LENGTH,
     )?;
     let valid_dataset = fit_result.data.get_dataset(
-        DatasetKind::Validate(validation_split),
+        DatasetKind::Validate(training_fraction),
         INPUT_LENGTH,
         OUTPUT_LENGTH,
     )?;

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -30,7 +30,7 @@ use fund::models::tide::artifact::{
     candidate_folders_descending, list_run_folders, package_dir_to_tar_gz, upload_artifact,
 };
 use fund::models::tide::configuration::ModelParameters;
-use fund::models::tide::data::input_feature_size;
+use fund::models::tide::data::{input_feature_size, DatasetKind, ValidationSplit};
 use fund::models::tide::drift::{check_drift, DriftStatus};
 use fund::models::tide::evaluate::evaluate;
 use fund::models::tide::fit::{filter_training_bars, fit, write_artifact_json};
@@ -139,14 +139,17 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let fit_result = fit(filtered)?;
 
-    let train_dataset =
-        fit_result
-            .data
-            .get_dataset("train", VALIDATION_SPLIT, INPUT_LENGTH, OUTPUT_LENGTH)?;
-    let valid_dataset =
-        fit_result
-            .data
-            .get_dataset("validate", VALIDATION_SPLIT, INPUT_LENGTH, OUTPUT_LENGTH)?;
+    let validation_split = ValidationSplit::new(VALIDATION_SPLIT)?;
+    let train_dataset = fit_result.data.get_dataset(
+        DatasetKind::Train(validation_split),
+        INPUT_LENGTH,
+        OUTPUT_LENGTH,
+    )?;
+    let valid_dataset = fit_result.data.get_dataset(
+        DatasetKind::Validate(validation_split),
+        INPUT_LENGTH,
+        OUTPUT_LENGTH,
+    )?;
     info!(
         train_samples = train_dataset.len(),
         validation_samples = valid_dataset.len(),

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -347,9 +347,16 @@ async fn run_inference(
     let array = predictions.as_array().cloned().unwrap_or_default();
     predict::validate_predictions(&array).map_err(at("validate"))?;
 
+    // Split back apart rather than propagated as one error: a malformed payload is a bug in the
+    // model output this function just produced, and belongs with the other pipeline stages; a
+    // database failure is the database, and keeps reading as one.
     let rows =
         predict::insert_predictions(&state.pool, &array, correlation_id, model_state.run_id())
-            .await?;
+            .await
+            .map_err(|error| match error {
+                predict::InsertPredictionsError::Payload(message) => at("insert")(message),
+                predict::InsertPredictionsError::Database(error) => HandlerError::Database(error),
+            })?;
 
     Ok((array.len(), rows))
 }

--- a/src/models/tide/artifact.rs
+++ b/src/models/tide/artifact.rs
@@ -8,6 +8,7 @@
 //! format is the only contract between them.
 
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, PoisonError};
 
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client as S3Client;
@@ -26,7 +27,15 @@ use crate::models::tide::model::TiDEModel;
 // --------------------------------------------------------------------------
 
 pub struct ModelState {
-    model: TiDEModel<NdArray>,
+    /// The loaded weights, behind a mutex because the forward pass mutates them.
+    ///
+    /// Burn stores each parameter as a `core::cell::OnceCell`, and `Param::val` initializes it
+    /// through `get_or_init` — so a forward pass writes through a shared reference and
+    /// `TiDEModel<NdArray>` is therefore `!Sync`. The mutex is not here to arbitrate contention;
+    /// there is exactly one caller. It is here so this type is `Sync` by construction, which the
+    /// prediction handler needs: it holds a `&ModelState` across an await and `JoinSet::spawn`
+    /// requires the resulting future to be `Send`.
+    model: Mutex<TiDEModel<NdArray>>,
     parameters: ModelParameters,
     scaler: Scaler,
     mappings: FeatureMappings,
@@ -56,7 +65,7 @@ impl ModelState {
         load_timestamp: i64,
     ) -> Self {
         Self {
-            model,
+            model: Mutex::new(model),
             parameters,
             scaler,
             mappings,
@@ -66,8 +75,15 @@ impl ModelState {
         }
     }
 
-    pub fn model(&self) -> &TiDEModel<NdArray> {
-        &self.model
+    /// Borrows the model for a forward pass.
+    ///
+    /// A poisoned lock is recovered from rather than propagated. Poisoning here means a previous
+    /// forward pass panicked, but the weights carry no invariant that a panic could leave half
+    /// written: the only mutation is `OnceCell::get_or_init` caching a materialized tensor, and a
+    /// panic during initialization leaves the cell empty rather than partly filled. Failing every
+    /// later session because one earlier one panicked would be the worse outcome.
+    pub fn model(&self) -> MutexGuard<'_, TiDEModel<NdArray>> {
+        self.model.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
     pub fn parameters(&self) -> &ModelParameters {
@@ -95,10 +111,16 @@ impl ModelState {
     }
 }
 
-// SAFETY: TiDEModel<NdArray> is not Sync due to burn's Param<T> using an RwLock
-// with a non-Sync FnOnce inside. We guard all access behind a Mutex, so this is safe.
-unsafe impl Send for ModelState {}
-unsafe impl Sync for ModelState {}
+/// `ModelState` must stay `Send + Sync` — the prediction handler holds a `&ModelState` across an
+/// await inside a future that `JoinSet::spawn` requires to be `Send`. That used to be asserted with
+/// `unsafe impl`; it is now a property the compiler derives from the `Mutex` around the model, and
+/// this is what makes the difference visible. Removing the mutex fails here rather than in
+/// `bin/fund.rs`, several call layers from the cause.
+#[allow(dead_code)]
+fn model_state_is_send_and_sync() {
+    fn require<T: Send + Sync>() {}
+    require::<ModelState>();
+}
 
 // --------------------------------------------------------------------------
 // Reading: resolve, download, load

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -240,6 +240,46 @@ pub fn input_feature_size(input_length: usize, output_length: usize) -> usize {
         + STATIC_CATEGORICAL_COLUMNS.len()
 }
 
+/// The fraction of the observed time range that goes to training.
+///
+/// Strictly between 0 and 1. At either endpoint one side of the split is empty, and an empty side
+/// is not an error anywhere downstream — [`window_frame`] simply yields no windows, training runs
+/// on nothing or validates against nothing, and the run reports a loss computed over zero rows.
+/// Rejecting the endpoint here is the only place that failure is still legible.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ValidationSplit(f64);
+
+impl ValidationSplit {
+    pub fn new(fraction: f64) -> Result<Self, String> {
+        if !fraction.is_finite() || fraction <= 0.0 || fraction >= 1.0 {
+            return Err(format!(
+                "the validation split must be a fraction strictly between 0 and 1, got {fraction}"
+            ));
+        }
+        Ok(Self(fraction))
+    }
+
+    fn fraction(self) -> f64 {
+        self.0
+    }
+}
+
+/// Which dataset [`Data::get_dataset`] should window out of the engineered frame.
+///
+/// The split rides on the two variants that consume it rather than on the call, because inference
+/// has no meaningful value to pass: it reads the whole frame. The previous `&str` selector took a
+/// split regardless, so the predict call site carried a `0.8` that did nothing — and, worse, its
+/// `_` arm turned any unrecognized string into training data rather than an error.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DatasetKind {
+    /// One window per ticker at the end of its series, no targets.
+    Predict,
+    /// All sliding windows at or before the cutoff, with the future `daily_return` as targets.
+    Train(ValidationSplit),
+    /// All sliding windows after the cutoff, with the future `daily_return` as targets.
+    Validate(ValidationSplit),
+}
+
 pub struct Data {
     pub data: DataFrame,
     pub scaler: Scaler,
@@ -290,8 +330,9 @@ impl Data {
     /// `min + (max - min) * validation_split`. Rows at or before the cutoff are training.
     pub fn split_by_timestamp(
         &self,
-        validation_split: f64,
+        validation_split: ValidationSplit,
     ) -> Result<(DataFrame, DataFrame), Box<dyn std::error::Error>> {
+        let validation_split = validation_split.fraction();
         let timestamps = self.data.column("timestamp").map_err(|e| e.to_string())?;
         let timestamps = timestamps.i64().map_err(|e| e.to_string())?;
         let minimum_timestamp = timestamps.min().unwrap_or(0);
@@ -307,24 +348,21 @@ impl Data {
     }
 
     /// Build a windowed dataset.
-    ///
-    /// - `predict` → one window per ticker at the end of its series, no targets.
-    /// - `train` / `validate` → all sliding windows over the corresponding date
-    ///   split, with the future `daily_return` window as targets.
     pub fn get_dataset(
         &self,
-        data_type: &str,
-        validation_split: f64,
+        kind: DatasetKind,
         input_length: usize,
         output_length: usize,
     ) -> Result<TrainingDataset, Box<dyn std::error::Error>> {
-        match data_type {
-            "predict" => window_frame(&self.data, input_length, output_length, true, false),
-            "validate" => {
+        match kind {
+            DatasetKind::Predict => {
+                window_frame(&self.data, input_length, output_length, true, false)
+            }
+            DatasetKind::Validate(validation_split) => {
                 let (_, valid) = self.split_by_timestamp(validation_split)?;
                 window_frame(&valid, input_length, output_length, false, true)
             }
-            _ => {
+            DatasetKind::Train(validation_split) => {
                 let (train, _) = self.split_by_timestamp(validation_split)?;
                 window_frame(&train, input_length, output_length, false, true)
             }
@@ -1228,10 +1266,14 @@ mod tests {
         )
     }
 
+    fn split_of(fraction: f64) -> ValidationSplit {
+        ValidationSplit::new(fraction).expect("the fixture split must be in range")
+    }
+
     #[test]
     fn test_get_dataset_predict_one_window_per_ticker() {
         let data = empty_data(make_encoded_frame(3, 6));
-        let dataset = data.get_dataset("predict", 0.8, 2, 1).unwrap();
+        let dataset = data.get_dataset(DatasetKind::Predict, 2, 1).unwrap();
         // One prediction window per ticker, no targets.
         assert_eq!(dataset.len(), 3);
         assert!(dataset.targets.is_none());
@@ -1243,7 +1285,9 @@ mod tests {
     #[test]
     fn test_get_dataset_train_has_targets() {
         let data = empty_data(make_encoded_frame(2, 10));
-        let dataset = data.get_dataset("train", 0.8, 3, 2).unwrap();
+        let dataset = data
+            .get_dataset(DatasetKind::Train(split_of(0.8)), 3, 2)
+            .unwrap();
         let sample_count = dataset.len();
         assert!(sample_count > 0);
         let targets = dataset.targets.expect("train dataset must have targets");
@@ -1252,10 +1296,47 @@ mod tests {
         assert_eq!(targets.shape()[0], sample_count);
     }
 
+    /// Both endpoints leave one side of the split empty, and nothing downstream reports that as a
+    /// failure — the run trains on no windows and records a loss over zero rows. The constructor is
+    /// the only place it is still visible.
+    #[test]
+    fn test_validation_split_rejects_values_outside_the_open_unit_interval() {
+        for rejected in [0.0, 1.0, -0.1, 1.5, f64::NAN, f64::INFINITY] {
+            assert!(
+                ValidationSplit::new(rejected).is_err(),
+                "expected {rejected} to be rejected"
+            );
+        }
+        assert!(ValidationSplit::new(0.8).is_ok());
+    }
+
+    /// The predict variant carries no split, so inference cannot pass one that does nothing — which
+    /// is what the `0.8` at the old predict call site was. This is a compile-time property; the
+    /// assertion here records that predicting reads the whole frame rather than a split of it.
+    #[test]
+    fn test_predict_windows_the_whole_frame_rather_than_a_split() {
+        let frame = make_encoded_frame(1, 10);
+        let data = empty_data(frame);
+
+        let predicted = data.get_dataset(DatasetKind::Predict, 3, 1).unwrap();
+        // One window at the end of the ticker's full series.
+        assert_eq!(predicted.len(), 1);
+
+        // A split that keeps only the first 20% of the range cannot reach the predict path, so the
+        // predict window count is unchanged by any split value.
+        let trained = data
+            .get_dataset(DatasetKind::Train(split_of(0.2)), 3, 1)
+            .unwrap();
+        assert!(
+            trained.len() < 10,
+            "the training split must cover fewer windows than the full frame"
+        );
+    }
+
     #[test]
     fn test_split_by_timestamp_partitions_rows() {
         let data = empty_data(make_encoded_frame(1, 10));
-        let (train, valid) = data.split_by_timestamp(0.8).unwrap();
+        let (train, valid) = data.split_by_timestamp(split_of(0.8)).unwrap();
         assert_eq!(train.height() + valid.height(), 10);
         assert!(train.height() > 0);
         assert!(valid.height() > 0);
@@ -1713,7 +1794,7 @@ mod tests {
         // Train is date <= split, validation is date > split. With 11 daily rows (0..=10 days)
         // and split 0.8 the cutoff lands exactly on day 8, which must belong to train.
         let data = empty_data(make_encoded_frame(1, 11));
-        let (train, valid) = data.split_by_timestamp(0.8).unwrap();
+        let (train, valid) = data.split_by_timestamp(split_of(0.8)).unwrap();
         assert_eq!(train.height(), 9);
         assert_eq!(valid.height(), 2);
     }

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -240,20 +240,25 @@ pub fn input_feature_size(input_length: usize, output_length: usize) -> usize {
         + STATIC_CATEGORICAL_COLUMNS.len()
 }
 
-/// The fraction of the observed time range that goes to training.
+/// The fraction of the observed time range that goes to **training**; the remainder validates.
+///
+/// Named for the side it measures rather than for the split it defines. "Validation split" is
+/// ambiguous across the field — some libraries mean the held-out fraction by it — and a type whose
+/// name reads backwards is worse than a bare `f64`, because `TrainingFraction::new(0.2)` looks
+/// deliberate. At 0.2 this trains on a fifth of the window and every guard still passes.
 ///
 /// Strictly between 0 and 1. At either endpoint one side of the split is empty, and an empty side
 /// is not an error anywhere downstream — [`window_frame`] simply yields no windows, training runs
 /// on nothing or validates against nothing, and the run reports a loss computed over zero rows.
 /// Rejecting the endpoint here is the only place that failure is still legible.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ValidationSplit(f64);
+pub struct TrainingFraction(f64);
 
-impl ValidationSplit {
+impl TrainingFraction {
     pub fn new(fraction: f64) -> Result<Self, String> {
         if !fraction.is_finite() || fraction <= 0.0 || fraction >= 1.0 {
             return Err(format!(
-                "the validation split must be a fraction strictly between 0 and 1, got {fraction}"
+                "the training fraction must be strictly between 0 and 1, got {fraction}"
             ));
         }
         Ok(Self(fraction))
@@ -275,9 +280,9 @@ pub enum DatasetKind {
     /// One window per ticker at the end of its series, no targets.
     Predict,
     /// All sliding windows at or before the cutoff, with the future `daily_return` as targets.
-    Train(ValidationSplit),
+    Train(TrainingFraction),
     /// All sliding windows after the cutoff, with the future `daily_return` as targets.
-    Validate(ValidationSplit),
+    Validate(TrainingFraction),
 }
 
 pub struct Data {
@@ -327,18 +332,18 @@ impl Data {
     }
 
     /// Split the engineered frame into (train, validate) by a global date cutoff at
-    /// `min + (max - min) * validation_split`. Rows at or before the cutoff are training.
+    /// `min + (max - min) * training_fraction`. Rows at or before the cutoff are training.
     pub fn split_by_timestamp(
         &self,
-        validation_split: ValidationSplit,
+        training_fraction: TrainingFraction,
     ) -> Result<(DataFrame, DataFrame), Box<dyn std::error::Error>> {
-        let validation_split = validation_split.fraction();
+        let training_fraction = training_fraction.fraction();
         let timestamps = self.data.column("timestamp").map_err(|e| e.to_string())?;
         let timestamps = timestamps.i64().map_err(|e| e.to_string())?;
         let minimum_timestamp = timestamps.min().unwrap_or(0);
         let maximum_timestamp = timestamps.max().unwrap_or(0);
         let cutoff = minimum_timestamp
-            + (((maximum_timestamp - minimum_timestamp) as f64) * validation_split) as i64;
+            + (((maximum_timestamp - minimum_timestamp) as f64) * training_fraction) as i64;
 
         let train_mask = timestamps.lt_eq(cutoff);
         let valid_mask = timestamps.gt(cutoff);
@@ -358,12 +363,12 @@ impl Data {
             DatasetKind::Predict => {
                 window_frame(&self.data, input_length, output_length, true, false)
             }
-            DatasetKind::Validate(validation_split) => {
-                let (_, valid) = self.split_by_timestamp(validation_split)?;
+            DatasetKind::Validate(training_fraction) => {
+                let (_, valid) = self.split_by_timestamp(training_fraction)?;
                 window_frame(&valid, input_length, output_length, false, true)
             }
-            DatasetKind::Train(validation_split) => {
-                let (train, _) = self.split_by_timestamp(validation_split)?;
+            DatasetKind::Train(training_fraction) => {
+                let (train, _) = self.split_by_timestamp(training_fraction)?;
                 window_frame(&train, input_length, output_length, false, true)
             }
         }
@@ -1266,8 +1271,8 @@ mod tests {
         )
     }
 
-    fn split_of(fraction: f64) -> ValidationSplit {
-        ValidationSplit::new(fraction).expect("the fixture split must be in range")
+    fn fraction_of(value: f64) -> TrainingFraction {
+        TrainingFraction::new(value).expect("the fixture fraction must be in range")
     }
 
     #[test]
@@ -1286,7 +1291,7 @@ mod tests {
     fn test_get_dataset_train_has_targets() {
         let data = empty_data(make_encoded_frame(2, 10));
         let dataset = data
-            .get_dataset(DatasetKind::Train(split_of(0.8)), 3, 2)
+            .get_dataset(DatasetKind::Train(fraction_of(0.8)), 3, 2)
             .unwrap();
         let sample_count = dataset.len();
         assert!(sample_count > 0);
@@ -1300,14 +1305,14 @@ mod tests {
     /// failure — the run trains on no windows and records a loss over zero rows. The constructor is
     /// the only place it is still visible.
     #[test]
-    fn test_validation_split_rejects_values_outside_the_open_unit_interval() {
+    fn test_training_fraction_rejects_values_outside_the_open_unit_interval() {
         for rejected in [0.0, 1.0, -0.1, 1.5, f64::NAN, f64::INFINITY] {
             assert!(
-                ValidationSplit::new(rejected).is_err(),
+                TrainingFraction::new(rejected).is_err(),
                 "expected {rejected} to be rejected"
             );
         }
-        assert!(ValidationSplit::new(0.8).is_ok());
+        assert!(TrainingFraction::new(0.8).is_ok());
     }
 
     /// The predict variant carries no split, so inference cannot pass one that does nothing — which
@@ -1325,7 +1330,7 @@ mod tests {
         // A split that keeps only the first 20% of the range cannot reach the predict path, so the
         // predict window count is unchanged by any split value.
         let trained = data
-            .get_dataset(DatasetKind::Train(split_of(0.2)), 3, 1)
+            .get_dataset(DatasetKind::Train(fraction_of(0.2)), 3, 1)
             .unwrap();
         assert!(
             trained.len() < 10,
@@ -1336,7 +1341,7 @@ mod tests {
     #[test]
     fn test_split_by_timestamp_partitions_rows() {
         let data = empty_data(make_encoded_frame(1, 10));
-        let (train, valid) = data.split_by_timestamp(split_of(0.8)).unwrap();
+        let (train, valid) = data.split_by_timestamp(fraction_of(0.8)).unwrap();
         assert_eq!(train.height() + valid.height(), 10);
         assert!(train.height() > 0);
         assert!(valid.height() > 0);
@@ -1794,7 +1799,7 @@ mod tests {
         // Train is date <= split, validation is date > split. With 11 daily rows (0..=10 days)
         // and split 0.8 the cutoff lands exactly on day 8, which must belong to train.
         let data = empty_data(make_encoded_frame(1, 11));
-        let (train, valid) = data.split_by_timestamp(split_of(0.8)).unwrap();
+        let (train, valid) = data.split_by_timestamp(fraction_of(0.8)).unwrap();
         assert_eq!(train.height(), 9);
         assert_eq!(valid.height(), 2);
     }

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 use crate::common::types::{EquityPrediction, Ticker};
 use crate::data::calendar::SessionDate;
 use crate::models::tide::artifact::ModelState;
-use crate::models::tide::data::Data;
+use crate::models::tide::data::{Data, DatasetKind};
 
 #[derive(Debug, thiserror::Error)]
 pub enum PredictionError {
@@ -184,7 +184,7 @@ pub fn filter_to_trained_tickers(
 
     let ticker_series = Series::new("valid_ticker".into(), &trained_tickers);
 
-    let original_count = data.height();
+    let original_rows = data.height();
     let filtered = data
         .lazy()
         .with_column(col("ticker").cast(DataType::String).str().to_uppercase())
@@ -196,13 +196,16 @@ pub fn filter_to_trained_tickers(
         return Err(PredictionError::NoMatchingTickers);
     }
 
-    let original_tickers = original_count;
-    let filtered_tickers = filtered.height();
-    if original_tickers != filtered_tickers {
+    // Rows, not tickers. The frame carries one row per ticker per bar, so these counts are roughly
+    // the ticker count times the lookback — reported under a `tickers` name they read as a universe
+    // two orders of magnitude larger than it is.
+    let filtered_rows = filtered.height();
+    if original_rows != filtered_rows {
         info!(
-            original = original_tickers,
-            filtered = filtered_tickers,
-            dropped = original_tickers - filtered_tickers,
+            original_rows,
+            filtered_rows,
+            dropped_rows = original_rows - filtered_rows,
+            trained_tickers = trained_tickers.len(),
             "Filtered to trained tickers"
         );
     }
@@ -253,7 +256,7 @@ pub fn generate_predictions(
     let output_length = model_state.parameters().output_length();
     let dataset_input_length = model_state.parameters().input_length();
     let dataset = tide_data
-        .get_dataset("predict", 0.8, dataset_input_length, output_length)
+        .get_dataset(DatasetKind::Predict, dataset_input_length, output_length)
         .map_err(|e| PredictionError::DatasetCreation(e.to_string()))?;
 
     if dataset.is_empty() {
@@ -430,51 +433,45 @@ pub fn validate_predictions(predictions: &[serde_json::Value]) -> Result<(), Str
 ///
 /// These come from our own pipeline, so a missing or mistyped field is a bug upstream. It fails
 /// loudly with the offending field and ticker rather than persisting placeholders.
+///
+/// The failure is a plain message rather than a `sqlx::Error::Decode`, which is what it used to be.
+/// Nothing here came from the database — this is our own in-memory JSON — so reporting a malformed
+/// payload as a decode error sent the reader looking at the wrong machine.
 fn prediction_from_json(
     prediction: &serde_json::Value,
     correlation_id: Uuid,
     model_run_id: &str,
-) -> Result<EquityPrediction, sqlx::Error> {
+) -> Result<EquityPrediction, String> {
     let ticker = prediction
         .get("ticker")
         .and_then(|value| value.as_str())
-        .ok_or_else(|| sqlx::Error::Decode("Prediction is missing a string ticker field".into()))?;
+        .ok_or_else(|| "Prediction is missing a string ticker field".to_string())?;
 
     let timestamp_milliseconds = prediction
         .get("timestamp")
         .and_then(|value| value.as_i64())
         .ok_or_else(|| {
-            sqlx::Error::Decode(
-                format!("Prediction for ticker {ticker} is missing an integer timestamp field")
-                    .into(),
-            )
+            format!("Prediction for ticker {ticker} is missing an integer timestamp field")
         })?;
     let timestamp = DateTime::<Utc>::from_timestamp_millis(timestamp_milliseconds)
         .filter(|_| timestamp_milliseconds > 0)
         .ok_or_else(|| {
-            sqlx::Error::Decode(
-                format!(
-                    "Prediction for ticker {ticker} has an invalid timestamp: {timestamp_milliseconds}"
-                )
-                .into(),
+            format!(
+                "Prediction for ticker {ticker} has an invalid timestamp: {timestamp_milliseconds}"
             )
         })?;
 
-    let quantile = |field: &str| -> Result<f64, sqlx::Error> {
+    let quantile = |field: &str| -> Result<f64, String> {
         prediction
             .get(field)
             .and_then(|value| value.as_f64())
             .ok_or_else(|| {
-                sqlx::Error::Decode(
-                    format!("Prediction for ticker {ticker} is missing a numeric {field} field")
-                        .into(),
-                )
+                format!("Prediction for ticker {ticker} is missing a numeric {field} field")
             })
     };
 
-    let validated_ticker = Ticker::new(ticker).ok_or_else(|| {
-        sqlx::Error::Decode(format!("Invalid ticker in prediction payload: {ticker}").into())
-    })?;
+    let validated_ticker = Ticker::new(ticker)
+        .ok_or_else(|| format!("Invalid ticker in prediction payload: {ticker}"))?;
     // `EquityPrediction::new` enforces the quantile ordering invariant, so a crossed set from the
     // model is rejected here rather than stored. Every downstream use -- the confidence measure,
     // the directional signal -- produces plausible nonsense from crossed quantiles rather than
@@ -488,9 +485,20 @@ fn prediction_from_json(
         quantile("quantile_50")?,
         quantile("quantile_90")?,
     )
-    .map_err(|error| {
-        sqlx::Error::Decode(format!("Prediction for ticker {ticker} is invalid: {error}").into())
-    })
+    .map_err(|error| format!("Prediction for ticker {ticker} is invalid: {error}"))
+}
+
+/// Why writing a prediction batch failed.
+///
+/// Two variants because the two failures point at different machines: a malformed payload is a bug
+/// in this process's own model output, and a database error is the database. Collapsing them, as
+/// the `sqlx::Error` return did, made every model bug read as a storage problem.
+#[derive(Debug, thiserror::Error)]
+pub enum InsertPredictionsError {
+    #[error("prediction payload is malformed: {0}")]
+    Payload(String),
+    #[error("{0}")]
+    Database(#[from] sqlx::Error),
 }
 
 pub async fn insert_predictions(
@@ -498,7 +506,7 @@ pub async fn insert_predictions(
     predictions: &[serde_json::Value],
     correlation_id: Uuid,
     model_run_id: &str,
-) -> Result<u64, sqlx::Error> {
+) -> Result<u64, InsertPredictionsError> {
     if predictions.is_empty() {
         return Ok(0);
     }
@@ -506,7 +514,8 @@ pub async fn insert_predictions(
     let validated: Vec<EquityPrediction> = predictions
         .iter()
         .map(|prediction| prediction_from_json(prediction, correlation_id, model_run_id))
-        .collect::<Result<_, _>>()?;
+        .collect::<Result<_, _>>()
+        .map_err(InsertPredictionsError::Payload)?;
 
     let mut rows_affected: u64 = 0;
     let mut transaction = pool.begin().await?;
@@ -1359,5 +1368,79 @@ mod tests {
 
         let result = unscale_and_sort_quantiles(&[], &scaler);
         assert!(result.is_empty());
+    }
+
+    fn valid_prediction_payload() -> serde_json::Value {
+        serde_json::json!({
+            "ticker": "AAPL",
+            "timestamp": 1_760_000_000_000i64,
+            "quantile_10": -0.01,
+            "quantile_50": 0.0,
+            "quantile_90": 0.01,
+        })
+    }
+
+    fn convert(payload: &serde_json::Value) -> Result<EquityPrediction, String> {
+        prediction_from_json(payload, Uuid::nil(), "2026-08-05-00-00-00-000")
+    }
+
+    #[test]
+    fn test_prediction_from_json_accepts_a_well_formed_payload() {
+        let prediction = convert(&valid_prediction_payload()).expect("the fixture must convert");
+        assert_eq!(prediction.ticker().as_str(), "AAPL");
+        assert_eq!(prediction.quantile_50(), 0.0);
+    }
+
+    /// Every field this reads comes from our own pipeline, so each of these is an upstream bug. The
+    /// message has to name the offending field and, where it can, the ticker — the payload is a
+    /// batch of thousands and "a field is missing" would not narrow it.
+    #[test]
+    fn test_prediction_from_json_names_the_field_it_rejects() {
+        for (field, expected_fragment) in [
+            ("ticker", "string ticker field"),
+            ("timestamp", "integer timestamp field"),
+            ("quantile_10", "numeric quantile_10 field"),
+            ("quantile_50", "numeric quantile_50 field"),
+            ("quantile_90", "numeric quantile_90 field"),
+        ] {
+            let mut payload = valid_prediction_payload();
+            payload.as_object_mut().unwrap().remove(field);
+
+            let error = convert(&payload).expect_err("a missing {field} must be rejected");
+            assert!(
+                error.contains(expected_fragment),
+                "removing {field} produced `{error}`, which does not name the field"
+            );
+        }
+    }
+
+    #[test]
+    fn test_prediction_from_json_rejects_a_non_positive_timestamp() {
+        let mut payload = valid_prediction_payload();
+        payload["timestamp"] = serde_json::json!(0i64);
+
+        let error = convert(&payload).expect_err("a zero timestamp must be rejected");
+        assert!(error.contains("invalid timestamp"), "got `{error}`");
+    }
+
+    #[test]
+    fn test_prediction_from_json_rejects_a_ticker_the_domain_type_refuses() {
+        let mut payload = valid_prediction_payload();
+        payload["ticker"] = serde_json::json!("NOTATICKER123");
+
+        let error = convert(&payload).expect_err("an unusable ticker must be rejected");
+        assert!(error.contains("Invalid ticker"), "got `{error}`");
+    }
+
+    /// Crossed quantiles are the failure this conversion exists to stop: every downstream use of a
+    /// prediction produces plausible nonsense from them rather than failing, so a crossed set that
+    /// reaches the table is never detected again.
+    #[test]
+    fn test_prediction_from_json_rejects_crossed_quantiles() {
+        let mut payload = valid_prediction_payload();
+        payload["quantile_10"] = serde_json::json!(0.05);
+
+        let error = convert(&payload).expect_err("crossed quantiles must be rejected");
+        assert!(error.contains("AAPL"), "got `{error}`");
     }
 }

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -1406,7 +1406,9 @@ mod tests {
             let mut payload = valid_prediction_payload();
             payload.as_object_mut().unwrap().remove(field);
 
-            let error = convert(&payload).expect_err("a missing {field} must be rejected");
+            let Err(error) = convert(&payload) else {
+                panic!("removing {field} must leave the payload rejected");
+            };
             assert!(
                 error.contains(expected_fragment),
                 "removing {field} produced `{error}`, which does not name the field"

--- a/src/models/tide/train.rs
+++ b/src/models/tide/train.rs
@@ -220,17 +220,26 @@ pub fn train(
         };
         losses.push(train_loss);
 
-        let stopping_loss = match valid_dataset {
-            Some(valid) if !valid.is_empty() => {
-                validation_loss(&model, valid, parameters, configuration.batch_size)
-            }
-            _ => train_loss,
+        // Kept separate from `stopping_loss` so the log can say which one it is. When there is no
+        // validation set, early stopping falls back to the training loss — and logging that
+        // fallback under `validation_loss` produced a line where the two losses matched exactly,
+        // which reads as a suspiciously well-generalizing model rather than as an absent split.
+        let measured_validation_loss = match valid_dataset {
+            Some(valid) if !valid.is_empty() => Some(validation_loss(
+                &model,
+                valid,
+                parameters,
+                configuration.batch_size,
+            )),
+            _ => None,
         };
+        let stopping_loss = measured_validation_loss.unwrap_or(train_loss);
 
         info!(
             epoch = epoch + 1,
-            train_loss = train_loss,
-            validation_loss = stopping_loss,
+            train_loss,
+            validation_loss = ?measured_validation_loss,
+            stopping_loss,
             "Epoch complete"
         );
 


### PR DESCRIPTION
# Overview

Removes the two `unsafe impl`s on `ModelState` by making the property they asserted something the compiler derives, and folds in four deferred cosmetics on the files this touches.

## Changes

- Replace `unsafe impl Send`/`unsafe impl Sync` for `ModelState` with a `Mutex` around the model, so `Send + Sync` is derived rather than asserted; a module-level `Send + Sync` assertion fails at the cause if the mutex is ever removed
- Replace `get_dataset`'s `&str` selector with a `DatasetKind` enum carrying the split only on the variants that use it, plus a validated `TrainingFraction` newtype
- Log the measured validation loss as an `Option` alongside the stopping loss, instead of recording the training loss under `validation_loss`
- Split `insert_predictions`' error into `InsertPredictionsError::Payload` and `::Database` so a malformed prediction stops reporting as a `sqlx::Error::Decode`
- Rename `filter_to_trained_tickers`' log fields from ticker counts to row counts, and report the trained ticker count separately
- Add the `prediction_from_json` tests that never existed

## Context

The safety comment on the `unsafe impl` read "We guard all access behind a Mutex, so this is safe." The rebuild deleted that mutex. `download_and_load_model` runs per inference and the result is never shared, so the assertion held — but its stated justification was false, and a safety argument that cannot be checked against the code is the kind that survives the change that invalidates it.

The comment was also wrong about why the type is `!Sync`. It blamed burn's `RwLock` holding a non-`Sync` `FnOnce`. The compiler names `core::cell::OnceCell` inside `Param`, which `Param::val` initializes through `get_or_init` on every forward pass — an unsynchronized write through a shared reference, which is a different hazard with a different remedy.

Adding the mutex the comment already claimed existed removes the need for `unsafe` entirely: `TiDEModel<NdArray>` is `Send`, so `Mutex<TiDEModel<NdArray>>` is `Sync`. The lock is uncontended by construction — there is one caller. It exists to satisfy the bound `handle_predictions` needs, since it holds a `&ModelState` across an await inside a future `JoinSet::spawn` requires to be `Send`. Verified by removing the mutex and confirming the failure lands on the new assertion in `artifact.rs` rather than several call layers away in `bin/fund.rs`.

The `get_dataset` change is the one with live consequences beyond legibility. Its `_` arm turned any unrecognized selector string into training data rather than an error, and its `validation_split` parameter was ignored on the predict path — which is why the inference call site carried a `0.8` that did nothing. Both are now unrepresentable. `ValidationSplit` rejects 0 and 1 because at either endpoint one side of the split is empty and nothing downstream reports it: windowing simply yields nothing and the run records a loss over zero rows.

The `prediction_from_json` tests close `3693221306` from the deferred hardening list. Verified non-vacuous by mutation — removing the `timestamp_milliseconds > 0` guard fails `test_prediction_from_json_rejects_a_non_positive_timestamp`.

Two `improvements_tide_model_hardening.md` §7 items are deliberately not here. The `observability.rs` appender duplication belongs with whatever next touches that file, per the section's own rule, and this PR does not. Moving synchronous artifact IO off the async runtime thread remains declined for the reason recorded there: it happens once per day at pre-open, on a runtime with nothing else pending.

443 tests, coverage 82.13% against the 75% floor. The one remaining clippy warning (`needless_range_loop` in a `data.rs` test fixture) is pre-existing on `master` and is folded into the identifier sweep that follows this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved prediction error reporting by distinguishing invalid prediction data from database failures.
  - Added validation for malformed timestamps, fields, tickers, quantiles, and invalid dataset split values.
  - Improved model reliability during concurrent prediction and training operations.
  - Corrected prediction filtering and row-count reporting.

- **Training**
  - Training logs now clearly distinguish validation loss from the metric used for early stopping.
  - When validation data is unavailable, logs indicate this explicitly while continuing to use training loss appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
