### PR TITLE
Spell out identifiers across the model code

### DIFF
--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -145,14 +145,14 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         INPUT_LENGTH,
         OUTPUT_LENGTH,
     )?;
-    let valid_dataset = fit_result.data.get_dataset(
+    let validation_dataset = fit_result.data.get_dataset(
         DatasetKind::Validate(training_fraction),
         INPUT_LENGTH,
         OUTPUT_LENGTH,
     )?;
     info!(
         train_samples = train_dataset.len(),
-        validation_samples = valid_dataset.len(),
+        validation_samples = validation_dataset.len(),
         "Built windowed datasets"
     );
     if train_dataset.is_empty() {
@@ -178,7 +178,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let (best_model, losses) = train(
         model,
         &train_dataset,
-        Some(&valid_dataset),
+        Some(&validation_dataset),
         &parameters,
         &configuration,
         &device,
@@ -190,9 +190,9 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let inner_model = best_model.valid();
-    let metrics = evaluate(&inner_model, &valid_dataset, &parameters)?;
+    let metrics = evaluate(&inner_model, &validation_dataset, &parameters)?;
     info!(
-        crps = metrics.crps,
+        continuous_ranked_probability_score = metrics.continuous_ranked_probability_score,
         directional_accuracy = metrics.directional_accuracy,
         quantile_coverage = metrics.quantile_coverage,
         "Evaluation metrics"
@@ -235,17 +235,18 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     info!(key = model_key, "Uploaded model artifact");
 
     let current_folder = format!("{artifact_prefix}{timestamp}/");
-    let prior_crps = fetch_prior_crps(
-        &s3_client,
-        &bucket,
-        &artifact_prefix,
-        &current_folder,
-        DRIFT_PRIOR_RUN_COUNT,
-    )
-    .await;
+    let prior_continuous_ranked_probability_scores =
+        fetch_prior_continuous_ranked_probability_scores(
+            &s3_client,
+            &bucket,
+            &artifact_prefix,
+            &current_folder,
+            DRIFT_PRIOR_RUN_COUNT,
+        )
+        .await;
     let drift = check_drift(
-        metrics.crps,
-        &prior_crps,
+        metrics.continuous_ranked_probability_score,
+        &prior_continuous_ranked_probability_scores,
         DRIFT_MINIMUM_RUNS,
         DRIFT_DEGRADATION_THRESHOLD,
     );
@@ -253,15 +254,17 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // with no compiler error, which is the case where a new signal is most likely to be missed.
     match drift.status {
         DriftStatus::DriftDetected => warn!(
-            current_crps = drift.current_crps,
-            baseline_crps = drift.baseline_crps,
+            current_continuous_ranked_probability_score =
+                drift.current_continuous_ranked_probability_score,
+            baseline_continuous_ranked_probability_score =
+                drift.baseline_continuous_ranked_probability_score,
             "Model drift detected"
         ),
         DriftStatus::NoDrift | DriftStatus::InsufficientHistory => info!(
             status = ?drift.status,
-            current_crps = drift.current_crps,
-            baseline_crps = drift.baseline_crps,
-            prior_runs = prior_crps.len(),
+            current_continuous_ranked_probability_score = drift.current_continuous_ranked_probability_score,
+            baseline_continuous_ranked_probability_score = drift.baseline_continuous_ranked_probability_score,
+            prior_runs = prior_continuous_ranked_probability_scores.len(),
             message = drift.message,
             "Drift check complete"
         ),
@@ -281,16 +284,18 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         "final_train_loss": losses.last().copied().unwrap_or_default(),
         "metrics": metrics,
         "train_samples": train_dataset.len(),
-        "validation_samples": valid_dataset.len(),
+        "validation_samples": validation_dataset.len(),
+        // `crps` keys are the published spelling and stay that way; see `EvaluationMetrics`. Renaming
+        // them would orphan every artifact already in the bucket.
         "drift": {
             "status": drift.status,
             "message": drift.message,
-            "baseline_crps": drift.baseline_crps,
-            "prior_runs": prior_crps.len(),
+            "baseline_crps": drift.baseline_continuous_ranked_probability_score,
+            "prior_runs": prior_continuous_ranked_probability_scores.len(),
         },
     });
     // Retried, because the model tarball is already published by this point. A folder holding a
-    // model and no metadata is skipped by `fetch_prior_crps`, so the run vanishes from the drift
+    // model and no metadata is skipped by `fetch_prior_continuous_ranked_probability_scores`, so the run vanishes from the drift
     // baseline for the next DRIFT_PRIOR_RUN_COUNT executions -- and with DRIFT_MINIMUM_RUNS at three,
     // repeated partial publishes suppress drift reporting entirely.
     let metadata_key = format!("{current_folder}run_metadata.json");
@@ -330,7 +335,9 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     println!("Training complete: artifact s3://{bucket}/{model_key}");
     println!(
         "Metrics: CRPS={:.6} directional_accuracy={:.4} quantile_coverage={:.4}",
-        metrics.crps, metrics.directional_accuracy, metrics.quantile_coverage
+        metrics.continuous_ranked_probability_score,
+        metrics.directional_accuracy,
+        metrics.quantile_coverage
     );
     Ok(())
 }
@@ -554,7 +561,7 @@ async fn load_archived_bars(
 /// baseline can be built without downloading every prior run. An unreadable run is skipped and the
 /// rest are kept; only an unlistable prefix yields nothing. Either way a drift baseline that cannot
 /// be read is not a reason to fail a training run.
-async fn fetch_prior_crps(
+async fn fetch_prior_continuous_ranked_probability_scores(
     s3_client: &aws_sdk_s3::Client,
     bucket: &str,
     prefix: &str,
@@ -569,9 +576,9 @@ async fn fetch_prior_crps(
         }
     };
 
-    let mut prior_crps = Vec::new();
+    let mut prior_continuous_ranked_probability_scores = Vec::new();
     for folder in candidate_folders_descending(folders) {
-        if prior_crps.len() >= run_count {
+        if prior_continuous_ranked_probability_scores.len() >= run_count {
             break;
         }
         if folder == current_folder {
@@ -592,11 +599,11 @@ async fn fetch_prior_crps(
         let Ok(metadata) = serde_json::from_slice::<serde_json::Value>(&bytes.into_bytes()) else {
             continue;
         };
-        if let Some(crps) = metadata["metrics"]["crps"].as_f64() {
-            prior_crps.push(crps);
+        if let Some(continuous_ranked_probability_score) = metadata["metrics"]["crps"].as_f64() {
+            prior_continuous_ranked_probability_scores.push(continuous_ranked_probability_score);
         }
     }
-    prior_crps
+    prior_continuous_ranked_probability_scores
 }
 
 #[cfg(test)]

--- a/src/bin/tide_model_trainer.rs
+++ b/src/bin/tide_model_trainer.rs
@@ -158,6 +158,15 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     if train_dataset.is_empty() {
         return Err("No training samples produced from the lookback window".into());
     }
+    // Failing here rather than training anyway, because every downstream consequence of an empty
+    // validation split is silent. Early stopping falls back to the training loss, `evaluate`
+    // short-circuits to `EvaluationMetrics::zero()`, and the metadata below publishes `crps: 0.0`
+    // -- the best score possible. That zero then sits in the drift baseline for
+    // DRIFT_PRIOR_RUN_COUNT runs, dragging down the mean every later run is measured against. A
+    // run that produced no validation data reads as a flawless one.
+    if validation_dataset.is_empty() {
+        return Err("No validation samples produced from the lookback window".into());
+    }
 
     let input_size = input_feature_size(INPUT_LENGTH, OUTPUT_LENGTH);
     let parameters = ModelParameters::new(input_size, INPUT_LENGTH, OUTPUT_LENGTH);

--- a/src/models/tide/artifact.rs
+++ b/src/models/tide/artifact.rs
@@ -182,11 +182,11 @@ pub async fn list_run_folders(
         .into_paginator()
         .send();
     while let Some(page) = pages.next().await {
-        let page = page.map_err(|e| ArtifactError::S3(e.to_string()))?;
+        let page = page.map_err(|error| ArtifactError::S3(error.to_string()))?;
         folders.extend(
             page.common_prefixes()
                 .iter()
-                .filter_map(|p| p.prefix().map(String::from)),
+                .filter_map(|prefix| prefix.prefix().map(String::from)),
         );
     }
     Ok(folders)
@@ -256,9 +256,9 @@ fn resolve_local_artifact_key(
 
     let mut entries: Vec<PathBuf> = std::fs::read_dir(local_dir)
         .map_err(|_| ArtifactError::NoArtifacts)?
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| p.is_dir())
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.is_dir())
         .collect();
 
     entries.sort();
@@ -320,13 +320,13 @@ pub async fn download_and_load_model(
         .key(key)
         .send()
         .await
-        .map_err(|e| ArtifactError::S3(e.to_string()))?;
+        .map_err(|error| ArtifactError::S3(error.to_string()))?;
 
     let bytes = response
         .body
         .collect()
         .await
-        .map_err(|e| ArtifactError::S3(e.to_string()))?
+        .map_err(|error| ArtifactError::S3(error.to_string()))?
         .into_bytes();
 
     let tmp_file = extract_path.join("model.tar.gz");
@@ -336,7 +336,7 @@ pub async fn download_and_load_model(
     load_model_from_directory(extract_path, key)
 }
 
-fn extract_tar_gz(tar_path: &Path, dest: &Path) -> Result<(), ArtifactError> {
+fn extract_tar_gz(tar_path: &Path, destination: &Path) -> Result<(), ArtifactError> {
     let file = std::fs::File::open(tar_path)?;
     let decoder = flate2::read::GzDecoder::new(file);
     let mut archive = tar::Archive::new(decoder);
@@ -362,14 +362,14 @@ fn extract_tar_gz(tar_path: &Path, dest: &Path) -> Result<(), ArtifactError> {
             continue;
         }
 
-        let dest_path = dest.join(&path);
+        let destination_path = destination.join(&path);
         if entry.header().entry_type().is_dir() {
-            std::fs::create_dir_all(&dest_path)?;
+            std::fs::create_dir_all(&destination_path)?;
         } else {
-            if let Some(parent) = dest_path.parent() {
+            if let Some(parent) = destination_path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            let mut output = std::fs::File::create(&dest_path)?;
+            let mut output = std::fs::File::create(&destination_path)?;
             std::io::copy(&mut entry, &mut output)?;
         }
     }
@@ -380,18 +380,18 @@ fn extract_tar_gz(tar_path: &Path, dest: &Path) -> Result<(), ArtifactError> {
 fn load_model_from_directory(dir: &Path, artifact_key: &str) -> Result<ModelState, ArtifactError> {
     let parameters_path = dir.join("tide_parameters.json");
     let parameters = crate::models::tide::configuration::ModelParameters::load(&parameters_path)
-        .map_err(|e| ArtifactError::ModelLoad(e.to_string()))?;
+        .map_err(|error| ArtifactError::ModelLoad(error.to_string()))?;
 
     let scaler_path = dir.join("tide_data_scaler.json");
     let scaler = crate::models::tide::data::Scaler::load(&scaler_path)
-        .map_err(|e| ArtifactError::ModelLoad(e.to_string()))?;
+        .map_err(|error| ArtifactError::ModelLoad(error.to_string()))?;
 
     let mappings_path = dir.join("tide_data_mappings.json");
     let mappings_content = std::fs::read_to_string(&mappings_path)
-        .map_err(|e| ArtifactError::ModelLoad(e.to_string()))?;
+        .map_err(|error| ArtifactError::ModelLoad(error.to_string()))?;
     let mappings: crate::models::tide::data::FeatureMappings =
         serde_json::from_str(&mappings_content)
-            .map_err(|e| ArtifactError::ModelLoad(e.to_string()))?;
+            .map_err(|error| ArtifactError::ModelLoad(error.to_string()))?;
 
     let quantile_count = parameters.quantiles().len();
     let model = crate::models::tide::model::TiDEModel::load(
@@ -404,7 +404,7 @@ fn load_model_from_directory(dir: &Path, artifact_key: &str) -> Result<ModelStat
         quantile_count,
         parameters.dropout_rate(),
     )
-    .map_err(|e| ArtifactError::ModelLoad(e.to_string()))?;
+    .map_err(|error| ArtifactError::ModelLoad(error.to_string()))?;
 
     let load_timestamp = Utc::now().timestamp();
 
@@ -481,7 +481,7 @@ pub async fn upload_artifact(
         .content_type(content_type)
         .send()
         .await
-        .map_err(|e| ArtifactWriteError::S3(e.to_string()))?;
+        .map_err(|error| ArtifactWriteError::S3(error.to_string()))?;
     Ok(())
 }
 
@@ -830,11 +830,11 @@ mod tests {
 
     #[test]
     fn test_package_dir_to_tar_gz_is_flat_and_readable() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("tide_parameters.json"), b"{}").unwrap();
-        std::fs::write(dir.path().join("tide_states.mpk"), b"weights").unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(directory.path().join("tide_parameters.json"), b"{}").unwrap();
+        std::fs::write(directory.path().join("tide_states.mpk"), b"weights").unwrap();
 
-        let bytes = package_dir_to_tar_gz(dir.path()).unwrap();
+        let bytes = package_dir_to_tar_gz(directory.path()).unwrap();
 
         let decoder = flate2::read::GzDecoder::new(bytes.as_slice());
         let mut archive = tar::Archive::new(decoder);

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -302,11 +302,17 @@ impl Data {
             data,
             scaler,
             mappings,
-            continuous_columns: CONTINUOUS_COLUMNS.iter().map(|s| s.to_string()).collect(),
-            categorical_columns: CATEGORICAL_COLUMNS.iter().map(|s| s.to_string()).collect(),
+            continuous_columns: CONTINUOUS_COLUMNS
+                .iter()
+                .map(|name| name.to_string())
+                .collect(),
+            categorical_columns: CATEGORICAL_COLUMNS
+                .iter()
+                .map(|name| name.to_string())
+                .collect(),
             static_categorical_columns: STATIC_CATEGORICAL_COLUMNS
                 .iter()
-                .map(|s| s.to_string())
+                .map(|name| name.to_string())
                 .collect(),
         }
     }
@@ -338,18 +344,27 @@ impl Data {
         training_fraction: TrainingFraction,
     ) -> Result<(DataFrame, DataFrame), Box<dyn std::error::Error>> {
         let training_fraction = training_fraction.fraction();
-        let timestamps = self.data.column("timestamp").map_err(|e| e.to_string())?;
-        let timestamps = timestamps.i64().map_err(|e| e.to_string())?;
+        let timestamps = self
+            .data
+            .column("timestamp")
+            .map_err(|error| error.to_string())?;
+        let timestamps = timestamps.i64().map_err(|error| error.to_string())?;
         let minimum_timestamp = timestamps.min().unwrap_or(0);
         let maximum_timestamp = timestamps.max().unwrap_or(0);
         let cutoff = minimum_timestamp
             + (((maximum_timestamp - minimum_timestamp) as f64) * training_fraction) as i64;
 
         let train_mask = timestamps.lt_eq(cutoff);
-        let valid_mask = timestamps.gt(cutoff);
-        let train = self.data.filter(&train_mask).map_err(|e| e.to_string())?;
-        let valid = self.data.filter(&valid_mask).map_err(|e| e.to_string())?;
-        Ok((train, valid))
+        let validation_mask = timestamps.gt(cutoff);
+        let train = self
+            .data
+            .filter(&train_mask)
+            .map_err(|error| error.to_string())?;
+        let validation = self
+            .data
+            .filter(&validation_mask)
+            .map_err(|error| error.to_string())?;
+        Ok((train, validation))
     }
 
     /// Build a windowed dataset.
@@ -364,8 +379,8 @@ impl Data {
                 window_frame(&self.data, input_length, output_length, true, false)
             }
             DatasetKind::Validate(training_fraction) => {
-                let (_, valid) = self.split_by_timestamp(training_fraction)?;
-                window_frame(&valid, input_length, output_length, false, true)
+                let (_, validation) = self.split_by_timestamp(training_fraction)?;
+                window_frame(&validation, input_length, output_length, false, true)
             }
             DatasetKind::Train(training_fraction) => {
                 let (train, _) = self.split_by_timestamp(training_fraction)?;
@@ -399,9 +414,9 @@ fn window_frame(
     // the encoded id; sorted for deterministic sample ordering.
     let mut tickers: Vec<i32> = frame
         .column("ticker")
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .i32()
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .into_no_null_iter()
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
@@ -417,11 +432,11 @@ fn window_frame(
     for ticker in &tickers {
         let mask = frame
             .column("ticker")
-            .map_err(|e| e.to_string())?
+            .map_err(|error| error.to_string())?
             .i32()
-            .map_err(|e| e.to_string())?
+            .map_err(|error| error.to_string())?
             .equal(*ticker);
-        let ticker_data = frame.filter(&mask).map_err(|e| e.to_string())?;
+        let ticker_data = frame.filter(&mask).map_err(|error| error.to_string())?;
 
         if ticker_data.height() < window_size {
             continue;
@@ -568,20 +583,20 @@ pub(crate) fn append_forecast_session_rows(
             ["ticker", "timestamp"],
             SortMultipleOptions::default().with_maintain_order(true),
         )
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
 
     let tickers: Vec<&str> = sorted
         .column("ticker")
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .str()
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .into_no_null_iter()
         .collect();
     let timestamps: Vec<i64> = sorted
         .column("timestamp")
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .i64()
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .into_no_null_iter()
         .collect();
 
@@ -607,18 +622,20 @@ pub(crate) fn append_forecast_session_rows(
     }
 
     let source_index = IdxCa::from_vec("index".into(), source_rows);
-    let mut forecast_rows = sorted.take(&source_index).map_err(|e| e.to_string())?;
+    let mut forecast_rows = sorted
+        .take(&source_index)
+        .map_err(|error| error.to_string())?;
     forecast_rows
         .with_column(Column::new(
             "timestamp".into(),
             vec![target_milliseconds; forecast_rows.height()],
         ))
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
 
     let mut combined = sorted;
     combined
         .vstack_mut(&forecast_rows)
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
     Ok(combined)
 }
 
@@ -631,9 +648,11 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn st
             ["ticker", "timestamp"],
             SortMultipleOptions::default().with_maintain_order(true),
         )
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
 
-    let timestamps = data.column("timestamp").map_err(|e| e.to_string())?;
+    let timestamps = data
+        .column("timestamp")
+        .map_err(|error| error.to_string())?;
     let height = data.height();
 
     let mut day_of_week = Vec::with_capacity(height);
@@ -645,24 +664,24 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn st
 
     let close_prices: Vec<f64> = data
         .column("close_price")
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .f64()
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .into_no_null_iter()
         .collect();
 
     let tickers: Vec<String> = data
         .column("ticker")
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .str()
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .into_no_null_iter()
-        .map(|s| s.to_string())
+        .map(|name| name.to_string())
         .collect();
 
     let timestamp_values: Vec<i64> = timestamps
         .i64()
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .into_no_null_iter()
         .collect();
 
@@ -710,22 +729,22 @@ pub(crate) fn engineer_features(data: DataFrame) -> Result<DataFrame, Box<dyn st
     let mut new_data = data.clone();
     new_data
         .with_column(Column::new("day_of_week".into(), day_of_week))
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
     new_data
         .with_column(Column::new("day_of_month".into(), day_of_month))
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
     new_data
         .with_column(Column::new("day_of_year".into(), day_of_year))
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
     new_data
         .with_column(Column::new("month".into(), month))
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
     new_data
         .with_column(Column::new("year".into(), year))
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
     new_data
         .with_column(Column::new("daily_return".into(), daily_return))
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
 
     Ok(new_data)
 }
@@ -736,9 +755,9 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
     // `engineer_features` does rather than encoding one and filtering it back out.
     let tickers = data
         .column("ticker")
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .str()
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
     if tickers.null_count() > 0 {
         return Err(format!(
             "Equity bars contain {} null ticker values out of {} rows",
@@ -756,28 +775,28 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
 
     let sector_upper: Vec<String> = data
         .column("sector")
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .str()
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .into_iter()
         .map(|value| value.unwrap_or(UNKNOWN_SECTOR_OR_INDUSTRY).to_uppercase())
         .collect();
 
     let industry_upper: Vec<String> = data
         .column("industry")
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .str()
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .into_iter()
         .map(|value| value.unwrap_or(UNKNOWN_SECTOR_OR_INDUSTRY).to_uppercase())
         .collect();
 
     data.with_column(Column::new("ticker".into(), ticker_upper))
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
     data.with_column(Column::new("sector".into(), sector_upper))
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
     data.with_column(Column::new("industry".into(), industry_upper))
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
 
     let cleaned = data;
 
@@ -789,10 +808,10 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
     for column in CONTINUOUS_COLUMNS {
         let values = cleaned
             .column(column)
-            .map_err(|e| e.to_string())?
+            .map_err(|error| error.to_string())?
             .cast(&DataType::Float64)
-            .map_err(|e| e.to_string())?;
-        let values = values.f64().map_err(|e| e.to_string())?;
+            .map_err(|error| error.to_string())?;
+        let values = values.f64().map_err(|error| error.to_string())?;
         for (index, value) in values.into_iter().enumerate() {
             if !value.is_some_and(f64::is_finite) {
                 keep_row[index] = false;
@@ -800,7 +819,9 @@ pub(crate) fn clean_data(mut data: DataFrame) -> Result<DataFrame, Box<dyn std::
         }
     }
     let finite_mask: BooleanChunked = keep_row.into_iter().collect();
-    let cleaned = cleaned.filter(&finite_mask).map_err(|e| e.to_string())?;
+    let cleaned = cleaned
+        .filter(&finite_mask)
+        .map_err(|error| error.to_string())?;
     Ok(cleaned)
 }
 
@@ -820,18 +841,18 @@ pub(crate) fn apply_scaling(
 
         let values: Vec<f32> = result
             .column(column_name)
-            .map_err(|e| e.to_string())?
+            .map_err(|error| error.to_string())?
             .cast(&DataType::Float64)
-            .map_err(|e| e.to_string())?
+            .map_err(|error| error.to_string())?
             .f64()
-            .map_err(|e| e.to_string())?
+            .map_err(|error| error.to_string())?
             .into_no_null_iter()
             .map(|value| ((value - mean) / standard_deviation) as f32)
             .collect();
 
         result
             .with_column(Column::new((*column_name).into(), values))
-            .map_err(|e| e.to_string())?;
+            .map_err(|error| error.to_string())?;
     }
     Ok(result)
 }
@@ -852,20 +873,21 @@ pub(crate) fn encode_categoricals(
         if let Some(mapping) = mappings.get(column_name) {
             let values: Vec<Option<i32>> = result
                 .column(column_name)
-                .map_err(|e| e.to_string())?
+                .map_err(|error| error.to_string())?
                 .str()
-                .map(|ca| {
-                    ca.into_iter()
-                        .map(|opt_val| opt_val.and_then(|val| mapping.get(val).copied()))
+                .map(|chunked| {
+                    chunked
+                        .into_iter()
+                        .map(|value| value.and_then(|text| mapping.get(text).copied()))
                         .collect()
                 })
                 .or_else(|_| {
                     result
                         .column(column_name)
-                        .map_err(|e| e.to_string())?
+                        .map_err(|error| error.to_string())?
                         .i32()
-                        .map(|ca| ca.into_iter().collect())
-                        .map_err(|e| e.to_string())
+                        .map(|chunked| chunked.into_iter().collect())
+                        .map_err(|error| error.to_string())
                 })?;
 
             // A sentinel merges every unmapped value into one id. For the static columns that
@@ -881,13 +903,16 @@ pub(crate) fn encode_categoricals(
             let is_static = STATIC_CATEGORICAL_COLUMNS.contains(&column_name);
             let unmapped = values.iter().filter(|value| value.is_none()).count();
             let keep: BooleanChunked = values.iter().map(|value| value.is_some()).collect();
-            let encoded: Vec<i32> = values.into_iter().map(|v| v.unwrap_or(-1)).collect();
+            let encoded: Vec<i32> = values
+                .into_iter()
+                .map(|value| value.unwrap_or(-1))
+                .collect();
             result
                 .with_column(Column::new(column_name.into(), encoded))
-                .map_err(|e| e.to_string())?;
+                .map_err(|error| error.to_string())?;
 
             if is_static && unmapped > 0 {
-                result = result.filter(&keep).map_err(|e| e.to_string())?;
+                result = result.filter(&keep).map_err(|error| error.to_string())?;
                 tracing::warn!(
                     column = column_name,
                     dropped_rows = unmapped,
@@ -938,13 +963,13 @@ fn get_float_columns(
     for column_name in columns {
         let cast = data
             .column(column_name)
-            .map_err(|e| e.to_string())?
+            .map_err(|error| error.to_string())?
             .cast(&DataType::Float32)
-            .map_err(|e| e.to_string())?;
+            .map_err(|error| error.to_string())?;
         reject_null_column(&cast, column_name)?;
         let values: Vec<f32> = cast
             .f32()
-            .map_err(|e| e.to_string())?
+            .map_err(|error| error.to_string())?
             .into_no_null_iter()
             .collect();
         result.push(values);
@@ -960,13 +985,13 @@ fn get_int_columns(
     for column_name in columns {
         let cast = data
             .column(column_name)
-            .map_err(|e| e.to_string())?
+            .map_err(|error| error.to_string())?
             .cast(&DataType::Int32)
-            .map_err(|e| e.to_string())?;
+            .map_err(|error| error.to_string())?;
         reject_null_column(&cast, column_name)?;
         let values: Vec<i32> = cast
             .i32()
-            .map_err(|e| e.to_string())?
+            .map_err(|error| error.to_string())?
             .into_no_null_iter()
             .collect();
         result.push(values);
@@ -1398,7 +1423,9 @@ mod tests {
             .unwrap()
             .into_no_null_iter()
             .collect();
-        assert!(returns.iter().all(|r| (r - 0.1).abs() < 1e-6));
+        assert!(returns
+            .iter()
+            .all(|daily_return| (daily_return - 0.1).abs() < 1e-6));
     }
 
     #[test]
@@ -1432,7 +1459,9 @@ mod tests {
                 .into_no_null_iter()
                 .collect();
             assert!(
-                values.iter().all(|v| *v == crate::data::details::UNKNOWN),
+                values
+                    .iter()
+                    .all(|value| *value == crate::data::details::UNKNOWN),
                 "{column} fell back to {values:?} instead of the schema default"
             );
         }
@@ -1447,9 +1476,9 @@ mod tests {
         let mut ticker = Vec::with_capacity(total);
         let mut timestamp = Vec::with_capacity(total);
         let mut close = Vec::with_capacity(total);
-        for index in 0..ticker_count {
+        for name in names.iter().take(ticker_count) {
             for row in 0..rows_per_ticker {
-                ticker.push(names[index]);
+                ticker.push(*name);
                 let date =
                     SessionDate::from_date(chrono::NaiveDate::from_ymd_opt(2026, 6, 1).unwrap())
                         .plus_calendar_days(row as i64);

--- a/src/models/tide/data.rs
+++ b/src/models/tide/data.rs
@@ -1340,6 +1340,40 @@ mod tests {
         assert!(TrainingFraction::new(0.8).is_ok());
     }
 
+    /// A validation split can yield no windows at all while the training split yields plenty, and
+    /// nothing in this module treats that as an error — `window_frame` just returns an empty
+    /// dataset.
+    ///
+    /// This is the condition `bin/tide_model_trainer.rs` refuses before training, and it pins why
+    /// that guard has to exist. Downstream, an empty validation set is silent in three places at
+    /// once: early stopping falls back to the training loss, [`crate::models::tide::evaluate`]
+    /// short-circuits to zeroed metrics, and the trainer publishes `crps: 0.0` — the best score
+    /// achievable — into the drift baseline that every later run is measured against.
+    ///
+    /// The guard itself is not exercised here; it lives in `run()`, which fetches from S3.
+    #[test]
+    fn test_a_validation_split_can_produce_no_windows_while_training_produces_many() {
+        // 11 rows split at 0.8 leaves 2 validation rows, and a window needs input + output = 4.
+        let data = empty_data(make_encoded_frame(1, 11));
+
+        let training = data
+            .get_dataset(DatasetKind::Train(fraction_of(0.8)), 3, 1)
+            .unwrap();
+        let validation = data
+            .get_dataset(DatasetKind::Validate(fraction_of(0.8)), 3, 1)
+            .unwrap();
+
+        assert!(
+            !training.is_empty(),
+            "the training split must produce windows, or this proves nothing"
+        );
+        assert!(
+            validation.is_empty(),
+            "expected no validation windows from 2 rows, got {}",
+            validation.len()
+        );
+    }
+
     /// The predict variant carries no split, so inference cannot pass one that does nothing — which
     /// is what the `0.8` at the old predict call site was. This is a compile-time property; the
     /// assertion here records that predicting reads the whole frame rather than a split of it.

--- a/src/models/tide/drift.rs
+++ b/src/models/tide/drift.rs
@@ -16,66 +16,76 @@ pub enum DriftStatus {
 pub struct DriftResult {
     pub status: DriftStatus,
     pub message: String,
-    pub current_crps: f64,
-    pub baseline_crps: Option<f64>,
+    pub current_continuous_ranked_probability_score: f64,
+    pub baseline_continuous_ranked_probability_score: Option<f64>,
 }
 
-/// Check whether `current_crps` has degraded relative to the mean of
-/// `prior_crps` by more than `degradation_threshold` (a fraction, e.g. 0.20).
+/// Check whether `current_continuous_ranked_probability_score` has degraded relative to the mean of
+/// `prior_continuous_ranked_probability_scores` by more than `degradation_threshold` (a fraction, e.g. 0.20).
 /// Fewer than `minimum_runs` prior values yields `InsufficientHistory`; the
 /// baseline is floored at 1e-8 so a near-zero history cannot flag noise.
 pub fn check_drift(
-    current_crps: f64,
-    prior_crps: &[f64],
+    current_continuous_ranked_probability_score: f64,
+    prior_continuous_ranked_probability_scores: &[f64],
     minimum_runs: usize,
     degradation_threshold: f64,
 ) -> DriftResult {
     // The emptiness check is separate from the `minimum_runs` check on purpose. With
     // `minimum_runs` of 0 the comparison below is false for an empty slice, so the function would
-    // continue and divide by zero: `baseline_crps` becomes NaN, `NaN.max(1e-8)` collapses the limit
+    // continue and divide by zero: `baseline_continuous_ranked_probability_score` becomes NaN, `NaN.max(1e-8)` collapses the limit
     // to the floor so almost any current value reports drift, and the NaN then fails JSON
     // serialization at the call site.
-    if prior_crps.is_empty() || prior_crps.len() < minimum_runs {
+    if prior_continuous_ranked_probability_scores.is_empty()
+        || prior_continuous_ranked_probability_scores.len() < minimum_runs
+    {
         let message = format!(
             "Insufficient evaluation history: {} run(s) recorded, {} required for baseline.",
-            prior_crps.len(),
+            prior_continuous_ranked_probability_scores.len(),
             minimum_runs
         );
         return DriftResult {
             status: DriftStatus::InsufficientHistory,
             message,
-            current_crps,
-            baseline_crps: None,
+            current_continuous_ranked_probability_score,
+            baseline_continuous_ranked_probability_score: None,
         };
     }
 
-    let baseline_crps = prior_crps.iter().sum::<f64>() / prior_crps.len() as f64;
-    let degradation_limit = baseline_crps.max(1e-8) * (1.0 + degradation_threshold);
+    let baseline_continuous_ranked_probability_score = prior_continuous_ranked_probability_scores
+        .iter()
+        .sum::<f64>()
+        / prior_continuous_ranked_probability_scores.len() as f64;
+    let degradation_limit =
+        baseline_continuous_ranked_probability_score.max(1e-8) * (1.0 + degradation_threshold);
 
-    if current_crps > degradation_limit {
+    if current_continuous_ranked_probability_score > degradation_limit {
         let message = format!(
-            "Drift detected: current CRPS {current_crps:.6} exceeds baseline \
-             {baseline_crps:.6} by more than {:.0}%.",
+            "Drift detected: current CRPS {current_continuous_ranked_probability_score:.6} exceeds baseline \
+             {baseline_continuous_ranked_probability_score:.6} by more than {:.0}%.",
             degradation_threshold * 100.0
         );
         return DriftResult {
             status: DriftStatus::DriftDetected,
             message,
-            current_crps,
-            baseline_crps: Some(baseline_crps),
+            current_continuous_ranked_probability_score,
+            baseline_continuous_ranked_probability_score: Some(
+                baseline_continuous_ranked_probability_score,
+            ),
         };
     }
 
     let message = format!(
-        "No drift detected: current CRPS {current_crps:.6} is within {:.0}% of \
-         baseline {baseline_crps:.6}.",
+        "No drift detected: current CRPS {current_continuous_ranked_probability_score:.6} is within {:.0}% of \
+         baseline {baseline_continuous_ranked_probability_score:.6}.",
         degradation_threshold * 100.0
     );
     DriftResult {
         status: DriftStatus::NoDrift,
         message,
-        current_crps,
-        baseline_crps: Some(baseline_crps),
+        current_continuous_ranked_probability_score,
+        baseline_continuous_ranked_probability_score: Some(
+            baseline_continuous_ranked_probability_score,
+        ),
     }
 }
 
@@ -90,15 +100,15 @@ mod tests {
     fn test_empty_history_is_insufficient_regardless_of_minimum_runs() {
         let result = check_drift(0.5, &[], 0, 0.2);
         assert_eq!(result.status, DriftStatus::InsufficientHistory);
-        assert_eq!(result.baseline_crps, None);
+        assert_eq!(result.baseline_continuous_ranked_probability_score, None);
     }
 
     #[test]
     fn test_insufficient_history_below_minimum_runs() {
         let result = check_drift(0.5, &[0.3, 0.3], 3, 0.20);
         assert_eq!(result.status, DriftStatus::InsufficientHistory);
-        assert_eq!(result.baseline_crps, None);
-        assert_eq!(result.current_crps, 0.5);
+        assert_eq!(result.baseline_continuous_ranked_probability_score, None);
+        assert_eq!(result.current_continuous_ranked_probability_score, 0.5);
     }
 
     #[test]
@@ -107,14 +117,20 @@ mod tests {
         // exactly at the limit is not drift.
         let result = check_drift(0.36, &[0.3, 0.3, 0.3], 3, 0.20);
         assert_eq!(result.status, DriftStatus::NoDrift);
-        assert_eq!(result.baseline_crps, Some(0.3));
+        assert_eq!(
+            result.baseline_continuous_ranked_probability_score,
+            Some(0.3)
+        );
     }
 
     #[test]
     fn test_drift_detected_just_over_limit() {
         let result = check_drift(0.361, &[0.3, 0.3, 0.3], 3, 0.20);
         assert_eq!(result.status, DriftStatus::DriftDetected);
-        assert_eq!(result.baseline_crps, Some(0.3));
+        assert_eq!(
+            result.baseline_continuous_ranked_probability_score,
+            Some(0.3)
+        );
         assert!(result.message.contains("Drift detected"));
     }
 
@@ -123,7 +139,7 @@ mod tests {
         // mean(0.2, 0.3, 0.4) = 0.3 -> limit 0.36.
         let result = check_drift(0.35, &[0.2, 0.3, 0.4], 3, 0.20);
         assert_eq!(result.status, DriftStatus::NoDrift);
-        assert!((result.baseline_crps.unwrap() - 0.3).abs() < 1e-12);
+        assert!((result.baseline_continuous_ranked_probability_score.unwrap() - 0.3).abs() < 1e-12);
     }
 
     #[test]

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -11,19 +11,27 @@ use crate::models::tide::configuration::ModelParameters;
 use crate::models::tide::data::TrainingDataset;
 use crate::models::tide::model::TiDEModel;
 
-const EVAL_BATCH: usize = 4096;
+const EVALUATION_BATCH_SIZE: usize = 4096;
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
-pub struct EvalMetrics {
-    pub crps: f64,
+pub struct EvaluationMetrics {
+    /// Serialized as `crps`, deliberately, even though the field is spelled out.
+    ///
+    /// This value is written into each run's `run_metadata.json` in S3 and read back out of
+    /// *previous* runs' metadata by the trainer's drift check. Every artifact already published
+    /// spells the key `crps`, so renaming it would make the drift baseline read `None` for every
+    /// historical run — and with `DRIFT_MINIMUM_RUNS` at three, that suppresses drift reporting
+    /// entirely until three new runs accumulate, silently.
+    #[serde(rename = "crps")]
+    pub continuous_ranked_probability_score: f64,
     pub directional_accuracy: f64,
     pub quantile_coverage: f64,
 }
 
-impl EvalMetrics {
+impl EvaluationMetrics {
     fn zero() -> Self {
         Self {
-            crps: 0.0,
+            continuous_ranked_probability_score: 0.0,
             directional_accuracy: 0.0,
             quantile_coverage: 0.0,
         }
@@ -91,13 +99,13 @@ impl MetricAccumulator {
     }
 
     /// Averages the totals over the rows added, or returns zeros when none were.
-    fn finish(self) -> EvalMetrics {
+    fn finish(self) -> EvaluationMetrics {
         if self.row_count == 0 {
-            return EvalMetrics::zero();
+            return EvaluationMetrics::zero();
         }
         let rows = self.row_count as f64;
-        EvalMetrics {
-            crps: self.pinball_sum / rows,
+        EvaluationMetrics {
+            continuous_ranked_probability_score: self.pinball_sum / rows,
             directional_accuracy: self.directional_matches as f64 / rows,
             quantile_coverage: self.covered as f64 / rows,
         }
@@ -110,18 +118,18 @@ pub fn evaluate(
     model: &TiDEModel<NdArray>,
     dataset: &TrainingDataset,
     parameters: &ModelParameters,
-) -> Result<EvalMetrics, Box<dyn std::error::Error>> {
+) -> Result<EvaluationMetrics, Box<dyn std::error::Error>> {
     let sample_count = dataset.len();
     let targets = match dataset.targets.as_ref() {
         Some(targets) if sample_count > 0 => targets,
-        _ => return Ok(EvalMetrics::zero()),
+        _ => return Ok(EvaluationMetrics::zero()),
     };
 
     let output_length = parameters.output_length();
     let quantiles = parameters.quantiles();
     let quantile_count = quantiles.len();
     if quantile_count == 0 {
-        return Ok(EvalMetrics::zero());
+        return Ok(EvaluationMetrics::zero());
     }
 
     crate::models::tide::batch::validate_input_shape(dataset, parameters)?;
@@ -132,7 +140,7 @@ pub fn evaluate(
     let mut predictions: Vec<f32> =
         Vec::with_capacity(sample_count * output_length * quantile_count);
     let sample_indices: Vec<usize> = (0..sample_count).collect();
-    for chunk in sample_indices.chunks(EVAL_BATCH) {
+    for chunk in sample_indices.chunks(EVALUATION_BATCH_SIZE) {
         let input = build_input_tensor::<NdArray>(
             dataset,
             chunk,
@@ -141,7 +149,10 @@ pub fn evaluate(
             &device,
         );
         let output = model.forward(input);
-        let mut values: Vec<f32> = output.to_data().to_vec().map_err(|e| format!("{e:?}"))?;
+        let mut values: Vec<f32> = output
+            .to_data()
+            .to_vec()
+            .map_err(|error| format!("{error:?}"))?;
         predictions.append(&mut values);
     }
 
@@ -223,6 +234,33 @@ mod tests {
     use crate::models::tide::data::TrainingDataset;
     use crate::models::tide::model::TiDEModel;
 
+    /// The serialized key is the contract with every artifact already in the bucket, and the Rust
+    /// field name no longer matches it. Nothing else would notice if the `serde(rename)` were
+    /// dropped: the trainer would keep writing metadata, the drift check would keep reading
+    /// `metrics.crps`, and it would find nothing there — reporting `InsufficientHistory` rather
+    /// than an error, which is indistinguishable from a genuinely young bucket.
+    #[test]
+    fn test_metrics_serialize_under_the_published_crps_key() {
+        let metrics = EvaluationMetrics {
+            continuous_ranked_probability_score: 0.25,
+            directional_accuracy: 0.5,
+            quantile_coverage: 0.8,
+        };
+        let serialized = serde_json::to_value(metrics).expect("metrics must serialize");
+
+        assert_eq!(
+            serialized["crps"].as_f64(),
+            Some(0.25),
+            "the drift check reads `metrics.crps`; got {serialized}"
+        );
+        assert!(
+            serialized
+                .get("continuous_ranked_probability_score")
+                .is_none(),
+            "the spelled-out name must not reach the artifact metadata"
+        );
+    }
+
     // ---------------------------------------------------------------------------
     // argmin / argmax / closest_to
     // ---------------------------------------------------------------------------
@@ -280,13 +318,13 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------------
-    // EvalMetrics::zero
+    // EvaluationMetrics::zero
     // ---------------------------------------------------------------------------
 
     #[test]
     fn test_eval_metrics_zero_fields_are_zero() {
-        let metrics = EvalMetrics::zero();
-        assert_eq!(metrics.crps, 0.0);
+        let metrics = EvaluationMetrics::zero();
+        assert_eq!(metrics.continuous_ranked_probability_score, 0.0);
         assert_eq!(metrics.directional_accuracy, 0.0);
         assert_eq!(metrics.quantile_coverage, 0.0);
     }
@@ -307,7 +345,11 @@ mod tests {
     /// short, divide by a smaller row count, and produce a plausible number for a table nobody
     /// wrote — the failure this whole change exists to remove, reintroduced in the fixture instead
     /// of the code.
-    fn metrics_from(predictions: &[[f64; 3]], targets: &[f64], quantiles: &[f64]) -> EvalMetrics {
+    fn metrics_from(
+        predictions: &[[f64; 3]],
+        targets: &[f64],
+        quantiles: &[f64],
+    ) -> EvaluationMetrics {
         assert_eq!(
             predictions.len(),
             targets.len(),
@@ -351,35 +393,50 @@ mod tests {
         assert_eq!(shuffled.quantile_coverage, sorted.quantile_coverage);
         assert_eq!(shuffled.directional_accuracy, sorted.directional_accuracy);
         assert!(
-            (shuffled.crps - sorted.crps).abs() < 1e-9,
+            (shuffled.continuous_ranked_probability_score
+                - sorted.continuous_ranked_probability_score)
+                .abs()
+                < 1e-9,
             "pinball loss pairs each quantile with its own prediction: {} vs {}",
-            shuffled.crps,
-            sorted.crps
+            shuffled.continuous_ranked_probability_score,
+            sorted.continuous_ranked_probability_score
         );
     }
 
     #[test]
     fn test_continuous_ranked_probability_score_positive_error_branch() {
         // target=1.0, all predictions=0.0; error=1.0 >= 0 for every quantile.
-        // row_loss = 0.1*1 + 0.5*1 + 0.9*1 = 1.5; single row so crps=1.5.
+        // row_loss = 0.1*1 + 0.5*1 + 0.9*1 = 1.5; single row so continuous_ranked_probability_score=1.5.
         let metrics = metrics_from(&[[0.0, 0.0, 0.0]], &[1.0], &[0.1, 0.5, 0.9]);
-        assert!((metrics.crps - 1.5).abs() < 1e-9, "crps={}", metrics.crps);
+        assert!(
+            (metrics.continuous_ranked_probability_score - 1.5).abs() < 1e-9,
+            "crps={}",
+            metrics.continuous_ranked_probability_score
+        );
     }
 
     #[test]
     fn test_continuous_ranked_probability_score_negative_error_branch() {
         // target=-1.0, all predictions=0.0; error=-1.0 < 0 for every quantile.
         // pinball = (q-1)*error: (0.1-1)*(-1)=0.9, (0.5-1)*(-1)=0.5, (0.9-1)*(-1)=0.1
-        // row_loss = 1.5; single row so crps=1.5.
+        // row_loss = 1.5; single row so continuous_ranked_probability_score=1.5.
         let metrics = metrics_from(&[[0.0, 0.0, 0.0]], &[-1.0], &[0.1, 0.5, 0.9]);
-        assert!((metrics.crps - 1.5).abs() < 1e-9, "crps={}", metrics.crps);
+        assert!(
+            (metrics.continuous_ranked_probability_score - 1.5).abs() < 1e-9,
+            "crps={}",
+            metrics.continuous_ranked_probability_score
+        );
     }
 
     #[test]
     fn test_continuous_ranked_probability_score_exact_prediction_is_zero() {
-        // When every prediction equals the target, error=0 so crps=0.
+        // When every prediction equals the target, error=0 so continuous_ranked_probability_score=0.
         let metrics = metrics_from(&[[0.3, 0.3, 0.3]], &[0.3], &[0.1, 0.5, 0.9]);
-        assert!((metrics.crps).abs() < 1e-9, "crps={}", metrics.crps);
+        assert!(
+            (metrics.continuous_ranked_probability_score).abs() < 1e-9,
+            "crps={}",
+            metrics.continuous_ranked_probability_score
+        );
     }
 
     #[test]
@@ -441,18 +498,18 @@ mod tests {
     /// `input_length` and `output_length` so `build_input_tensor` does not
     /// panic, using the tiny 32-input-feature model defined below.
     ///
-    /// input_size = input_length*n_cont + input_length*n_cat + output_length*n_cat + n_static
+    /// input_size = input_length*continuous + input_length*categorical + output_length*categorical + static_categorical
     ///            = 2*7 + 2*5 + 1*5 + 3 = 32
-    fn make_tiny_dataset(num_samples: usize, with_targets: bool) -> TrainingDataset {
+    fn make_tiny_dataset(sample_count: usize, with_targets: bool) -> TrainingDataset {
         let input_length = 2_usize;
         let output_length = 1_usize;
         TrainingDataset {
-            past_continuous: ndarray::Array3::zeros((num_samples, input_length, 7)),
-            past_categorical: ndarray::Array3::zeros((num_samples, input_length, 5)),
-            future_categorical: ndarray::Array3::zeros((num_samples, output_length, 5)),
-            static_categorical: ndarray::Array3::zeros((num_samples, 1, 3)),
+            past_continuous: ndarray::Array3::zeros((sample_count, input_length, 7)),
+            past_categorical: ndarray::Array3::zeros((sample_count, input_length, 5)),
+            future_categorical: ndarray::Array3::zeros((sample_count, output_length, 5)),
+            static_categorical: ndarray::Array3::zeros((sample_count, 1, 3)),
             targets: if with_targets {
-                Some(ndarray::Array3::zeros((num_samples, output_length, 1)))
+                Some(ndarray::Array3::zeros((sample_count, output_length, 1)))
             } else {
                 None
             },
@@ -478,7 +535,7 @@ mod tests {
         let dataset = make_tiny_dataset(0, true);
         let parameters = make_tiny_parameters();
         let metrics = evaluate(&model, &dataset, &parameters).unwrap();
-        assert_eq!(metrics.crps, 0.0);
+        assert_eq!(metrics.continuous_ranked_probability_score, 0.0);
         assert_eq!(metrics.directional_accuracy, 0.0);
         assert_eq!(metrics.quantile_coverage, 0.0);
     }
@@ -490,7 +547,7 @@ mod tests {
         let dataset = make_tiny_dataset(4, false);
         let parameters = make_tiny_parameters();
         let metrics = evaluate(&model, &dataset, &parameters).unwrap();
-        assert_eq!(metrics.crps, 0.0);
+        assert_eq!(metrics.continuous_ranked_probability_score, 0.0);
         assert_eq!(metrics.directional_accuracy, 0.0);
         assert_eq!(metrics.quantile_coverage, 0.0);
     }
@@ -503,7 +560,7 @@ mod tests {
         // Use a model whose quantile list is empty.
         let parameters = ModelParameters::for_tests(32, 8, 1, 1, 1, 2, 0.0, vec![], 0.5);
         let metrics = evaluate(&model, &dataset, &parameters).unwrap();
-        assert_eq!(metrics.crps, 0.0);
+        assert_eq!(metrics.continuous_ranked_probability_score, 0.0);
         assert_eq!(metrics.directional_accuracy, 0.0);
         assert_eq!(metrics.quantile_coverage, 0.0);
     }
@@ -511,13 +568,17 @@ mod tests {
     #[test]
     fn test_evaluate_with_samples_returns_valid_metrics() {
         // Run the full inference path: sample_count > 0, targets present, quantiles non-empty.
-        // The model is randomly initialised so we only assert the metric ranges, not values.
+        // The model is randomly initialized so we only assert the metric ranges, not values.
         let model = make_tiny_model();
         let dataset = make_tiny_dataset(3, true);
         let parameters = make_tiny_parameters();
         let metrics = evaluate(&model, &dataset, &parameters).unwrap();
-        // crps is a sum of non-negative pinball losses so it must be >= 0.
-        assert!(metrics.crps >= 0.0, "crps={}", metrics.crps);
+        // continuous_ranked_probability_score is a sum of non-negative pinball losses so it must be >= 0.
+        assert!(
+            metrics.continuous_ranked_probability_score >= 0.0,
+            "crps={}",
+            metrics.continuous_ranked_probability_score
+        );
         // directional_accuracy is a fraction in [0,1].
         assert!(
             (0.0..=1.0).contains(&metrics.directional_accuracy),
@@ -534,7 +595,7 @@ mod tests {
 
     #[test]
     fn test_evaluate_larger_batch_than_eval_batch_size() {
-        // Exercises multi-chunk iteration by exceeding EVAL_BATCH (4096).
+        // Exercises multi-chunk iteration by exceeding EVALUATION_BATCH_SIZE (4096).
         let model = make_tiny_model();
         let dataset = make_tiny_dataset(4097, true);
         let parameters = make_tiny_parameters();

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -322,7 +322,7 @@ mod tests {
     // ---------------------------------------------------------------------------
 
     #[test]
-    fn test_eval_metrics_zero_fields_are_zero() {
+    fn test_evaluation_metrics_zero_fields_are_zero() {
         let metrics = EvaluationMetrics::zero();
         assert_eq!(metrics.continuous_ranked_probability_score, 0.0);
         assert_eq!(metrics.directional_accuracy, 0.0);

--- a/src/models/tide/evaluate.rs
+++ b/src/models/tide/evaluate.rs
@@ -199,7 +199,7 @@ fn argmin(values: &[f64]) -> usize {
     values
         .iter()
         .enumerate()
-        .min_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+        .min_by(|left, right| left.1.partial_cmp(right.1).unwrap())
         .map(|(index, _)| index)
         .unwrap_or(0)
 }
@@ -208,7 +208,7 @@ fn argmax(values: &[f64]) -> usize {
     values
         .iter()
         .enumerate()
-        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+        .max_by(|left, right| left.1.partial_cmp(right.1).unwrap())
         .map(|(index, _)| index)
         .unwrap_or(0)
 }
@@ -217,10 +217,10 @@ fn closest_to(values: &[f64], target: f64) -> usize {
     values
         .iter()
         .enumerate()
-        .min_by(|a, b| {
-            (a.1 - target)
+        .min_by(|left, right| {
+            (left.1 - target)
                 .abs()
-                .partial_cmp(&(b.1 - target).abs())
+                .partial_cmp(&(right.1 - target).abs())
                 .unwrap()
         })
         .map(|(index, _)| index)

--- a/src/models/tide/fit.rs
+++ b/src/models/tide/fit.rs
@@ -51,15 +51,19 @@ fn fit_scaler(data: &DataFrame) -> Result<Scaler, Box<dyn std::error::Error>> {
     for column in CONTINUOUS_COLUMNS {
         let series = data
             .column(column)
-            .map_err(|e| e.to_string())?
+            .map_err(|error| error.to_string())?
             .cast(&DataType::Float64)
-            .map_err(|e| e.to_string())?;
-        let values = series.f64().map_err(|e| e.to_string())?;
+            .map_err(|error| error.to_string())?;
+        let values = series.f64().map_err(|error| error.to_string())?;
         let mean = values.mean().unwrap_or(0.0);
-        let std = values.std(1).unwrap_or(0.0);
-        let std = if std == 0.0 { 1e-8 } else { std };
+        let standard_deviation = values.std(1).unwrap_or(0.0);
+        let standard_deviation = if standard_deviation == 0.0 {
+            1e-8
+        } else {
+            standard_deviation
+        };
         means.insert((*column).to_string(), mean);
-        standard_deviations.insert((*column).to_string(), std);
+        standard_deviations.insert((*column).to_string(), standard_deviation);
     }
 
     Scaler::new(means, standard_deviations).map_err(|reason| {
@@ -83,11 +87,11 @@ fn build_mapping(
 ) -> Result<CategoryMapping, Box<dyn std::error::Error>> {
     let mut values: Vec<String> = data
         .column(column)
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .str()
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .into_no_null_iter()
-        .map(|s| s.to_string())
+        .map(|name| name.to_string())
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();
@@ -109,21 +113,21 @@ pub fn filter_training_bars(
 ) -> Result<DataFrame, Box<dyn std::error::Error>> {
     let close_prices = data
         .column("close_price")
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .cast(&DataType::Float64)
-        .map_err(|e| e.to_string())?;
-    let close_prices = close_prices.f64().map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
+    let close_prices = close_prices.f64().map_err(|error| error.to_string())?;
     let volumes = data
         .column("volume")
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .cast(&DataType::Float64)
-        .map_err(|e| e.to_string())?;
-    let volumes = volumes.f64().map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
+    let volumes = volumes.f64().map_err(|error| error.to_string())?;
     let tickers = data
         .column("ticker")
-        .map_err(|e| e.to_string())?
+        .map_err(|error| error.to_string())?
         .str()
-        .map_err(|e| e.to_string())?;
+        .map_err(|error| error.to_string())?;
 
     let mask: BooleanChunked = close_prices
         .into_iter()
@@ -137,7 +141,7 @@ pub fn filter_training_bars(
         })
         .collect();
 
-    let filtered = data.filter(&mask).map_err(|e| e.to_string())?;
+    let filtered = data.filter(&mask).map_err(|error| error.to_string())?;
     Ok(filtered)
 }
 
@@ -351,17 +355,23 @@ mod tests {
     fn test_write_artifact_json_round_trips_via_loader() {
         let result = fit(raw_frame()).unwrap();
         let parameters = ModelParameters::new(448, 35, 5);
-        let dir = tempfile::tempdir().unwrap();
-        write_artifact_json(dir.path(), &result.scaler, &result.mappings, &parameters).unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        write_artifact_json(
+            directory.path(),
+            &result.scaler,
+            &result.mappings,
+            &parameters,
+        )
+        .unwrap();
 
         // The inference-side loaders must read what we wrote. `Scaler::load` now checks the column
         // lists against this build's constants itself, so reaching this line at all is the
         // assertion that the three lists round-tripped intact.
-        let scaler = Scaler::load(&dir.path().join("tide_data_scaler.json")).unwrap();
+        let scaler = Scaler::load(&directory.path().join("tide_data_scaler.json")).unwrap();
         assert!(scaler.means().contains_key("daily_return"));
 
         let loaded_parameters =
-            ModelParameters::load(&dir.path().join("tide_parameters.json")).unwrap();
+            ModelParameters::load(&directory.path().join("tide_parameters.json")).unwrap();
         assert_eq!(loaded_parameters.input_size(), 448);
     }
 }

--- a/src/models/tide/model.rs
+++ b/src/models/tide/model.rs
@@ -213,8 +213,8 @@ mod tests {
     fn test_load_fails_loudly_when_record_is_missing() {
         // No tide_states record in the directory: load must error rather than
         // fall back to random weights and report success.
-        let dir = tempfile::tempdir().unwrap();
-        let result = TiDEModel::<NdArray>::load(dir.path(), 24, 16, 2, 1, 5, 3, 0.0);
+        let directory = tempfile::tempdir().unwrap();
+        let result = TiDEModel::<NdArray>::load(directory.path(), 24, 16, 2, 1, 5, 3, 0.0);
         assert!(result.is_err());
         let message = result.err().unwrap().to_string();
         assert!(message.contains("Failed to load model weights"));
@@ -228,7 +228,7 @@ mod tests {
 
         let input = Tensor::<NdArray, 1>::from_floats(
             (0..(4 * input_size))
-                .map(|i| (i as f32 * 0.37).sin())
+                .map(|index| (index as f32 * 0.37).sin())
                 .collect::<Vec<_>>()
                 .as_slice(),
             &device,
@@ -277,7 +277,7 @@ mod tests {
         // A non-trivial input so a random-weight fallback would differ.
         let input = Tensor::<NdArray, 1>::from_floats(
             (0..(2 * input_size))
-                .map(|i| i as f32 * 0.01)
+                .map(|index| index as f32 * 0.01)
                 .collect::<Vec<_>>()
                 .as_slice(),
             &device,
@@ -285,11 +285,11 @@ mod tests {
         .reshape([2, input_size]);
         let expected: Vec<f32> = model.forward(input.clone()).to_data().to_vec().unwrap();
 
-        let dir = tempfile::tempdir().unwrap();
-        model.save(dir.path()).unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        model.save(directory.path()).unwrap();
 
         let loaded =
-            TiDEModel::<NdArray>::load(dir.path(), input_size, 16, 2, 1, 5, 3, 0.0).unwrap();
+            TiDEModel::<NdArray>::load(directory.path(), input_size, 16, 2, 1, 5, 3, 0.0).unwrap();
         let actual: Vec<f32> = loaded.forward(input).to_data().to_vec().unwrap();
 
         assert_eq!(expected.len(), actual.len());

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -59,7 +59,7 @@ pub fn consolidate_data(
                 .and(col("close_price").gt(lit(0.0))),
         )
         .collect()
-        .map_err(|e| PredictionError::DataConsolidation(e.to_string()))?;
+        .map_err(|error| PredictionError::DataConsolidation(error.to_string()))?;
 
     let details = equity_details
         .lazy()
@@ -81,7 +81,7 @@ pub fn consolidate_data(
                 .and(col("industry").is_not_null()),
         )
         .collect()
-        .map_err(|e| PredictionError::DataConsolidation(e.to_string()))?;
+        .map_err(|error| PredictionError::DataConsolidation(error.to_string()))?;
 
     let consolidated = bars
         .join(
@@ -91,7 +91,7 @@ pub fn consolidate_data(
             JoinArgs::new(JoinType::Inner),
             None,
         )
-        .map_err(|e| PredictionError::DataConsolidation(e.to_string()))?;
+        .map_err(|error| PredictionError::DataConsolidation(error.to_string()))?;
 
     let columns = [
         "ticker",
@@ -108,7 +108,7 @@ pub fn consolidate_data(
 
     let selected = consolidated
         .select(columns)
-        .map_err(|e| PredictionError::DataConsolidation(e.to_string()))?;
+        .map_err(|error| PredictionError::DataConsolidation(error.to_string()))?;
 
     info!(rows = selected.height(), "Data consolidated");
     Ok(selected)
@@ -146,7 +146,7 @@ pub fn filter_equity_bars(
         )
         .select([col("ticker")])
         .collect()
-        .map_err(|e| PredictionError::DataConsolidation(e.to_string()))?;
+        .map_err(|error| PredictionError::DataConsolidation(error.to_string()))?;
 
     let filtered = data
         .lazy()
@@ -157,7 +157,7 @@ pub fn filter_equity_bars(
             JoinArgs::new(JoinType::Semi),
         )
         .collect()
-        .map_err(|e| PredictionError::DataConsolidation(e.to_string()))?;
+        .map_err(|error| PredictionError::DataConsolidation(error.to_string()))?;
 
     info!(
         before = before_count,
@@ -175,7 +175,7 @@ pub fn filter_to_trained_tickers(
     let trained_tickers: Vec<String> = model_state
         .mappings()
         .get("ticker")
-        .map(|m| m.keys().cloned().collect())
+        .map(|mapping| mapping.keys().cloned().collect())
         .unwrap_or_default();
 
     if trained_tickers.is_empty() {
@@ -190,7 +190,7 @@ pub fn filter_to_trained_tickers(
         .with_column(col("ticker").cast(DataType::String).str().to_uppercase())
         .filter(col("ticker").is_in(lit(ticker_series), false))
         .collect()
-        .map_err(|e| PredictionError::DataConsolidation(e.to_string()))?;
+        .map_err(|error| PredictionError::DataConsolidation(error.to_string()))?;
 
     if filtered.height() == 0 {
         return Err(PredictionError::NoMatchingTickers);
@@ -251,13 +251,13 @@ pub fn generate_predictions(
 
     let tide_data =
         Data::apply_existing_scaler(data, model_state.scaler(), model_state.mappings(), session)
-            .map_err(|e| PredictionError::Preprocessing(e.to_string()))?;
+            .map_err(|error| PredictionError::Preprocessing(error.to_string()))?;
 
     let output_length = model_state.parameters().output_length();
     let dataset_input_length = model_state.parameters().input_length();
     let dataset = tide_data
         .get_dataset(DatasetKind::Predict, dataset_input_length, output_length)
-        .map_err(|e| PredictionError::DatasetCreation(e.to_string()))?;
+        .map_err(|error| PredictionError::DatasetCreation(error.to_string()))?;
 
     if dataset.is_empty() {
         return Err(PredictionError::DatasetCreation(
@@ -273,9 +273,9 @@ pub fn generate_predictions(
         .map_err(PredictionError::DatasetCreation)?;
 
     let device = Default::default();
-    let num_samples = dataset.len();
+    let sample_count = dataset.len();
 
-    let indices: Vec<usize> = (0..num_samples).collect();
+    let indices: Vec<usize> = (0..sample_count).collect();
     let inputs = crate::models::tide::batch::build_input_tensor::<NdArray>(
         &dataset,
         &indices,
@@ -288,7 +288,7 @@ pub fn generate_predictions(
     let predictions_data: Vec<f32> = predictions
         .to_data()
         .to_vec()
-        .map_err(|e| PredictionError::Inference(format!("{e:?}")))?;
+        .map_err(|error| PredictionError::Inference(format!("{error:?}")))?;
 
     let quantile_count = model_state.parameters().quantiles().len();
     // The output schema is fixed at quantile_10/quantile_50/quantile_90, so a
@@ -309,27 +309,29 @@ pub fn generate_predictions(
             "the loaded artifact has no 'ticker' categorical mapping".to_string(),
         )
     })?;
-    let reverse_ticker_map: std::collections::HashMap<i32, &String> =
-        ticker_mapping.iter().map(|(k, v)| (*v, k)).collect();
+    let reverse_ticker_map: std::collections::HashMap<i32, &String> = ticker_mapping
+        .iter()
+        .map(|(ticker, id)| (*id, ticker))
+        .collect();
 
-    for sample_idx in 0..num_samples {
-        let ticker_id = dataset.static_categorical[[sample_idx, 0, 0]];
+    for sample_index in 0..sample_count {
+        let ticker_id = dataset.static_categorical[[sample_index, 0, 0]];
         let ticker = reverse_ticker_map
             .get(&ticker_id)
-            .map(|s| s.as_str())
+            .map(|ticker| ticker.as_str())
             .unwrap_or("UNKNOWN");
 
-        for t in 0..output_length {
-            let base_idx = (sample_idx * output_length + t) * quantile_count;
+        for step in 0..output_length {
+            let base_index = (sample_index * output_length + step) * quantile_count;
 
             let scaled: Vec<f64> = (0..quantile_count)
-                .map(|q| predictions_data[base_idx + q] as f64)
+                .map(|quantile| predictions_data[base_index + quantile] as f64)
                 .collect();
             let quantiles = unscale_and_sort_quantiles(&scaled, model_state.scaler());
 
             results.push(serde_json::json!({
                 "ticker": ticker,
-                "timestamp": step_timestamp_milliseconds(now, t),
+                "timestamp": step_timestamp_milliseconds(now, step),
                 "quantile_10": quantiles[0],
                 "quantile_50": quantiles[1],
                 "quantile_90": quantiles[2],
@@ -345,7 +347,7 @@ pub fn generate_predictions(
 
     let final_predictions: Vec<serde_json::Value> = results
         .into_iter()
-        .filter(|r| r["timestamp"] == target_date)
+        .filter(|row| row["timestamp"] == target_date)
         .collect();
 
     info!(count = final_predictions.len(), "Predictions generated");
@@ -406,8 +408,8 @@ pub fn validate_predictions(predictions: &[serde_json::Value]) -> Result<(), Str
 
     let all_timestamp_sets: Vec<Vec<i64>> = timestamps_by_ticker
         .values()
-        .map(|ts| {
-            let mut sorted = ts.clone();
+        .map(|timestamps| {
+            let mut sorted = timestamps.clone();
             sorted.sort();
             sorted
         })
@@ -687,7 +689,7 @@ mod tests {
             .unwrap()
             .into_no_null_iter()
             .collect();
-        assert!(tickers.iter().all(|t| *t == "GOOG"));
+        assert!(tickers.iter().all(|ticker| *ticker == "GOOG"));
     }
 
     #[test]
@@ -709,7 +711,7 @@ mod tests {
             .unwrap()
             .into_no_null_iter()
             .collect();
-        assert!(tickers.iter().all(|t| *t == "GOOG"));
+        assert!(tickers.iter().all(|ticker| *ticker == "GOOG"));
     }
 
     /// The threshold itself must pass, because the other two sites that read these constants let it
@@ -1344,11 +1346,11 @@ mod tests {
 
     #[test]
     fn test_validate_predictions_three_tickers_same_timestamps_ok() {
-        let ts = 1_750_000_000_000i64;
+        let timestamp = 1_750_000_000_000i64;
         let predictions = vec![
-            serde_json::json!({"ticker": "AAPL", "timestamp": ts, "quantile_10": 0.0, "quantile_50": 0.01, "quantile_90": 0.02}),
-            serde_json::json!({"ticker": "MSFT", "timestamp": ts, "quantile_10": 0.0, "quantile_50": 0.01, "quantile_90": 0.02}),
-            serde_json::json!({"ticker": "GOOG", "timestamp": ts, "quantile_10": 0.0, "quantile_50": 0.01, "quantile_90": 0.02}),
+            serde_json::json!({"ticker": "AAPL", "timestamp": timestamp, "quantile_10": 0.0, "quantile_50": 0.01, "quantile_90": 0.02}),
+            serde_json::json!({"ticker": "MSFT", "timestamp": timestamp, "quantile_10": 0.0, "quantile_50": 0.01, "quantile_90": 0.02}),
+            serde_json::json!({"ticker": "GOOG", "timestamp": timestamp, "quantile_10": 0.0, "quantile_50": 0.01, "quantile_90": 0.02}),
         ];
         assert!(validate_predictions(&predictions).is_ok());
     }

--- a/src/models/tide/predict.rs
+++ b/src/models/tide/predict.rs
@@ -224,7 +224,7 @@ pub(crate) fn unscale_and_sort_quantiles(
         .iter()
         .map(|value| scaler.inverse_transform_value("daily_return", *value))
         .collect();
-    unscaled.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    unscaled.sort_by(|left, right| left.partial_cmp(right).unwrap_or(std::cmp::Ordering::Equal));
     unscaled
 }
 

--- a/src/models/tide/train.rs
+++ b/src/models/tide/train.rs
@@ -153,14 +153,14 @@ impl EarlyStopping {
 pub fn train(
     mut model: TiDEModel<TrainBackend>,
     train_dataset: &TrainingDataset,
-    valid_dataset: Option<&TrainingDataset>,
+    validation_dataset: Option<&TrainingDataset>,
     parameters: &ModelParameters,
     configuration: &TrainConfiguration,
     device: &<TrainBackend as Backend>::Device,
 ) -> (TiDEModel<TrainBackend>, Vec<f64>) {
-    let num_samples = train_dataset.len();
+    let sample_count = train_dataset.len();
     let mut losses = Vec::new();
-    if num_samples == 0 {
+    if sample_count == 0 {
         return (model, losses);
     }
 
@@ -175,7 +175,7 @@ pub fn train(
     let mut early_stopping = EarlyStopping::new();
 
     for epoch in 0..configuration.epoch_count {
-        let mut order: Vec<usize> = (0..num_samples).collect();
+        let mut order: Vec<usize> = (0..sample_count).collect();
         order.shuffle(&mut rng);
 
         let mut loss_sum = 0.0_f64;
@@ -224,10 +224,10 @@ pub fn train(
         // validation set, early stopping falls back to the training loss — and logging that
         // fallback under `validation_loss` produced a line where the two losses matched exactly,
         // which reads as a suspiciously well-generalizing model rather than as an absent split.
-        let measured_validation_loss = match valid_dataset {
-            Some(valid) if !valid.is_empty() => Some(validation_loss(
+        let measured_validation_loss = match validation_dataset {
+            Some(validation) if !validation.is_empty() => Some(validation_loss(
                 &model,
-                valid,
+                validation,
                 parameters,
                 configuration.batch_size,
             )),
@@ -263,27 +263,27 @@ pub fn train(
 /// Mean validation loss using the dropout-disabled inner (`NdArray`) model.
 fn validation_loss(
     model: &TiDEModel<TrainBackend>,
-    valid: &TrainingDataset,
+    validation: &TrainingDataset,
     parameters: &ModelParameters,
     batch_size: usize,
 ) -> f64 {
     let inner = model.valid();
     let device = <NdArray as Backend>::Device::default();
-    let sample_count = valid.len();
+    let sample_count = validation.len();
     let indices: Vec<usize> = (0..sample_count).collect();
 
     let mut loss_sum = 0.0_f64;
     let mut batch_count = 0usize;
     for chunk in indices.chunks(batch_size) {
         let input = build_input_tensor::<NdArray>(
-            valid,
+            validation,
             chunk,
             parameters.input_length(),
             parameters.output_length(),
             &device,
         );
         let target =
-            build_target_tensor::<NdArray>(valid, chunk, parameters.output_length(), &device);
+            build_target_tensor::<NdArray>(validation, chunk, parameters.output_length(), &device);
         let prediction = inner.forward(input);
         let loss = quantile_loss(
             prediction,
@@ -355,23 +355,23 @@ mod tests {
     /// A tiny dataset whose target is a constant the model can fit; used to prove
     /// the autodiff + optimizer + loss wiring actually reduces loss.
     fn overfit_dataset(
-        num_samples: usize,
+        sample_count: usize,
         input_length: usize,
         output_length: usize,
     ) -> TrainingDataset {
-        let mut past_continuous = ndarray::Array3::<f32>::zeros((num_samples, input_length, 7));
-        for s in 0..num_samples {
+        let mut past_continuous = ndarray::Array3::<f32>::zeros((sample_count, input_length, 7));
+        for s in 0..sample_count {
             for t in 0..input_length {
                 for f in 0..7 {
                     past_continuous[[s, t, f]] = ((s + t + f) as f32) * 0.01;
                 }
             }
         }
-        let past_categorical = ndarray::Array3::<i32>::ones((num_samples, input_length, 5));
-        let future_categorical = ndarray::Array3::<i32>::ones((num_samples, output_length, 5));
-        let static_categorical = ndarray::Array3::<i32>::ones((num_samples, 1, 3));
-        let mut targets = ndarray::Array3::<f32>::zeros((num_samples, output_length, 1));
-        for s in 0..num_samples {
+        let past_categorical = ndarray::Array3::<i32>::ones((sample_count, input_length, 5));
+        let future_categorical = ndarray::Array3::<i32>::ones((sample_count, output_length, 5));
+        let static_categorical = ndarray::Array3::<i32>::ones((sample_count, 1, 3));
+        let mut targets = ndarray::Array3::<f32>::zeros((sample_count, output_length, 1));
+        for s in 0..sample_count {
             for t in 0..output_length {
                 targets[[s, t, 0]] = 0.5;
             }

--- a/src/models/tide/train.rs
+++ b/src/models/tide/train.rs
@@ -360,10 +360,11 @@ mod tests {
         output_length: usize,
     ) -> TrainingDataset {
         let mut past_continuous = ndarray::Array3::<f32>::zeros((sample_count, input_length, 7));
-        for s in 0..sample_count {
-            for t in 0..input_length {
-                for f in 0..7 {
-                    past_continuous[[s, t, f]] = ((s + t + f) as f32) * 0.01;
+        for sample_index in 0..sample_count {
+            for time_index in 0..input_length {
+                for feature_index in 0..7 {
+                    past_continuous[[sample_index, time_index, feature_index]] =
+                        ((sample_index + time_index + feature_index) as f32) * 0.01;
                 }
             }
         }
@@ -371,9 +372,9 @@ mod tests {
         let future_categorical = ndarray::Array3::<i32>::ones((sample_count, output_length, 5));
         let static_categorical = ndarray::Array3::<i32>::ones((sample_count, 1, 3));
         let mut targets = ndarray::Array3::<f32>::zeros((sample_count, output_length, 1));
-        for s in 0..sample_count {
-            for t in 0..output_length {
-                targets[[s, t, 0]] = 0.5;
+        for sample_index in 0..sample_count {
+            for step_index in 0..output_length {
+                targets[[sample_index, step_index, 0]] = 0.5;
             }
         }
         TrainingDataset {

--- a/src/models/tide/train.rs
+++ b/src/models/tide/train.rs
@@ -150,6 +150,13 @@ impl EarlyStopping {
 
 /// Train the model, returning the best-checkpoint model and the per-epoch
 /// training loss history.
+///
+/// `validation_dataset` drives early stopping. When it is `None` or empty, the **training** loss is
+/// used as the stopping metric instead — which makes early stopping measure fit rather than
+/// generalization, so it will happily run to the epoch limit on a model that has memorized the
+/// window. The caller is expected to reject an empty validation split rather than rely on this;
+/// `bin/tide_model_trainer.rs` does. The fallback exists so a deliberately validation-free run
+/// (the overfitting tests below) still terminates, not as a supported production path.
 pub fn train(
     mut model: TiDEModel<TrainBackend>,
     train_dataset: &TrainingDataset,


### PR DESCRIPTION
# Overview

The §6 identifier sweep from `improvements_tide_model_hardening.md`, applied to the rest of the model code after `batch.rs` was done in #1041. Mechanical throughout, except for one identifier that turned out to be a wire contract.

## Changes

- Rename `crps` to `continuous_ranked_probability_score` and `EvalMetrics` to `EvaluationMetrics`, pinning the serialized key with `#[serde(rename = "crps")]` and adding a test that asserts the on-the-wire shape
- Rename roughly 110 single-letter closure bindings, mostly `|e|` to `|error|`
- Rename `num_samples`, `valid_dataset`, `dest`, `sample_idx`, `base_idx`, `std`, and `dir` to spelled-out forms
- Rename `valid`/`valid_mask` to `validation`/`validation_mask` where they meant the validation split rather than the adjective
- Fix the `needless_range_loop` clippy warning in a `data.rs` test fixture

## Context

`EvalMetrics.crps` is not just a Rust field. It is serialized into every training run's `run_metadata.json` in S3, and `fetch_prior_continuous_ranked_probability_scores` reads `metadata["metrics"]["crps"]` back out of *previous* runs to build the drift baseline.

Renaming the field alone would have made that lookup miss on every artifact already in the bucket. The failure mode is the reason it is called out here rather than buried in the diff: a missing value is skipped rather than raised, so the baseline would fall below `DRIFT_MINIMUM_RUNS` and `check_drift` would return `InsufficientHistory` — which is indistinguishable from a genuinely young bucket. Drift reporting would have gone quiet for several runs with nothing in the logs to explain it.

So the Rust identifier is spelled out and the published key is pinned. `test_metrics_serialize_under_the_published_crps_key` asserts both halves — that `crps` carries the value and that the spelled-out name does not appear — so the attribute cannot be dropped by a later edit. Verified by deleting it: the test fails. The two literal `crps` keys in the trainer's metadata JSON are left alone for the same reason, with a comment saying why.

Deliberately not renamed: burn and Polars API names (`model.valid()`, `.init()`, `dt.weekday()`), `std`/`len`/`abs` where they are std methods rather than identifiers, and the `/tmp` path literal.

Two renames in the first pass guessed wrong and were caught on read-back rather than by the compiler — a reverse-lookup map's value bound as `sector` when it held a ticker, and a test scalar pluralized to `timestamps`. Both are fixed here, but they are the characteristic risk of a sweep this wide and worth an eye during review: the compiler cannot tell a correct name from a plausible one.

This branch also carries the merge of `master` after #1046. The two conflicts were the same shape — this branch's `validation_dataset` and `|error|` renames against #1046's `ValidationSplit` to `TrainingFraction` rename — and were resolved by keeping both.

444 tests, coverage 82.21% against the 75% floor, zero warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Training now evaluates model performance against a dedicated validation dataset.
  - Training results and CLI output now use the full “continuous ranked probability score” metric name.
  - Drift monitoring reports current and baseline continuous ranked probability scores with updated terminology.

- **Bug Fixes**
  - Validation results are now consistently used for evaluation, metric reporting, and drift checks.

- **Refactor**
  - Improved consistency and clarity across evaluation, training, prediction, and data-processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->